### PR TITLE
feat: 알림 페이지 (NotificationsPage) 구현

### DIFF
--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1,4 +1,4 @@
-import type { Book, Memo, User } from '@/types'
+import type { Book, Memo, Notification, User } from '@/types'
 
 // 유저 Mock 데이터
 export const mockUsers: User[] = [
@@ -197,5 +197,55 @@ export const mockBookDetailReviews: Memo[] = [
     readingStatus: 'finished',
     hasSpoiler: false,
     commentCount: 5,
+  },
+]
+
+// 알림 Mock 데이터
+export const mockNotifications: Notification[] = [
+  {
+    id: 1,
+    type: 'like',
+    senderNickname: '김지우',
+    senderProfileImageUrl: 'https://picsum.photos/seed/noti1/100/100',
+    message: '님이 회원님의 감상에 좋아요를 눌렀습니다.',
+    isRead: false,
+    createdAt: '2시간 전',
+  },
+  {
+    id: 2,
+    type: 'comment',
+    senderNickname: '이민호',
+    senderProfileImageUrl: 'https://picsum.photos/seed/noti2/100/100',
+    message: '님이 회원님의 감상에 댓글을 남겼습니다.',
+    isRead: false,
+    createdAt: '5시간 전',
+  },
+  {
+    id: 3,
+    type: 'follow',
+    senderNickname: '박서연',
+    senderProfileImageUrl: 'https://picsum.photos/seed/noti3/100/100',
+    message: '님이 회원님을 팔로우하기 시작했습니다.',
+    isRead: true,
+    createdAt: '어제',
+  },
+  {
+    id: 4,
+    type: 'new_review',
+    senderNickname: '최준혁',
+    senderProfileImageUrl: 'https://picsum.photos/seed/noti4/100/100',
+    message: '님이 새로운 감상을 올렸습니다.',
+    isRead: true,
+    createdAt: '어제',
+    bookTitle: '데미안',
+  },
+  {
+    id: 5,
+    type: 'like',
+    senderNickname: '윤아름',
+    senderProfileImageUrl: 'https://picsum.photos/seed/noti5/100/100',
+    message: '님이 회원님의 감상에 좋아요를 눌렀습니다.',
+    isRead: true,
+    createdAt: '2일 전',
   },
 ]

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import { mockReviews } from '@/mocks/data'
 import BottomNav from '@/components/layout/BottomNav'
