### PR TITLE
feat: 내 서재 페이지 (MyLibraryPage) 구현

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 const navItems = [
   { label: '홈', icon: 'home', path: '/' },
   { label: '검색', icon: 'search', path: '/search' },
-  { label: '내 서재', icon: 'menu_book', path: '/' }, // TODO: 내 서재 페이지 생성 후 /library로 변경
+  { label: '내 서재', icon: 'menu_book', path: '/library' },
   { label: '프로필', icon: 'person', path: '/profile' },
 ]
 

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1,4 +1,4 @@
-import type { Book, Memo, Notification, User } from '@/types'
+import type { Book, LibraryBook, Memo, Notification, User } from '@/types'
 
 // 유저 Mock 데이터
 export const mockUsers: User[] = [
@@ -247,5 +247,96 @@ export const mockNotifications: Notification[] = [
     message: '님이 회원님의 감상에 좋아요를 눌렀습니다.',
     isRead: true,
     createdAt: '2일 전',
+  },
+]
+
+// 내 서재 Mock 데이터
+export const mockLibraryBooks: LibraryBook[] = [
+  { book: mockBooks[0], readingStatus: 'finished', addedAt: '2024-06-01' },
+  { book: mockBooks[2], readingStatus: 'reading', addedAt: '2024-06-10' },
+  {
+    book: {
+      isbn: '9788937460510',
+      title: '인간 실격',
+      author: '다자이 오사무',
+      publisher: '민음사',
+      coverImageUrl: 'https://picsum.photos/seed/ningen/200/300',
+      pageCount: 224,
+      rating: 4.3,
+      reviewCount: 680,
+    },
+    readingStatus: 'finished',
+    addedAt: '2024-05-20',
+  },
+  {
+    book: {
+      isbn: '9788937460527',
+      title: '이방인',
+      author: '알베르 카뮈',
+      publisher: '민음사',
+      coverImageUrl: 'https://picsum.photos/seed/stranger/200/300',
+      pageCount: 176,
+      rating: 4.4,
+      reviewCount: 750,
+    },
+    readingStatus: 'want_to_read',
+    addedAt: '2024-06-15',
+  },
+  {
+    book: {
+      isbn: '9788937460534',
+      title: '달과 6펜스',
+      author: '서머셋 몸',
+      publisher: '문학동네',
+      coverImageUrl: 'https://picsum.photos/seed/moon6/200/300',
+      pageCount: 340,
+      rating: 4.1,
+      reviewCount: 320,
+    },
+    readingStatus: 'reading',
+    addedAt: '2024-06-12',
+  },
+  { book: mockBooks[1], readingStatus: 'finished', addedAt: '2024-04-10' },
+  {
+    book: {
+      isbn: '9788937460541',
+      title: '모비 딕',
+      author: '허먼 멜빌',
+      publisher: '펭귄클래식',
+      coverImageUrl: 'https://picsum.photos/seed/mobydick/200/300',
+      pageCount: 720,
+      rating: 3.9,
+      reviewCount: 210,
+    },
+    readingStatus: 'stopped',
+    addedAt: '2024-03-01',
+  },
+  {
+    book: {
+      isbn: '9788937460558',
+      title: '어린 왕자',
+      author: '생텍쥐페리',
+      publisher: '문학동네',
+      coverImageUrl: 'https://picsum.photos/seed/prince/200/300',
+      pageCount: 136,
+      rating: 4.9,
+      reviewCount: 2100,
+    },
+    readingStatus: 'want_to_read',
+    addedAt: '2024-06-18',
+  },
+  {
+    book: {
+      isbn: '9788937460565',
+      title: '정의란 무엇인가',
+      author: '마이클 샌델',
+      publisher: '와이즈베리',
+      coverImageUrl: 'https://picsum.photos/seed/justice/200/300',
+      pageCount: 408,
+      rating: 4.2,
+      reviewCount: 980,
+    },
+    readingStatus: 'finished',
+    addedAt: '2024-02-15',
   },
 ]

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { cn } from '@/lib/utils'
+import { mockLibraryBooks } from '@/mocks/data'
+import type { ReadingStatus } from '@/types'
+import BottomNav from '@/components/layout/BottomNav'
+
+const filters: { label: string; value: ReadingStatus | 'all' }[] = [
+  { label: '전체', value: 'all' },
+  { label: '읽고 싶은', value: 'want_to_read' },
+  { label: '읽는 중', value: 'reading' },
+  { label: '다 읽음', value: 'finished' },
+  { label: '중단', value: 'stopped' },
+]
+
+const statusBadge: Record<ReadingStatus, { text: string; bg: string }> = {
+  finished: { text: '다 읽음', bg: 'bg-primary' },
+  reading: { text: '읽는 중', bg: 'bg-amber-600' },
+  want_to_read: { text: '읽고 싶은', bg: 'bg-primary/40' },
+  stopped: { text: '중단', bg: 'bg-slate-400' },
+}
+
+export default function MyLibraryPage() {
+  const [activeFilter, setActiveFilter] = useState<ReadingStatus | 'all'>('all')
+
+  const displayed =
+    activeFilter === 'all'
+      ? mockLibraryBooks
+      : mockLibraryBooks.filter(item => item.readingStatus === activeFilter)
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-20 flex items-center justify-between border-b border-border bg-background/80 px-4 py-4 backdrop-blur-md">
+        <h1 className="text-2xl font-bold">내 서재</h1>
+        <Link to="/search" className="rounded-full p-2 transition-colors hover:bg-primary/10">
+          <span className="material-symbols-outlined text-primary">search</span>
+        </Link>
+      </header>
+
+      {/* Filter Chips */}
+      <div className="no-scrollbar flex gap-2 overflow-x-auto p-4">
+        {filters.map(filter => (
+          <button
+            key={filter.value}
+            onClick={() => setActiveFilter(filter.value)}
+            className={cn(
+              'shrink-0 rounded-full px-5 py-2 text-sm font-medium transition-colors',
+              activeFilter === filter.value
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-primary/10 text-primary hover:bg-primary/20'
+            )}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex cursor-pointer items-center gap-2 rounded-lg bg-primary/5 px-3 py-1.5">
+          <span className="material-symbols-outlined text-sm text-primary">swap_vert</span>
+          <span className="text-sm font-medium text-primary">최근 추가순</span>
+        </div>
+        <div className="flex items-center gap-4 text-primary/60">
+          <span className="material-symbols-outlined cursor-pointer text-primary transition-colors">
+            grid_view
+          </span>
+          <span className="material-symbols-outlined cursor-pointer transition-colors hover:text-primary">
+            view_list
+          </span>
+          <span className="material-symbols-outlined cursor-pointer transition-colors hover:text-primary">
+            layers
+          </span>
+        </div>
+      </div>
+
+      {/* Book Count */}
+      <div className="px-4 py-4">
+        <p className="text-sm font-medium">총 {displayed.length}권</p>
+      </div>
+
+      {/* Book Grid */}
+      <main className="px-4 pb-24">
+        {displayed.length > 0 ? (
+          <div className="grid grid-cols-3 gap-4">
+            {displayed.map(item => {
+              const badge = statusBadge[item.readingStatus]
+              return (
+                <Link
+                  key={item.book.isbn}
+                  to={`/book/${item.book.isbn}`}
+                  className="relative flex flex-col gap-2"
+                >
+                  <div className="group relative aspect-[2/3] w-full overflow-hidden rounded-lg shadow-md">
+                    <img
+                      src={item.book.coverImageUrl}
+                      alt={item.book.title}
+                      className="size-full object-cover"
+                    />
+                    <div
+                      className={cn(
+                        'absolute bottom-1 right-1 rounded-full px-2 py-0.5 text-[10px] text-white',
+                        badge.bg
+                      )}
+                    >
+                      {badge.text}
+                    </div>
+                  </div>
+                  <p className="line-clamp-1 text-xs font-semibold">{item.book.title}</p>
+                </Link>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              menu_book
+            </span>
+            <p className="text-sm text-muted-foreground">해당 상태의 도서가 없습니다</p>
+          </div>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,6 +9,7 @@ import ReviewDetailPage from '@/pages/ReviewDetailPage'
 import MyProfilePage from '@/pages/MyProfilePage'
 import SettingsPage from '@/pages/SettingsPage'
 import NotificationsPage from '@/pages/NotificationsPage'
+import MyLibraryPage from '@/pages/MyLibraryPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -65,6 +66,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <MyProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/library',
+    element: (
+      <ProtectedRoute>
+        <MyLibraryPage />
       </ProtectedRoute>
     ),
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,7 +49,14 @@ export interface Notification {
 }
 
 // 읽기 상태
-export type ReadingStatus = 'reading' | 'finished' | 'want_to_read'
+export type ReadingStatus = 'reading' | 'finished' | 'want_to_read' | 'stopped'
+
+// 서재 도서
+export interface LibraryBook {
+  book: Book
+  readingStatus: ReadingStatus
+  addedAt: string
+}
 
 // 감상 (메모)
 export interface Memo {


### PR DESCRIPTION
  - LibraryBook 타입 및 ReadingStatus에 stopped 추가
  - Mock 서재 데이터 9권 생성
  - 내 서재 페이지 구현 (상태 필터 칩, 3열 그리드, 상태별 뱃지)
  - 라우트 연결 (/library) + ProtectedRoute 적용
  - BottomNav 내 서재 경로 /library로 변경 (TODO 해결)

  Closes #27