### PR TITLE
feat: MVP 4개 페이지 구현 (Login, HomeFeed, BookSearch, BookDetail)

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -12,8 +12,8 @@ export default function BottomNav() {
   const { pathname } = useLocation()
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-card/95 px-4 pb-6 pt-2 backdrop-blur-md">
-      <div className="mx-auto flex max-w-md items-center justify-around">
+    <nav className="fixed bottom-0 left-1/2 z-30 w-full max-w-[430px] -translate-x-1/2 border-t border-border bg-card/95 px-4 pb-6 pt-2 backdrop-blur-md">
+      <div className="flex items-center justify-around">
         {navItems.map(item => {
           const isActive = pathname === item.path
 

--- a/src/index.css
+++ b/src/index.css
@@ -54,8 +54,15 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
     font-family: 'Newsreader', serif;
+    background-color: #ffffff;
+  }
+
+  #root {
+    @apply mx-auto min-h-screen bg-background shadow-lg;
+    max-width: 430px;
+    position: relative;
   }
 }
 

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,0 +1,123 @@
+import { useParams } from 'react-router-dom'
+import { mockBooks, mockBookDetailReviews } from '@/mocks/data'
+import AppHeader from '@/components/layout/AppHeader'
+import BottomNav from '@/components/layout/BottomNav'
+import StarRating from '@/components/common/StarRating'
+
+export default function BookDetailPage() {
+  const { id } = useParams()
+  const book = mockBooks.find(b => b.isbn === id) ?? mockBooks[3]
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader
+        title="BookLog"
+        showBack
+        rightAction={
+          <button className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10">
+            <span className="material-symbols-outlined">share</span>
+          </button>
+        }
+      />
+
+      <main className="flex-1 overflow-y-auto pb-24">
+        {/* Hero: Book Cover */}
+        <div className="flex justify-center px-6 py-8">
+          <div className="relative aspect-[2/3] w-2/3 overflow-hidden rounded-lg border border-primary/5 shadow-2xl">
+            <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
+          </div>
+        </div>
+
+        {/* Book Info */}
+        <section className="px-6 text-center">
+          <h1 className="mb-2 text-3xl font-bold leading-tight">{book.title}</h1>
+          <p className="mb-1 text-lg font-medium text-primary">{book.author}</p>
+          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <span>{book.publisher}</span>
+            {book.pageCount && (
+              <>
+                <span className="size-1 rounded-full bg-muted-foreground/30" />
+                <span>{book.pageCount} pages</span>
+              </>
+            )}
+          </div>
+        </section>
+
+        {/* Rating */}
+        <section className="mt-8 px-6">
+          <div className="flex flex-col items-center rounded-xl bg-primary/5 p-6">
+            <div className="mb-2 flex items-center gap-1">
+              <span className="text-3xl font-bold">{book.rating}</span>
+              <span className="text-muted-foreground">/ 5.0</span>
+            </div>
+            <StarRating rating={book.rating ?? 0} size="md" />
+            <p className="mt-2 text-xs font-medium text-muted-foreground">
+              {book.reviewCount?.toLocaleString()} reviews from readers
+            </p>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mt-8 px-6">
+          <button className="w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98]">
+            내 서재에 추가
+          </button>
+        </section>
+
+        {/* Reviews */}
+        <section className="mt-12">
+          <div className="mb-4 flex items-center justify-between px-6">
+            <h3 className="text-xl font-bold">독자들의 감상</h3>
+            <button className="text-sm font-semibold text-primary">전체보기</button>
+          </div>
+          <div className="no-scrollbar flex gap-4 overflow-x-auto px-6 pb-4">
+            {mockBookDetailReviews.map(review => (
+              <div
+                key={review.id}
+                className="min-w-[280px] rounded-xl border border-primary/5 bg-card p-4 shadow-sm"
+              >
+                {/* Reviewer */}
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="size-8 overflow-hidden rounded-full border border-primary/10">
+                    {review.author.profileImageUrl && (
+                      <img
+                        src={review.author.profileImageUrl}
+                        alt={review.author.nickname}
+                        className="size-full object-cover"
+                      />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm font-bold leading-none">{review.author.nickname}</p>
+                    <div className="-mt-1 origin-left scale-75">
+                      <StarRating rating={review.rating ?? 0} size="sm" />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Review Content */}
+                {review.hasSpoiler ? (
+                  <div className="relative">
+                    <p className="select-none text-sm text-muted-foreground blur-sm">
+                      {review.content}
+                    </p>
+                    <div className="absolute inset-0 flex items-center justify-center bg-card/40 backdrop-blur-[2px]">
+                      <div className="flex items-center gap-1 rounded-full bg-primary/90 px-3 py-1.5 text-xs font-bold text-primary-foreground">
+                        <span className="material-symbols-outlined text-sm">visibility_off</span>
+                        스포일러 포함 리뷰
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="line-clamp-3 text-sm text-muted-foreground">{review.content}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { mockSearchResults } from '@/mocks/data'
+import AppHeader from '@/components/layout/AppHeader'
+import BottomNav from '@/components/layout/BottomNav'
+import BookListItem from '@/components/common/BookListItem'
+
+export default function BookSearchPage() {
+  const [recentKeywords, setRecentKeywords] = useState(['데미안', '헤르만 헤세', '자기계발'])
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const removeKeyword = (keyword: string) => {
+    setRecentKeywords(prev => prev.filter(k => k !== keyword))
+  }
+
+  const clearAllKeywords = () => {
+    setRecentKeywords([])
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="BookLog" showBack />
+
+      {/* Search Bar */}
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex h-12 w-full items-stretch rounded-xl border border-primary/10 bg-primary/5">
+          <div className="flex items-center justify-center pl-4 text-primary/60">
+            <span className="material-symbols-outlined text-[22px]">search</span>
+          </div>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="도서 제목, 저자, ISBN 검색"
+            className="h-full min-w-0 flex-1 border-none bg-transparent px-3 text-base font-normal outline-none placeholder:text-primary/40 focus:ring-0"
+          />
+          <div className="flex cursor-pointer items-center justify-center pr-4 text-primary">
+            <span className="material-symbols-outlined text-[24px]">barcode_scanner</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Recent Keywords */}
+      {recentKeywords.length > 0 && (
+        <div className="border-b border-border px-4 py-4">
+          <div className="mb-2 flex items-center justify-between">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-primary/70">
+              최근 검색어
+            </h4>
+            <button
+              onClick={clearAllKeywords}
+              className="text-xs text-primary/40 hover:text-primary"
+            >
+              전체 삭제
+            </button>
+          </div>
+          <div className="no-scrollbar flex gap-2 overflow-x-auto py-1">
+            {recentKeywords.map(keyword => (
+              <div
+                key={keyword}
+                className="flex h-8 shrink-0 items-center justify-center gap-x-1 rounded-full border border-primary/5 bg-primary/10 px-3"
+              >
+                <p className="text-sm font-medium leading-normal text-primary">{keyword}</p>
+                <button onClick={() => removeKeyword(keyword)}>
+                  <span className="material-symbols-outlined cursor-pointer text-[16px] text-primary/60">
+                    close
+                  </span>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Search Results */}
+      <main className="flex-1 overflow-y-auto px-4 pb-24">
+        <div className="flex flex-col">
+          {mockSearchResults.map(book => (
+            <BookListItem key={book.isbn} book={book} />
+          ))}
+        </div>
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { mockReviews } from '@/mocks/data'
+import BottomNav from '@/components/layout/BottomNav'
+import ReviewCard from '@/components/common/ReviewCard'
+
+export default function HomeFeedPage() {
+  const [activeTab, setActiveTab] = useState<'following' | 'recommend'>('following')
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
+        <div className="flex items-center justify-between px-4 py-3">
+          <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+          <button className="rounded-full p-2 transition-colors hover:bg-primary/5">
+            <span className="material-symbols-outlined text-primary">notifications</span>
+          </button>
+        </div>
+        {/* Tabs */}
+        <div className="flex gap-8 px-4">
+          <button
+            onClick={() => setActiveTab('following')}
+            className="relative flex flex-col items-center py-3"
+          >
+            <span
+              className={cn(
+                'text-sm font-bold',
+                activeTab === 'following' ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              팔로잉
+            </span>
+            {activeTab === 'following' && (
+              <div className="absolute bottom-0 h-0.5 w-full rounded-full bg-primary" />
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab('recommend')}
+            className="relative flex flex-col items-center py-3"
+          >
+            <span
+              className={cn(
+                'text-sm font-bold',
+                activeTab === 'recommend' ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              추천
+            </span>
+            {activeTab === 'recommend' && (
+              <div className="absolute bottom-0 h-0.5 w-full rounded-full bg-primary" />
+            )}
+          </button>
+        </div>
+      </header>
+
+      {/* Feed */}
+      <main className="flex-1 overflow-y-auto pb-24">
+        {mockReviews.map(review => (
+          <div key={review.id} className="p-4 pt-4 first:pt-4 [&:not(:first-child)]:pt-0">
+            <ReviewCard review={review} />
+          </div>
+        ))}
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,0 @@
-export default function HomePage() {
-  return (
-    <div className="min-h-screen bg-background">
-      <h1 className="text-2xl font-bold text-foreground">Shelfeed</h1>
-    </div>
-  )
-}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,154 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Link } from 'react-router-dom'
+
+const loginSchema = z.object({
+  email: z.string().email('올바른 이메일을 입력하세요'),
+  password: z.string().min(6, '비밀번호는 6자 이상이어야 합니다'),
+})
+
+type LoginForm = z.infer<typeof loginSchema>
+
+export default function LoginPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginForm>({
+    resolver: zodResolver(loginSchema),
+  })
+
+  const onSubmit = (data: LoginForm) => {
+    console.log('Login:', data)
+  }
+
+  return (
+    <div className="relative min-h-screen w-full overflow-hidden bg-background">
+      {/* Background (Simulated Feed) */}
+      <div className="flex flex-col gap-6 p-4 opacity-40">
+        <header className="flex items-center justify-between py-4">
+          <h1 className="text-2xl font-bold text-primary">BookLog</h1>
+          <span className="material-symbols-outlined text-primary">search</span>
+        </header>
+        <div className="flex flex-col gap-4">
+          <div className="rounded-xl border border-primary/10 bg-card p-4 shadow-sm">
+            <div className="flex gap-4">
+              <div className="h-24 w-16 rounded bg-primary/20" />
+              <div className="flex flex-col justify-center">
+                <h2 className="text-lg font-bold">위대한 개츠비</h2>
+                <p className="text-sm text-muted-foreground">F. 스콧 피츠제럴드</p>
+              </div>
+            </div>
+            <p className="mt-3 italic leading-relaxed text-muted-foreground">
+              "우리는 과거 속으로 끊임없이 밀려가면서도, 흐름을 거스르는 배처럼 앞으로 나아간다."
+            </p>
+          </div>
+          <div className="rounded-xl border border-primary/10 bg-card p-4 shadow-sm">
+            <div className="flex gap-4">
+              <div className="h-24 w-16 rounded bg-primary/20" />
+              <div className="flex flex-col justify-center">
+                <h2 className="text-lg font-bold">데미안</h2>
+                <p className="text-sm text-muted-foreground">헤르만 헤세</p>
+              </div>
+            </div>
+            <p className="mt-3 italic leading-relaxed text-muted-foreground">
+              "새는 알에서 나오려고 투쟁한다. 알은 세계이다."
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Dimmed Overlay */}
+      <div className="absolute inset-0 flex flex-col justify-end bg-primary/40 backdrop-blur-[2px]">
+        {/* Bottom Sheet */}
+        <div className="flex w-full max-h-[85%] flex-col items-stretch overflow-y-auto rounded-t-xl bg-background pb-10 shadow-2xl">
+          {/* Handle Bar */}
+          <div className="flex h-8 w-full shrink-0 items-center justify-center">
+            <div className="h-1.5 w-12 rounded-full bg-primary/20" />
+          </div>
+
+          <div className="px-6 pt-4">
+            <h3 className="pb-8 text-center text-2xl font-bold leading-tight">
+              로그인하고 감상을 기록해보세요
+            </h3>
+
+            {/* Google Login */}
+            <button className="flex h-14 w-full items-center justify-center gap-3 rounded-xl border border-primary/10 bg-card text-base font-semibold transition-colors hover:bg-primary/5">
+              <svg className="h-6 w-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              <span>Google로 로그인</span>
+            </button>
+
+            {/* Divider */}
+            <div className="relative flex items-center py-4">
+              <div className="flex-grow border-t border-primary/10" />
+              <span className="mx-4 shrink-0 text-sm font-medium">또는</span>
+              <div className="flex-grow border-t border-primary/10" />
+            </div>
+
+            {/* Email Form */}
+            <form onSubmit={handleSubmit(onSubmit)} className="mt-4 flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="ml-1 text-sm font-semibold">이메일</label>
+                <input
+                  {...register('email')}
+                  type="email"
+                  placeholder="email@example.com"
+                  className="w-full rounded-xl border border-primary/10 bg-card p-4 outline-none transition-all focus:border-primary focus:ring-1 focus:ring-primary"
+                />
+                {errors.email && (
+                  <p className="ml-1 text-xs text-destructive">{errors.email.message}</p>
+                )}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label className="ml-1 text-sm font-semibold">비밀번호</label>
+                <input
+                  {...register('password')}
+                  type="password"
+                  placeholder="비밀번호를 입력하세요"
+                  className="w-full rounded-xl border border-primary/10 bg-card p-4 outline-none transition-all focus:border-primary focus:ring-1 focus:ring-primary"
+                />
+                {errors.password && (
+                  <p className="ml-1 text-xs text-destructive">{errors.password.message}</p>
+                )}
+              </div>
+              <button
+                type="submit"
+                className="mt-4 h-14 w-full rounded-xl bg-primary text-lg font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
+              >
+                로그인
+              </button>
+            </form>
+
+            {/* Footer Link */}
+            <div className="mb-4 mt-8 text-center">
+              <p className="text-sm">
+                계정이 없으신가요?
+                <Link to="/signup" className="ml-1 font-bold hover:underline">
+                  회원가입
+                </Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,9 +1,24 @@
 import { createBrowserRouter } from 'react-router-dom'
-import HomePage from '@/pages/HomePage'
+import HomeFeedPage from '@/pages/HomeFeedPage'
+import LoginPage from '@/pages/LoginPage'
+import BookSearchPage from '@/pages/BookSearchPage'
+import BookDetailPage from '@/pages/BookDetailPage'
 
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <HomePage />,
+    element: <HomeFeedPage />,
+  },
+  {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
+    path: '/search',
+    element: <BookSearchPage />,
+  },
+  {
+    path: '/book/:id',
+    element: <BookDetailPage />,
   },
 ])


### PR DESCRIPTION
  - LoginPage: 바텀시트 레이아웃, Google/이메일 로그인 폼
  - HomeFeedPage: 팔로잉/추천 탭, 리뷰 카드 피드
  - BookSearchPage: 검색바, 최근 검색어 칩, 검색 결과 리스트
  - BookDetailPage: 히어로 커버, 평점, CTA, 독자 감상 캐러셀
  - 라우터 4개 연결, 모바일 컨테이너(max-w 430px) 적용

  #10