### PR TITLE
fix: ReviewDetailPage를 review id 기반 동적 데이터로 연동

### DIFF
--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,44 +1,69 @@
+import { useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
+import { mockBookDetailReviews, mockReviews } from '@/mocks/data'
+import type { ReadingStatus } from '@/types'
+
+const readingStatusLabel: Record<ReadingStatus, string> = {
+  finished: '다 읽음',
+  reading: '읽는 중',
+  stopped: '중단',
+  want_to_read: '읽고 싶어요',
+}
+
+const commentTemplates = [
+  '문장 해석이 인상적이네요. 저도 다시 읽어보고 싶어요.',
+  '공감되는 감상이에요. 다음에도 이런 리뷰 기대할게요.',
+  '스포일러 경고 덕분에 안심하고 읽었습니다. 감사합니다!',
+]
 
 export default function ReviewDetailPage() {
-  const review = {
-    book: {
-      title: '데미안',
-      author: '헤르만 헤세',
-      coverImageUrl:
-        'https://images.unsplash.com/photo-1544947950-fa07a98d237f?auto=format&fit=crop&w=800&q=80',
-      rating: 5.0,
-      status: '다 읽음',
-    },
-    content: `알을 깨고 나오는 새의 투쟁처럼, 자아를 찾아가는 치열한 성장의 기록입니다. 싱클레어가 데미안을 만나며 겪는 내면의 변화는 시대를 초월한 깊은 울림을 줍니다.
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const [liked, setLiked] = useState(false)
+  const allReviews = useMemo(() => [...mockReviews, ...mockBookDetailReviews], [])
+  const reviewId = Number(id)
+  const review = allReviews.find(item => item.id === reviewId)
 
-우리는 모두 각자의 ‘가인’의 표식을 지닌 채, 고정관념이라는 알 속에 갇혀 살아가고 있는지도 모릅니다. 헤세는 이 책을 통해 우리에게 묻습니다. 당신은 진정으로 자신의 길을 걷고 있는가?`,
-    quote:
-      '새는 알에서 나오려고 투쟁한다. 알은 세계이다. 태어나려는 자는 하나의 세계를 깨뜨려야 한다. 새는 신에게로 날아간다. 그 신의 이름은 아브락사스다.',
-    quoteSource: '본문 중에서',
-    tags: ['고전', '성장소설', '헤세'],
-    likes: 124,
-    commentsCount: 12,
-    comments: [
-      {
-        id: 1,
-        author: '김지민',
-        time: '2시간 전',
-        content: '이 문장은 읽을 때마다 마음에 깊게 남는 것 같아요. 정말 최고의 고전입니다.',
-      },
-      {
-        id: 2,
-        author: '박선영',
-        time: '5시간 전',
-        content: '저도 다시 한 번 꺼내 읽고 싶어졌어요.',
-      },
-    ],
+  if (!review) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="감상 상세" showBack />
+
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 pb-24">
+          <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
+            search_off
+          </span>
+          <p className="text-lg font-bold text-muted-foreground">감상을 찾을 수 없습니다</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            돌아가기
+          </button>
+        </main>
+
+        <BottomNav />
+      </div>
+    )
   }
+
+  const reviewStatus = review.readingStatus ? readingStatusLabel[review.readingStatus] : '기록'
+  const likeCount = review.likeCount + (liked ? 1 : 0)
+  const comments = Array.from({ length: Math.min(review.commentCount ?? 0, 3) }, (_, index) => ({
+    id: index + 1,
+    author: `독자 ${index + 1}`,
+    time: `${index + 1}시간 전`,
+    content: commentTemplates[index % commentTemplates.length],
+  }))
+  const tags = [review.book.author, review.book.publisher, reviewStatus]
+  const quote = review.book.description ?? review.content
+  const quoteSource = review.book.description ? '도서 소개' : '감상 중에서'
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <AppHeader title="데미안" showBack />
+      <AppHeader title={review.book.title} showBack />
 
       <main className="flex-1 overflow-y-auto pb-24">
         {/* Book Card */}
@@ -57,7 +82,7 @@ export default function ReviewDetailPage() {
             <div className="px-6 py-5">
               <div className="mb-3 flex items-center justify-between">
                 <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary">
-                  {review.book.status}
+                  {reviewStatus}
                 </span>
 
                 <div className="flex items-center gap-1 rounded-full bg-primary/5 px-3 py-1.5 text-sm font-bold text-primary">
@@ -67,7 +92,7 @@ export default function ReviewDetailPage() {
                   >
                     star
                   </span>
-                  <span>{review.book.rating.toFixed(1)}</span>
+                  <span>{(review.rating ?? review.book.rating ?? 0).toFixed(1)}</span>
                 </div>
               </div>
 
@@ -95,8 +120,8 @@ export default function ReviewDetailPage() {
             </div>
 
             <div className="border-l-4 border-primary pl-4">
-              <p className="text-xl italic leading-9 text-foreground/85">{review.quote}</p>
-              <p className="mt-4 text-base text-muted-foreground">{review.quoteSource}</p>
+              <p className="text-xl italic leading-9 text-foreground/85">{quote}</p>
+              <p className="mt-4 text-base text-muted-foreground">{quoteSource}</p>
             </div>
           </div>
         </section>
@@ -104,7 +129,7 @@ export default function ReviewDetailPage() {
         {/* Tags */}
         <section className="px-5 py-2">
           <div className="flex flex-wrap gap-2">
-            {review.tags.map(tag => (
+            {tags.map(tag => (
               <span
                 key={tag}
                 className="rounded-xl bg-primary/10 px-4 py-1.5 text-sm font-semibold text-primary/80"
@@ -119,19 +144,22 @@ export default function ReviewDetailPage() {
         <section className="mt-4 border-t border-border px-5 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-5 text-sm font-semibold text-muted-foreground">
-              <button className="flex items-center gap-1.5 transition-colors hover:text-primary">
+              <button
+                onClick={() => setLiked(prev => !prev)}
+                className="flex items-center gap-1.5 transition-colors hover:text-primary"
+              >
                 <span
                   className="material-symbols-outlined text-[20px]"
-                  style={{ fontVariationSettings: "'FILL' 1" }}
+                  style={{ fontVariationSettings: `'FILL' ${liked ? 1 : 0}` }}
                 >
                   favorite
                 </span>
-                <span>{review.likes}</span>
+                <span>{likeCount}</span>
               </button>
 
               <div className="flex items-center gap-1.5">
                 <span className="material-symbols-outlined text-[20px]">chat_bubble</span>
-                <span>{review.commentsCount}</span>
+                <span>{review.commentCount ?? 0}</span>
               </div>
             </div>
 
@@ -143,27 +171,35 @@ export default function ReviewDetailPage() {
 
         {/* Comments */}
         <section className="px-5 pb-6 pt-2">
-          <h3 className="mb-4 text-lg font-bold">댓글 {review.commentsCount}개</h3>
+          <h3 className="mb-4 text-lg font-bold">댓글 {review.commentCount ?? 0}개</h3>
 
-          <div className="border-t border-border">
-            {review.comments.map(comment => (
-              <div key={comment.id} className="border-b border-border py-4">
-                <div className="mb-2 flex items-start justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
-                      {comment.author[0]}
-                    </div>
-                    <div>
-                      <p className="text-sm font-bold">{comment.author}</p>
-                      <p className="text-xs text-muted-foreground">{comment.time}</p>
+          {comments.length > 0 ? (
+            <div className="border-t border-border">
+              {comments.map(comment => (
+                <div key={comment.id} className="border-b border-border py-4">
+                  <div className="mb-2 flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+                        {comment.author[0]}
+                      </div>
+                      <div>
+                        <p className="text-sm font-bold">{comment.author}</p>
+                        <p className="text-xs text-muted-foreground">{comment.time}</p>
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <p className="pl-[52px] text-sm leading-6 text-foreground/85">{comment.content}</p>
-              </div>
-            ))}
-          </div>
+                  <p className="pl-[52px] text-sm leading-6 text-foreground/85">
+                    {comment.content}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl bg-card px-4 py-5 text-center text-sm text-muted-foreground">
+              아직 댓글이 없습니다.
+            </div>
+          )}
         </section>
 
         {/* Comment Input */}


### PR DESCRIPTION
## 작업 내용
ReviewDetailPage를 하드코딩 데이터 기반에서 review/:id 파라미터 기반 동적 조회 방식으로 변경했습니다.
mockReviews + mockBookDetailReviews에서 id로 리뷰를 찾아 상세 화면에 렌더링하도록 수정했습니다.
기존 고정값(데미안 제목/저자/내용) 제거 후, 선택한 리뷰 데이터로 제목/본문/메타 정보가 표시되도록 반영했습니다.
잘못된 id 접근 시 “감상을 찾을 수 없습니다” 예외 화면을 추가했습니다.
## 변경 이유
홈/도서 상세에서 어떤 감상을 눌러도 동일한 하드코딩 화면이 보이는 문제를 해결하기 위함입니다.
라우트 파라미터와 실제 데이터가 연결되도록 하여 상세 페이지 일관성을 확보했습니다.
## 확인 방법
홈/도서 상세에서 서로 다른 감상 항목을 클릭합니다.
URL의 /review/:id 값에 맞는 리뷰 상세 내용이 노출되는지 확인합니다.
존재하지 않는 리뷰 id로 접근 시 예외 화면이 보이는지 확인합니다.

Closes #37 