### PR TITLE
fix: WriteReviewPage를 bookId 기반으로 연동하고 인용구 입력 UI를 동적 처리

### DIFF
--- a/src/components/common/AddToLibrarySheet.tsx
+++ b/src/components/common/AddToLibrarySheet.tsx
@@ -8,6 +8,7 @@ interface AddToLibrarySheetProps {
   isOpen: boolean
   onClose: () => void
   onSave: (status: ReadingStatus) => void
+  bookId: string
   defaultStatus?: ReadingStatus
 }
 
@@ -22,6 +23,7 @@ export default function AddToLibrarySheet({
   isOpen,
   onClose,
   onSave,
+  bookId,
   defaultStatus = 'want_to_read',
 }: AddToLibrarySheetProps) {
   const [selected, setSelected] = useState<ReadingStatus>(defaultStatus)
@@ -85,7 +87,7 @@ export default function AddToLibrarySheet({
             <button
               onClick={() => {
                 onClose()
-                navigate('/review/write')
+                navigate(`/review/write/${bookId}`)
               }}
               className="text-sm font-semibold text-primary underline decoration-primary/30 underline-offset-4 transition-colors hover:text-primary/80"
             >

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -163,6 +163,7 @@ export default function BookDetailPage() {
         isOpen={sheetOpen}
         onClose={() => setSheetOpen(false)}
         onSave={setSavedStatus}
+        bookId={id ?? book.isbn}
         defaultStatus={savedStatus ?? undefined}
       />
 

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -1,16 +1,59 @@
 import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import { mockBooks } from '@/mocks/data'
 
 export default function WriteReviewPage() {
-  const book = mockBooks[3]
+  const { bookId } = useParams()
+  const navigate = useNavigate()
+  const book = bookId ? mockBooks.find(item => item.isbn === bookId) : undefined
 
   const [rating, setRating] = useState(5)
   const [reviewText, setReviewText] = useState('')
-  const [quoteText] = useState(
-    '“내 속에서 솟아 나오려는 것, 바로 그것을 나는 살아보려고 했다. 왜 그것이 그토록 어려웠을까?”'
-  )
+  const [quoteText, setQuoteText] = useState('')
+  const [isQuoteEditorOpen, setIsQuoteEditorOpen] = useState(false)
+
+  if (!bookId) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="감상 작성" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 px-8 pb-24">
+          <p className="text-center text-sm text-muted-foreground">
+            도서를 먼저 선택하면 해당 책 기준으로 감상을 작성할 수 있어요.
+          </p>
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            돌아가기
+          </button>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (!book) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="감상 작성" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 px-8 pb-24">
+          <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
+            search_off
+          </span>
+          <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            돌아가기
+          </button>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -22,13 +65,13 @@ export default function WriteReviewPage() {
           <div className="flex items-center gap-4">
             <div className="flex h-24 w-16 shrink-0 items-center justify-center rounded-2xl bg-card shadow-sm">
               <div className="h-20 w-12 overflow-hidden rounded-md border border-primary/10 bg-primary/5">
-                <img src={book.coverImageUrl} alt="데미안" className="size-full object-cover" />
+                <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
               </div>
             </div>
 
             <div className="min-w-0">
-              <h2 className="text-2xl font-bold leading-tight text-foreground">데미안</h2>
-              <p className="mt-1 text-lg font-medium text-muted-foreground">헤르만 헤세</p>
+              <h2 className="text-2xl font-bold leading-tight text-foreground">{book.title}</h2>
+              <p className="mt-1 text-lg font-medium text-muted-foreground">{book.author}</p>
             </div>
           </div>
         </section>
@@ -74,20 +117,28 @@ export default function WriteReviewPage() {
           />
         </section>
 
-        {/* Quote Card */}
-        <section className="px-8 py-2">
-          <div className="rounded-2xl bg-primary/5 p-5">
-            <div className="border-l-4 border-primary pl-4">
-              <p className="text-lg italic leading-relaxed text-muted-foreground">{quoteText}</p>
-              <p className="mt-3 text-base text-muted-foreground/70">– page 12</p>
+        {/* Quote Editor */}
+        {isQuoteEditorOpen && (
+          <section className="px-8 py-2">
+            <div className="rounded-2xl bg-primary/5 p-5">
+              <div className="border-l-4 border-primary pl-4">
+                <textarea
+                  value={quoteText}
+                  onChange={e => setQuoteText(e.target.value)}
+                  maxLength={200}
+                  placeholder="기억하고 싶은 문장을 입력하세요."
+                  className="min-h-[96px] w-full resize-none bg-transparent text-lg italic leading-relaxed outline-none placeholder:text-muted-foreground/50"
+                />
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
 
         {/* Quote Add Button */}
         <section className="px-8 py-3">
           <button
             type="button"
+            onClick={() => setIsQuoteEditorOpen(true)}
             className="flex items-center gap-2 text-base font-bold text-primary transition-colors hover:text-primary/80"
           >
             <span className="material-symbols-outlined text-[20px]">format_quote</span>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -63,6 +63,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: '/review/write/:bookId',
+    element: (
+      <ProtectedRoute>
+        <WriteReviewPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: '/review/:id',
     element: (
       <ProtectedRoute>


### PR DESCRIPTION
## 개요
WriteReviewPage 진입/렌더링 흐름을 bookId 기반으로 동적화하고, 인용구 UI의 하드코딩을 제거했습니다.
관련 라우팅 및 진입 컴포넌트까지 함께 수정해 감상 작성 플로우를 일관되게 맞췄습니다.

## 해결한 문제
감상 작성 페이지가 특정 책(mockBooks[3])으로 고정되어, 선택한 책과 무관한 정보가 표시되던 문제
감상 메모 남기기 진입 시 책 식별자 없이 이동하여 페이지가 컨텍스트를 잃던 문제
인용구 영역이 기본 노출 + 하드코딩 텍스트/페이지 정보(page 12)를 보여주던 문제
잘못된/없는 bookId 접근 시 예외 처리 부재 문제

## 파일별 수정사항
1) src/router/index.tsx
  - WriteReviewPage 라우트에 파라미터 경로 추가
  - 추가 경로: /review/write/:bookId
  - 기존 /review/write 경로는 유지(호환성/기존 링크 대응)
2) src/components/common/AddToLibrarySheet.tsx
  - AddToLibrarySheetProps에 bookId: string 추가
  - 감상 메모 남기기 버튼 클릭 시 이동 경로 변경
  - 기존: /review/write
  - 변경: /review/write/${bookId}
3) src/pages/BookDetailPage.tsx
  - AddToLibrarySheet 호출 시 현재 책 id 전달
  - 전달값: bookId={id ?? book.isbn}
4) src/pages/WriteReviewPage.tsx
  - useParams로 bookId 수신
  - bookId 기준으로 mockBooks에서 책 조회 후 제목/저자/커버 동적 렌더링
  - bookId 없음 / 잘못된 경우 예외 화면 추가
  - 인용구 관련 하드코딩 제거
  - 초기 인용구 값: 빈 문자열
  - 기본 상태에서 인용구 박스 미노출
  - 인용구 추가 버튼 클릭 시에만 인용구 입력 박스 생성
  - 하드코딩 문구/page 12 제거

## 동작 확인 체크리스트

- [ ] /book/:id에서 내 서재에 추가 → 감상 메모 남기기 클릭 시 /review/write/:bookId로 이동
- [ ] 이동한 페이지에서 책 정보(제목/저자/표지)가 선택한 책 기준으로 표시
- [ ] 초기 화면에서 인용구 박스가 보이지 않게끔
- [ ] 인용구 추가 클릭 시 인용구 입력 박스가 생성되고 입력 가능
- [ ] 잘못된 bookId로 접근 시 “도서를 찾을 수 없습니다” 예외 화면 표시

Closes #39 