### PR TITLE
fix: overscroll 바운스 제거 및 데스크탑 횡스크롤 추가

### DIFF
--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -1,0 +1,54 @@
+import { useRef, useEffect } from 'react'
+
+export function useDragScroll<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    let isDown = false
+    let startX = 0
+    let scrollLeft = 0
+
+    const onMouseDown = (e: MouseEvent) => {
+      isDown = true
+      el.style.cursor = 'grabbing'
+      startX = e.pageX - el.offsetLeft
+      scrollLeft = el.scrollLeft
+    }
+
+    const onMouseLeave = () => {
+      isDown = false
+      el.style.cursor = 'grab'
+    }
+
+    const onMouseUp = () => {
+      isDown = false
+      el.style.cursor = 'grab'
+    }
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isDown) return
+      e.preventDefault()
+      const x = e.pageX - el.offsetLeft
+      const walk = (x - startX) * 2
+      el.scrollLeft = scrollLeft - walk
+    }
+
+    el.style.cursor = 'grab'
+    el.addEventListener('mousedown', onMouseDown)
+    el.addEventListener('mouseleave', onMouseLeave)
+    el.addEventListener('mouseup', onMouseUp)
+    el.addEventListener('mousemove', onMouseMove)
+
+    return () => {
+      el.removeEventListener('mousedown', onMouseDown)
+      el.removeEventListener('mouseleave', onMouseLeave)
+      el.removeEventListener('mouseup', onMouseUp)
+      el.removeEventListener('mousemove', onMouseMove)
+    }
+  }, [])
+
+  return ref
+}

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,7 @@
     @apply text-foreground;
     font-family: 'Newsreader', serif;
     background-color: hsl(var(--card));
+    overscroll-behavior: none;
   }
 
   #root {

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -3,10 +3,12 @@ import { mockBooks, mockBookDetailReviews } from '@/mocks/data'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
+import { useDragScroll } from '@/hooks/useDragScroll'
 
 export default function BookDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const scrollRef = useDragScroll<HTMLDivElement>()
   const book = mockBooks.find(b => b.isbn === id)
 
   if (!book) {
@@ -92,7 +94,7 @@ export default function BookDetailPage() {
             <h3 className="text-xl font-bold">독자들의 감상</h3>
             <button className="text-sm font-semibold text-primary">전체보기</button>
           </div>
-          <div className="no-scrollbar flex gap-4 overflow-x-auto px-6 pb-4">
+          <div ref={scrollRef} className="no-scrollbar flex gap-4 overflow-x-auto px-6 pb-4">
             {mockBookDetailReviews.map(review => (
               <div
                 key={review.id}


### PR DESCRIPTION
  - body에 overscroll-behavior: none 적용 (모바일 바운스 제거)
  - useDragScroll 커스텀 훅 생성 (마우스 드래그 횡스크롤)
  - BookDetailPage 독자 감상 섹션에 드래그 스크롤 적용
  - LoginPage console.log는 이미 제거 확인 완료

  Closes #23