@@ -13,9 +14,12 @@ export default function HomeFeedPage() {
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="flex items-center justify-between px-4 py-3">
           <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
-          <button className="rounded-full p-2 transition-colors hover:bg-primary/5">
+          <Link
+            to="/notifications"
+            className="rounded-full p-2 transition-colors hover:bg-primary/5"
+          >
             <span className="material-symbols-outlined text-primary">notifications</span>
-          </button>
+          </Link>
         </div>
         {/* Tabs */}
         <div className="flex gap-8 px-4">

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { mockNotifications } from '@/mocks/data'
+import type { NotificationType } from '@/types'
+import AppHeader from '@/components/layout/AppHeader'
+import BottomNav from '@/components/layout/BottomNav'
+
+const typeIcon: Record<NotificationType, { icon: string; bg: string }> = {
+  like: { icon: 'favorite', bg: 'bg-red-500' },
+  comment: { icon: 'chat_bubble', bg: 'bg-blue-500' },
+  follow: { icon: 'person_add', bg: 'bg-emerald-500' },
+  new_review: { icon: 'menu_book', bg: 'bg-amber-600' },
+}
+
+export default function NotificationsPage() {
+  const [activeTab, setActiveTab] = useState<'all' | 'unread'>('all')
+  const [notifications, setNotifications] = useState(mockNotifications)
+
+  const displayed = activeTab === 'all' ? notifications : notifications.filter(n => !n.isRead)
+
+  const unread = notifications.filter(n => !n.isRead)
+  const read = notifications.filter(n => n.isRead)
+
+  const markAsRead = (id: number) => {
+    setNotifications(prev => prev.map(n => (n.id === id ? { ...n, isRead: true } : n)))
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
+        <div className="flex h-16 items-center justify-between px-4">
+          <AppHeader title="알림" showBack className="border-none" />
+        </div>
+        {/* Tabs */}
+        <div className="flex gap-6 px-4">
+          <button
+            onClick={() => setActiveTab('all')}
+            className={cn(
+              'border-b-2 pb-2 text-sm font-bold transition-colors',
+              activeTab === 'all'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground'
+            )}
+          >
+            전체
+          </button>
+          <button
+            onClick={() => setActiveTab('unread')}
+            className={cn(
+              'border-b-2 pb-2 text-sm font-medium transition-colors',
+              activeTab === 'unread'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground'
+            )}
+          >
+            읽지 않음
+          </button>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto pb-24">
+        {activeTab === 'all' ? (
+          <>
+            {/* Unread Section */}
+            {unread.length > 0 && (
+              <div className="bg-primary/5 px-4 py-3">
+                <p className="mb-2 text-[10px] font-bold uppercase tracking-widest">New</p>
+                {unread.map(noti => (
+                  <NotificationItem
+                    key={noti.id}
+                    notification={noti}
+                    onRead={markAsRead}
+                    highlighted
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Read Section */}
+            {read.length > 0 && (
+              <div className="px-4 py-3">
+                <p className="mb-4 text-[10px] font-bold uppercase tracking-widest">Earlier</p>
+                {read.map(noti => (
+                  <NotificationItem key={noti.id} notification={noti} onRead={markAsRead} />
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="px-4 py-3">
+            {displayed.length > 0 ? (
+              displayed.map(noti => (
+                <NotificationItem
+                  key={noti.id}
+                  notification={noti}
+                  onRead={markAsRead}
+                  highlighted
+                />
+              ))
+            ) : (
+              <div className="flex flex-col items-center justify-center gap-3 py-20">
+                <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+                  notifications_off
+                </span>
+                <p className="text-sm text-muted-foreground">읽지 않은 알림이 없습니다</p>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}
+
+function NotificationItem({
+  notification,
+  onRead,
+  highlighted = false,
+}: {
+  notification: (typeof mockNotifications)[number]
+  onRead: (id: number) => void
+  highlighted?: boolean
+}) {
+  const icon = typeIcon[notification.type]
+
+  return (
+    <button
+      onClick={() => onRead(notification.id)}
+      className={cn(
+        'mb-3 flex w-full items-center gap-4 rounded-xl p-4 text-left transition-colors',
+        highlighted ? 'bg-primary/10 shadow-sm' : 'hover:bg-primary/5'
+      )}
+    >
+      <div className="relative shrink-0">
+        <div className="size-12 overflow-hidden rounded-full border-2 border-card">
+          {notification.senderProfileImageUrl ? (
+            <img
+              src={notification.senderProfileImageUrl}
+              alt={notification.senderNickname}
+              className="size-full object-cover"
+            />
+          ) : (
+            <div className="flex size-full items-center justify-center bg-primary/10">
+              <span className="material-symbols-outlined text-primary/40">person</span>
+            </div>
+          )}
+        </div>
+        <div
+          className={cn(
+            'absolute -bottom-1 -right-1 flex size-5 items-center justify-center rounded-full border-2 border-card text-white',
+            icon.bg
+          )}
+        >
+          <span
+            className={cn(
+              'material-symbols-outlined text-[12px]',
+              notification.type === 'like' && 'fill-icon'
+            )}
+          >
+            {icon.icon}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1">
+        <p className="text-sm leading-snug">
+          <span className="font-bold">{notification.senderNickname}</span>
+          {notification.message}
+          {notification.bookTitle && (
+            <span className="italic"> &apos;{notification.bookTitle}&apos;</span>
+          )}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{notification.createdAt}</p>
+      </div>
+
+      {!notification.isRead && <div className="size-2 shrink-0 rounded-full bg-primary" />}
+    </button>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -8,6 +8,7 @@ import WriteReviewPage from '@/pages/WriteReviewPage'
 import ReviewDetailPage from '@/pages/ReviewDetailPage'
 import MyProfilePage from '@/pages/MyProfilePage'
 import SettingsPage from '@/pages/SettingsPage'
+import NotificationsPage from '@/pages/NotificationsPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -64,6 +65,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <MyProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/notifications',
+    element: (
+      <ProtectedRoute>
+        <NotificationsPage />
       </ProtectedRoute>
     ),
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,20 @@ export interface Book {
   reviewCount?: number
 }
 
+// 알림
+export type NotificationType = 'like' | 'comment' | 'follow' | 'new_review'
+
+export interface Notification {
+  id: number
+  type: NotificationType
+  senderNickname: string
+  senderProfileImageUrl?: string
+  message: string
+  isRead: boolean
+  createdAt: string
+  bookTitle?: string
+}
+
 // 읽기 상태
 export type ReadingStatus = 'reading' | 'finished' | 'want_to_read'
 


### PR DESCRIPTION
  - Notification 타입 및 Mock 알림 데이터 추가
  - 알림 페이지 구현 (전체/읽지 않음 탭, 읽음 처리)
  - 알림 유형별 아이콘 표시 (좋아요, 댓글, 팔로우, 새 감상)
  - 라우트 연결 (/notifications) + ProtectedRoute 적용
  - HomeFeedPage 알림 아이콘에 /notifications 링크 연결

  Closes #25