### PR TITLE
feat: 로그인 보호 로직, 회원가입 페이지, 로그인 디자인 수정

### DIFF
--- a/src/components/layout/ProtectedRoute.tsx
+++ b/src/components/layout/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated)
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <>{children}</>
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,8 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
 
 const loginSchema = z.object({
   email: z.string().email('올바른 이메일을 입력하세요'),
@@ -11,6 +12,8 @@ const loginSchema = z.object({
 type LoginForm = z.infer<typeof loginSchema>
 
 export default function LoginPage() {
+  const navigate = useNavigate()
+  const setAuth = useAuthStore(state => state.setAuth)
   const {
     register,
     handleSubmit,
@@ -19,136 +22,114 @@ export default function LoginPage() {
     resolver: zodResolver(loginSchema),
   })
 
-  const onSubmit = (data: LoginForm) => {
-    console.log('Login:', data)
+  const onSubmit = () => {
+    setAuth(
+      { id: 1, nickname: '독서광', profileImageUrl: 'https://picsum.photos/seed/user1/100/100' },
+      'mock-access-token'
+    )
+    navigate('/')
   }
 
   return (
-    <div className="relative min-h-screen w-full overflow-hidden bg-background">
-      {/* Background (Simulated Feed) */}
-      <div className="flex flex-col gap-6 p-4 opacity-40">
-        <header className="flex items-center justify-between py-4">
-          <h1 className="text-2xl font-bold text-primary">BookLog</h1>
-          <span className="material-symbols-outlined text-primary">search</span>
-        </header>
-        <div className="flex flex-col gap-4">
-          <div className="rounded-xl border border-primary/10 bg-card p-4 shadow-sm">
-            <div className="flex gap-4">
-              <div className="h-24 w-16 rounded bg-primary/20" />
-              <div className="flex flex-col justify-center">
-                <h2 className="text-lg font-bold">위대한 개츠비</h2>
-                <p className="text-sm text-muted-foreground">F. 스콧 피츠제럴드</p>
-              </div>
-            </div>
-            <p className="mt-3 italic leading-relaxed text-muted-foreground">
-              "우리는 과거 속으로 끊임없이 밀려가면서도, 흐름을 거스르는 배처럼 앞으로 나아간다."
-            </p>
-          </div>
-          <div className="rounded-xl border border-primary/10 bg-card p-4 shadow-sm">
-            <div className="flex gap-4">
-              <div className="h-24 w-16 rounded bg-primary/20" />
-              <div className="flex flex-col justify-center">
-                <h2 className="text-lg font-bold">데미안</h2>
-                <p className="text-sm text-muted-foreground">헤르만 헤세</p>
-              </div>
-            </div>
-            <p className="mt-3 italic leading-relaxed text-muted-foreground">
-              "새는 알에서 나오려고 투쟁한다. 알은 세계이다."
-            </p>
-          </div>
+    <div className="relative flex min-h-screen flex-col items-center justify-between bg-background selection:bg-primary/20">
+      {/* Background Blurs */}
+      <div className="pointer-events-none fixed left-[-5%] top-[-10%] -z-10 h-[40%] w-[40%] rounded-full bg-primary/5 blur-[120px]" />
+      <div className="pointer-events-none fixed bottom-[-5%] right-[-5%] -z-10 h-[30%] w-[30%] rounded-full bg-primary/5 blur-[100px]" />
+
+      {/* Header */}
+      <header className="flex w-full items-center justify-center py-16">
+        <div className="flex flex-col items-center gap-2">
+          <h1 className="text-4xl font-bold tracking-tight text-primary">BookLog</h1>
+          <div className="h-px w-8 bg-primary/30" />
         </div>
-      </div>
+      </header>
 
-      {/* Dimmed Overlay */}
-      <div className="absolute inset-0 flex flex-col justify-end bg-primary/40 backdrop-blur-[2px]">
-        {/* Bottom Sheet */}
-        <div className="flex w-full max-h-[85%] flex-col items-stretch overflow-y-auto rounded-t-xl bg-background pb-10 shadow-2xl">
-          {/* Handle Bar */}
-          <div className="flex h-8 w-full shrink-0 items-center justify-center">
-            <div className="h-1.5 w-12 rounded-full bg-primary/20" />
-          </div>
+      {/* Main Form */}
+      <main className="flex w-full max-w-md flex-col gap-10 px-6">
+        {/* Google Login */}
+        <button className="group flex w-full items-center justify-center gap-3 rounded-xl border border-primary/10 bg-card px-6 py-4 shadow-sm transition-all duration-300 hover:shadow-md active:scale-[0.98]">
+          <svg className="h-5 w-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
+          </svg>
+          <span className="text-base font-medium">Google 로그인</span>
+        </button>
 
-          <div className="px-6 pt-4">
-            <h3 className="pb-8 text-center text-2xl font-bold leading-tight">
-              로그인하고 감상을 기록해보세요
-            </h3>
-
-            {/* Google Login */}
-            <button className="flex h-14 w-full items-center justify-center gap-3 rounded-xl border border-primary/10 bg-card text-base font-semibold transition-colors hover:bg-primary/5">
-              <svg className="h-6 w-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              <span>Google로 로그인</span>
-            </button>
-
-            {/* Divider */}
-            <div className="relative flex items-center py-4">
-              <div className="flex-grow border-t border-primary/10" />
-              <span className="mx-4 shrink-0 text-sm font-medium">또는</span>
-              <div className="flex-grow border-t border-primary/10" />
-            </div>
-
-            {/* Email Form */}
-            <form onSubmit={handleSubmit(onSubmit)} className="mt-4 flex flex-col gap-4">
-              <div className="flex flex-col gap-1.5">
-                <label className="ml-1 text-sm font-semibold">이메일</label>
-                <input
-                  {...register('email')}
-                  type="email"
-                  placeholder="email@example.com"
-                  className="w-full rounded-xl border border-primary/10 bg-card p-4 outline-none transition-all focus:border-primary focus:ring-1 focus:ring-primary"
-                />
-                {errors.email && (
-                  <p className="ml-1 text-xs text-destructive">{errors.email.message}</p>
-                )}
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="ml-1 text-sm font-semibold">비밀번호</label>
-                <input
-                  {...register('password')}
-                  type="password"
-                  placeholder="비밀번호를 입력하세요"
-                  className="w-full rounded-xl border border-primary/10 bg-card p-4 outline-none transition-all focus:border-primary focus:ring-1 focus:ring-primary"
-                />
-                {errors.password && (
-                  <p className="ml-1 text-xs text-destructive">{errors.password.message}</p>
-                )}
-              </div>
-              <button
-                type="submit"
-                className="mt-4 h-14 w-full rounded-xl bg-primary text-lg font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
-              >
-                로그인
-              </button>
-            </form>
-
-            {/* Footer Link */}
-            <div className="mb-4 mt-8 text-center">
-              <p className="text-sm">
-                계정이 없으신가요?
-                <Link to="/signup" className="ml-1 font-bold hover:underline">
-                  회원가입
-                </Link>
-              </p>
-            </div>
-          </div>
+        {/* Divider */}
+        <div className="relative flex items-center py-4">
+          <div className="flex-grow border-t border-primary/10" />
+          <span className="mx-4 shrink-0 text-sm text-muted-foreground">또는</span>
+          <div className="flex-grow border-t border-primary/10" />
         </div>
-      </div>
+
+        {/* Email Form */}
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <label className="ml-1 text-sm font-semibold">이메일</label>
+            <input
+              {...register('email')}
+              type="email"
+              placeholder="email@example.com"
+              className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+            />
+            {errors.email && (
+              <p className="ml-1 text-xs text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between px-1">
+              <label className="text-sm font-semibold">비밀번호</label>
+              <span className="cursor-pointer text-[13px] text-primary hover:underline">
+                비밀번호를 잊으셨나요?
+              </span>
+            </div>
+            <input
+              {...register('password')}
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+            />
+            {errors.password && (
+              <p className="ml-1 text-xs text-destructive">{errors.password.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98]"
+          >
+            로그인
+          </button>
+        </form>
+      </main>
+
+      {/* Footer */}
+      <footer className="flex w-full items-center justify-center py-12">
+        <p className="text-sm tracking-tight text-muted-foreground">
+          계정이 없으신가요?
+          <Link
+            to="/signup"
+            className="ml-2 font-bold text-foreground underline decoration-primary/30 underline-offset-4 transition-colors hover:text-primary"
+          >
+            회원가입
+          </Link>
+        </p>
+      </footer>
     </div>
   )
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate, Link } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
+
+const step1Schema = z
+  .object({
+    email: z.string().email('올바른 이메일을 입력하세요'),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
+    passwordConfirm: z.string(),
+  })
+  .refine(data => data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['passwordConfirm'],
+  })
+
+const step2Schema = z.object({
+  nickname: z.string().min(2, '닉네임은 2자 이상이어야 합니다'),
+  bio: z.string().optional(),
+})
+
+type Step1Form = z.infer<typeof step1Schema>
+type Step2Form = z.infer<typeof step2Schema>
+
+export default function SignupPage() {
+  const [step, setStep] = useState(1)
+  const [showPassword, setShowPassword] = useState(false)
+  const navigate = useNavigate()
+  const setAuth = useAuthStore(state => state.setAuth)
+
+  const step1Form = useForm<Step1Form>({
+    resolver: zodResolver(step1Schema),
+  })
+
+  const step2Form = useForm<Step2Form>({
+    resolver: zodResolver(step2Schema),
+  })
+
+  const onStep1Submit = () => {
+    setStep(2)
+  }
+
+  const onStep2Submit = (data: Step2Form) => {
+    // Mock: 회원가입 성공 후 자동 로그인
+    setAuth(
+      {
+        id: Date.now(),
+        nickname: data.nickname,
+        profileImageUrl: undefined,
+      },
+      'mock-signup-token'
+    )
+    navigate('/')
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 pb-2">
+        <button
+          onClick={() => (step === 1 ? navigate(-1) : setStep(1))}
+          className="flex size-12 shrink-0 items-center text-primary"
+        >
+          <span className="material-symbols-outlined text-[24px]">arrow_back</span>
+        </button>
+        <h2 className="flex-1 pr-12 text-center text-lg font-bold leading-tight tracking-tight">
+          {step === 1 ? '회원가입' : 'BookLog'}
+        </h2>
+      </div>
+
+      {/* Progress */}
+      <div className="flex flex-col gap-3 p-4">
+        <p className="text-base font-medium">{step === 1 ? '계정 정보 입력' : '프로필 설정'}</p>
+        <div className="rounded-full bg-primary/10">
+          <div
+            className="h-2 rounded-full bg-primary transition-all"
+            style={{ width: step === 1 ? '50%' : '100%' }}
+          />
+        </div>
+        <p className="text-sm text-muted-foreground">{step} / 2단계</p>
+      </div>
+
+      {step === 1 ? (
+        <>
+          {/* Step 1: 계정 정보 */}
+          <div className="px-4 pb-3 pt-6">
+            <h1 className="text-[32px] font-bold leading-tight tracking-tight">
+              BookLog에 오신 것을 환영합니다
+            </h1>
+            <p className="pt-2 text-base text-muted-foreground">
+              먼저 로그인에 사용할 계정 정보를 입력해주세요.
+            </p>
+          </div>
+
+          <form onSubmit={step1Form.handleSubmit(onStep1Submit)} className="flex flex-1 flex-col">
+            <div className="mt-4 flex flex-col gap-4 px-4 py-3">
+              <div className="flex flex-col gap-2">
+                <label className="text-base font-medium">이메일</label>
+                <input
+                  {...step1Form.register('email')}
+                  type="email"
+                  placeholder="example@email.com"
+                  className="h-14 w-full rounded-xl border border-primary/20 bg-card p-4 text-base outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20"
+                />
+                {step1Form.formState.errors.email && (
+                  <p className="ml-1 text-xs text-destructive">
+                    {step1Form.formState.errors.email.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-2 flex flex-col gap-2">
+                <label className="text-base font-medium">비밀번호</label>
+                <div className="relative">
+                  <input
+                    {...step1Form.register('password')}
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="8자 이상 입력해주세요"
+                    className="h-14 w-full rounded-xl border border-primary/20 bg-card p-4 pr-12 text-base outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+                  >
+                    <span className="material-symbols-outlined">
+                      {showPassword ? 'visibility_off' : 'visibility'}
+                    </span>
+                  </button>
+                </div>
+                {step1Form.formState.errors.password && (
+                  <p className="ml-1 text-xs text-destructive">
+                    {step1Form.formState.errors.password.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-2 flex flex-col gap-2">
+                <label className="text-base font-medium">비밀번호 확인</label>
+                <input
+                  {...step1Form.register('passwordConfirm')}
+                  type="password"
+                  placeholder="비밀번호를 한 번 더 입력해주세요"
+                  className="h-14 w-full rounded-xl border border-primary/20 bg-card p-4 text-base outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20"
+                />
+                {step1Form.formState.errors.passwordConfirm && (
+                  <p className="ml-1 text-xs text-destructive">
+                    {step1Form.formState.errors.passwordConfirm.message}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-auto mb-8 p-4">
+              <button
+                type="submit"
+                className="h-14 w-full rounded-xl bg-primary text-lg font-bold text-primary-foreground shadow-lg shadow-primary/10 transition-colors hover:bg-primary/90"
+              >
+                다음
+              </button>
+              <div className="mt-6 flex justify-center">
+                <p className="text-sm">
+                  이미 계정이 있으신가요?{' '}
+                  <Link to="/login" className="font-bold underline underline-offset-4">
+                    로그인
+                  </Link>
+                </p>
+              </div>
+            </div>
+          </form>
+        </>
+      ) : (
+        <>
+          {/* Step 2: 프로필 설정 */}
+          <div className="flex flex-col items-center gap-6 p-6">
+            <div className="group relative">
+              <div className="flex size-32 items-center justify-center overflow-hidden rounded-full border-2 border-primary/20 bg-primary/10 shadow-sm">
+                <span className="material-symbols-outlined text-4xl text-primary/40">person</span>
+              </div>
+              <div className="absolute bottom-0 right-0 rounded-full border-2 border-background bg-primary p-2 text-primary-foreground shadow-lg">
+                <span className="material-symbols-outlined text-sm">photo_camera</span>
+              </div>
+            </div>
+            <div className="space-y-2 text-center">
+              <p className="text-2xl font-bold tracking-tight">나만의 서재 완성하기</p>
+              <p className="px-4 text-base text-muted-foreground">
+                다른 독서가들이 당신을 알아볼 수 있도록 프로필을 완성해주세요.
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={step2Form.handleSubmit(onStep2Submit)} className="flex flex-1 flex-col">
+            <div className="space-y-6 px-6">
+              <div className="flex flex-col gap-2">
+                <label className="ml-1 text-base font-semibold">닉네임</label>
+                <input
+                  {...step2Form.register('nickname')}
+                  type="text"
+                  placeholder="사용할 닉네임을 입력하세요"
+                  className="h-14 w-full rounded-xl border border-primary/20 bg-card px-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                />
+                {step2Form.formState.errors.nickname && (
+                  <p className="ml-1 text-xs text-destructive">
+                    {step2Form.formState.errors.nickname.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label className="ml-1 text-base font-semibold">소개글 (선택)</label>
+                <textarea
+                  {...step2Form.register('bio')}
+                  placeholder="당신의 독서 취향이나 간단한 소개를 남겨보세요."
+                  className="min-h-[100px] w-full resize-none rounded-xl border border-primary/20 bg-card p-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                />
+              </div>
+            </div>
+
+            <div className="mt-auto p-6 pb-10">
+              <button
+                type="submit"
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-4 font-bold text-primary-foreground shadow-md transition-colors hover:bg-primary/90"
+              >
+                <span>시작하기</span>
+                <span className="material-symbols-outlined">arrow_forward</span>
+              </button>
+              <p className="mt-4 text-center text-sm text-muted-foreground">
+                나중에 언제든지 수정할 수 있습니다.
+              </p>
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,44 +1,78 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomeFeedPage from '@/pages/HomeFeedPage'
 import LoginPage from '@/pages/LoginPage'
+import SignupPage from '@/pages/SignupPage'
 import BookSearchPage from '@/pages/BookSearchPage'
 import BookDetailPage from '@/pages/BookDetailPage'
 import WriteReviewPage from '@/pages/WriteReviewPage'
 import ReviewDetailPage from '@/pages/ReviewDetailPage'
 import MyProfilePage from '@/pages/MyProfilePage'
 import SettingsPage from '@/pages/SettingsPage'
+import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <HomeFeedPage />,
+    element: (
+      <ProtectedRoute>
+        <HomeFeedPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/login',
     element: <LoginPage />,
   },
   {
+    path: '/signup',
+    element: <SignupPage />,
+  },
+  {
     path: '/search',
-    element: <BookSearchPage />,
+    element: (
+      <ProtectedRoute>
+        <BookSearchPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/book/:id',
-    element: <BookDetailPage />,
+    element: (
+      <ProtectedRoute>
+        <BookDetailPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/review/write',
-    element: <WriteReviewPage />,
+    element: (
+      <ProtectedRoute>
+        <WriteReviewPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/review/:id',
-    element: <ReviewDetailPage />,
+    element: (
+      <ProtectedRoute>
+        <ReviewDetailPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/my-profile',
-    element: <MyProfilePage />,
+    element: (
+      <ProtectedRoute>
+        <MyProfilePage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/settings',
-    element: <SettingsPage />,
+    element: (
+      <ProtectedRoute>
+        <SettingsPage />
+      </ProtectedRoute>
+    ),
   },
 ])


### PR DESCRIPTION
  - ProtectedRoute 컴포넌트 생성 (미로그인 시 /login 리다이렉트)
  - LoginPage를 Standalone 디자인으로 전면 교체
  - 로그인 시 mock setAuth 연동 (홈피드로 이동)
  - SignupPage 2단계 구현 (계정 정보 → 프로필 설정)
  - 라우터에 ProtectedRoute 및 /signup 라우트 추가

  Closes #18