### PR TITLE
feat: 이메일/비밀번호 로그인 API 연동 (#45)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,53 @@
+import axios from 'axios'
+import apiClient from './client'
+
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+export interface LoginUserInfo {
+  userId: number
+  email: string
+  nickname: string
+  profileImageUrl: string | null
+  emailVerified: boolean
+  onboardingCompleted: boolean
+}
+
+export interface LoginResponse {
+  accessToken: string
+  accessTokenExpiresIn: number
+  user: LoginUserInfo
+}
+
+interface ApiResponse<T> {
+  status: 'SUCCESS' | 'ERROR'
+  code: number
+  message?: string
+  data?: T
+  errors?: Array<{ field: string; message: string }>
+}
+
+export async function login(request: LoginRequest): Promise<LoginResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<LoginResponse>>('/api/v1/auth/login', request)
+    if (!data.data) {
+      throw new Error(data.message ?? '로그인 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const apiMessage = error.response?.data?.message
+      if (apiMessage) throw new Error(apiMessage)
+      if (error.code === 'ECONNABORTED') {
+        throw new Error('요청 시간이 초과되었습니다. 다시 시도해주세요.')
+      }
+      if (!error.response) {
+        throw new Error('서버에 연결할 수 없습니다. 백엔드 서버 상태를 확인해주세요.')
+      }
+      throw new Error('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    }
+    throw error
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,10 @@
 import axios from 'axios'
+import { useAuthStore } from '@/store/authStore'
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
   timeout: 10000,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -10,20 +12,23 @@ const apiClient = axios.create({
 
 // 요청 인터셉터 - JWT 토큰 자동 첨부
 apiClient.interceptors.request.use(config => {
-  const token = localStorage.getItem('access_token')
+  const token = useAuthStore.getState().accessToken
   if (token) {
     config.headers.Authorization = `Bearer ${token}`
   }
   return config
 })
 
-// 응답 인터셉터 - 401 처리
+// 응답 인터셉터 - 401 처리 (인증된 사용자의 토큰 만료 시에만 로그아웃 처리)
 apiClient.interceptors.response.use(
   response => response,
   async error => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('access_token')
-      window.location.href = '/login'
+      const wasAuthenticated = useAuthStore.getState().isAuthenticated
+      if (wasAuthenticated) {
+        useAuthStore.getState().clearAuth()
+        window.location.href = '/login'
+      }
     }
     return Promise.reject(error)
   }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
+import { login } from '@/api/auth'
 
 const ONBOARDING_KEY = 'booklog-onboarding-complete'
 
@@ -17,6 +18,9 @@ type LoginForm = z.infer<typeof loginSchema>
 export default function LoginPage() {
   const navigate = useNavigate()
   const setAuth = useAuthStore(state => state.setAuth)
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   // 온보딩을 완료하지 않은 사용자는 온보딩 페이지로 리다이렉트
   useEffect(() => {
@@ -32,13 +36,31 @@ export default function LoginPage() {
     resolver: zodResolver(loginSchema),
   })
 
-  // TODO: API 연동 시 POST /auth/login 호출로 교체
-  const onSubmit = () => {
-    setAuth(
-      { id: 1, nickname: '독서광', profileImageUrl: 'https://picsum.photos/seed/user1/100/100' },
-      'mock-access-token'
-    )
-    navigate('/')
+  const onSubmit = async (formData: LoginForm) => {
+    setIsLoading(true)
+    setErrorMessage(null)
+    try {
+      const result = await login({
+        email: formData.email,
+        password: formData.password,
+      })
+      setAuth(
+        {
+          id: result.user.userId,
+          nickname: result.user.nickname,
+          profileImageUrl: result.user.profileImageUrl ?? undefined,
+          email: result.user.email,
+          emailVerified: result.user.emailVerified,
+          onboardingCompleted: result.user.onboardingCompleted,
+        },
+        result.accessToken
+      )
+      navigate('/')
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '로그인에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
@@ -123,11 +145,21 @@ export default function LoginPage() {
             )}
           </div>
 
+          {errorMessage && (
+            <p
+              role="alert"
+              className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {errorMessage}
+            </p>
+          )}
+
           <button
             type="submit"
-            className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98]"
+            disabled={isLoading}
+            className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
           >
-            로그인
+            {isLoading ? '로그인 중...' : '로그인'}
           </button>
         </form>
       </main>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -5,6 +5,9 @@ interface User {
   id: number
   nickname: string
   profileImageUrl?: string
+  email?: string
+  emailVerified?: boolean
+  onboardingCompleted?: boolean
 }
 
 interface AuthState {


### PR DESCRIPTION
- src/api/auth.ts 신규: login() 함수 + LoginRequest/LoginResponse/ApiResponse 타입 정의, axios 에러를 사용자용 메시지로 정규화

- src/api/client.ts: withCredentials 추가, 요청 인터셉터를 useAuthStore.getState() 기반으로 교체 (기존 localStorage 직접 접근 버그 수정), 401 핸들러는 인증된 사용자에게만 동작하도록 변경

- src/store/authStore.ts: User 타입에 email/emailVerified/onboardingCompleted optional 필드 추가

- src/pages/LoginPage.tsx: mock 호출 제거 후 실제 login() API 연동, 로딩/에러 상태와 에러 메시지 UI 추가, 로그인 중 버튼 disabled 처리