### PR TITLE
fix: correct profile route path to /profile

### DIFF
--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -34,7 +34,7 @@ export const router = createBrowserRouter([
     element: <ReviewDetailPage />,
   },
   {
-    path: '/my-profile',
+    path: '/profile',
     element: <MyProfilePage />,
   },
   {


### PR DESCRIPTION
## 🐛 수정 내용

- BottomNav에서 프로필 탭 클릭 시 잘못된 경로(`/my-profile`)로 이동하던 문제를 수정했습니다.
- 올바른 경로(`/profile`)로 이동하도록 라우팅을 변경했습니다.

---

## 🎯 수정 목적

프로필 탭 클릭 시 정상적인 페이지로 이동하도록 하여  
사용자 네비게이션 흐름을 올바르게 동작하도록 수정합니다.

---

## 🔍 변경 사항

- route path 수정
  - `/my-profile` → `/profile`

---

## 🔗 관련 이슈

Closes #17 