### PR TITLE
fix: 프론트엔드 UI/UX 일괄 수정 6건

### DIFF
--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import type { Memo } from '@/types'
 import StarRating from './StarRating'
@@ -16,12 +17,20 @@ const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }
 
 export default function ReviewCard({ review, className }: ReviewCardProps) {
   const [spoilerRevealed, setSpoilerRevealed] = useState(false)
+  const [liked, setLiked] = useState(review.isLiked)
+  const [likeCount, setLikeCount] = useState(review.likeCount)
   const status = review.readingStatus ? statusLabel[review.readingStatus] : null
 
+  const toggleLike = () => {
+    setLiked(prev => !prev)
+    setLikeCount(prev => (liked ? prev - 1 : prev + 1))
+  }
+
   return (
-    <div
+    <Link
+      to={`/review/${review.id}`}
       className={cn(
-        'overflow-hidden rounded-xl border border-primary/5 bg-card shadow-sm',
+        'block overflow-hidden rounded-xl border border-primary/5 bg-card shadow-sm',
         className
       )}
     >
@@ -76,7 +85,10 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
         {/* Review Text */}
         {review.hasSpoiler && !spoilerRevealed ? (
           <button
-            onClick={() => setSpoilerRevealed(true)}
+            onClick={e => {
+              e.preventDefault()
+              setSpoilerRevealed(true)
+            }}
             className="group relative mb-4 w-full cursor-pointer"
           >
             <div className="pointer-events-none select-none opacity-40 blur-md">
@@ -100,16 +112,30 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
 
         {/* Actions */}
         <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
-          <button className="flex items-center gap-1.5 transition-colors hover:text-primary">
-            <span className="material-symbols-outlined text-xl">favorite</span>
-            <span className="text-xs font-bold">{review.likeCount}</span>
+          <button
+            onClick={e => {
+              e.preventDefault()
+              toggleLike()
+            }}
+            className={cn(
+              'flex items-center gap-1.5 transition-colors hover:text-primary',
+              liked && 'text-primary'
+            )}
+          >
+            <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
+              favorite
+            </span>
+            <span className="text-xs font-bold">{likeCount}</span>
           </button>
-          <button className="flex items-center gap-1.5 transition-colors hover:text-primary">
+          <button
+            onClick={e => e.preventDefault()}
+            className="flex items-center gap-1.5 transition-colors hover:text-primary"
+          >
             <span className="material-symbols-outlined text-xl">chat_bubble</span>
             <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
           </button>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 const navItems = [
   { label: '홈', icon: 'home', path: '/' },
   { label: '검색', icon: 'search', path: '/search' },
-  { label: '내 서재', icon: 'menu_book', path: '/library' },
+  { label: '내 서재', icon: 'menu_book', path: '/' }, // TODO: 내 서재 페이지 생성 후 /library로 변경
   { label: '프로필', icon: 'person', path: '/profile' },
 ]
 

--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,7 @@
   body {
     @apply text-foreground;
     font-family: 'Newsreader', serif;
-    background-color: #ffffff;
+    background-color: hsl(var(--card));
   }
 
   #root {

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { mockBooks, mockBookDetailReviews } from '@/mocks/data'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
@@ -6,7 +6,29 @@ import StarRating from '@/components/common/StarRating'
 
 export default function BookDetailPage() {
   const { id } = useParams()
-  const book = mockBooks.find(b => b.isbn === id) ?? mockBooks[3]
+  const navigate = useNavigate()
+  const book = mockBooks.find(b => b.isbn === id)
+
+  if (!book) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="BookLog" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 pb-24">
+          <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
+            search_off
+          </span>
+          <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            돌아가기
+          </button>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-background">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -94,7 +94,11 @@ export default function SignupPage() {
             </p>
           </div>
 
-          <form onSubmit={step1Form.handleSubmit(onStep1Submit)} className="flex flex-1 flex-col">
+          <form
+            key="step1"
+            onSubmit={step1Form.handleSubmit(onStep1Submit)}
+            className="flex flex-1 flex-col"
+          >
             <div className="mt-4 flex flex-col gap-4 px-4 py-3">
               <div className="flex flex-col gap-2">
                 <label className="text-base font-medium">이메일</label>
@@ -191,13 +195,18 @@ export default function SignupPage() {
             </div>
           </div>
 
-          <form onSubmit={step2Form.handleSubmit(onStep2Submit)} className="flex flex-1 flex-col">
+          <form
+            key="step2"
+            onSubmit={step2Form.handleSubmit(onStep2Submit)}
+            className="flex flex-1 flex-col"
+          >
             <div className="space-y-6 px-6">
               <div className="flex flex-col gap-2">
                 <label className="ml-1 text-base font-semibold">닉네임</label>
                 <input
                   {...step2Form.register('nickname')}
                   type="text"
+                  autoComplete="one-time-code" // Chrome이 autoComplete="off"를 무시하므로 인식 불가한 값 사용
                   placeholder="사용할 닉네임을 입력하세요"
                   className="h-14 w-full rounded-xl border border-primary/20 bg-card px-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
                 />


### PR DESCRIPTION
  - SignupPage 닉네임 autofill 문제 수정 (form key 분리 + autoComplete)
  - ReviewCard 좋아요 하트 토글 (fill-icon)
  - ReviewCard 클릭 시 /review/:id로 이동 (Link 추가)
  - BottomNav 내 서재 경로 임시 홈으로 변경
  - BookDetailPage 존재하지 않는 도서 fallback UI 추가
  - body 배경색 CSS 변수로 변경 (다크모드 대응)

  Closes #21