### PR TITLE
feat: Google OAuth 로그인 연동 (#49)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -44,6 +44,26 @@ export interface CheckEmailResponse {
   available: boolean
 }
 
+export interface OAuthLoginUrlResponse {
+  loginUrl: string
+}
+
+export interface GoogleLoginUserInfo {
+  userId: number
+  email: string
+  nickname: string
+  profileImageUrl: string | null
+  emailVerified: boolean
+  onboardingCompleted: boolean
+}
+
+export interface GoogleLoginResponse {
+  accessToken: string
+  accessTokenExpiresIn: number
+  isNewUser: boolean
+  user: GoogleLoginUserInfo
+}
+
 interface ApiResponse<T> {
   status: 'SUCCESS' | 'ERROR'
   code: number
@@ -106,5 +126,37 @@ export async function checkEmail(email: string): Promise<CheckEmailResponse> {
     return data.data
   } catch (error) {
     throw normalizeAxiosError(error, '이메일 확인에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function getGoogleLoginUrl(): Promise<OAuthLoginUrlResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<OAuthLoginUrlResponse>>(
+      '/api/v1/auth/oauth2/google'
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? 'Google 로그인 URL 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      'Google 로그인 URL을 받아오지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
+export async function googleLogin(code: string, redirectUri: string): Promise<GoogleLoginResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<GoogleLoginResponse>>(
+      '/api/v1/auth/oauth2/google/login',
+      { code, redirectUri }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? 'Google 로그인 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, 'Google 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.')
   }
 }

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuthStore } from '@/store/authStore'
+import { googleLogin } from '@/api/auth'
+
+export default function AuthCallbackPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const setAuth = useAuthStore(state => state.setAuth)
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // useEffect가 StrictMode에서 두 번 실행되어 같은 code로 두 번 호출되는 것 방지.
+  // OAuth code는 일회성이라 두 번째 호출은 invalid_grant 에러가 남.
+  const handledRef = useRef(false)
+
+  useEffect(() => {
+    if (handledRef.current) return
+    handledRef.current = true
+
+    const error = searchParams.get('error')
+    if (error) {
+      setErrorMessage(
+        error === 'access_denied'
+          ? 'Google 로그인이 취소되었습니다.'
+          : `Google 로그인 중 오류가 발생했습니다: ${error}`
+      )
+      return
+    }
+
+    const code = searchParams.get('code')
+    if (!code) {
+      setErrorMessage('잘못된 접근입니다. 인증 코드가 없습니다.')
+      return
+    }
+
+    const redirectUri = `${window.location.origin}/auth/callback/google`
+
+    googleLogin(code, redirectUri)
+      .then(result => {
+        setAuth(
+          {
+            id: result.user.userId,
+            nickname: result.user.nickname,
+            profileImageUrl: result.user.profileImageUrl ?? undefined,
+            email: result.user.email,
+            emailVerified: result.user.emailVerified,
+            onboardingCompleted: result.user.onboardingCompleted,
+          },
+          result.accessToken
+        )
+        navigate('/', { replace: true })
+      })
+      .catch(err => {
+        setErrorMessage(err instanceof Error ? err.message : 'Google 로그인에 실패했습니다.')
+      })
+  }, [searchParams, setAuth, navigate])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6">
+      {errorMessage ? (
+        <div className="flex max-w-md flex-col items-center gap-6 text-center">
+          <span className="material-symbols-outlined text-6xl text-destructive">error</span>
+          <h1 className="text-2xl font-bold tracking-tight">Google 로그인 실패</h1>
+          <p
+            role="alert"
+            className="rounded-lg bg-destructive/10 px-6 py-4 text-sm text-destructive"
+          >
+            {errorMessage}
+          </p>
+          <Link
+            to="/login"
+            className="rounded-xl bg-primary px-6 py-3 text-base font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95"
+          >
+            로그인 페이지로 돌아가기
+          </Link>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-6 text-center">
+          <div className="size-12 animate-spin rounded-full border-4 border-primary/20 border-t-primary" />
+          <p className="text-base text-muted-foreground">Google 로그인 처리 중...</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
-import { login } from '@/api/auth'
+import { login, getGoogleLoginUrl } from '@/api/auth'
 
 const ONBOARDING_KEY = 'booklog-onboarding-complete'
 
@@ -21,6 +21,8 @@ export default function LoginPage() {
 
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false)
+  const [googleErrorMessage, setGoogleErrorMessage] = useState<string | null>(null)
 
   // 온보딩을 완료하지 않은 사용자는 온보딩 페이지로 리다이렉트
   useEffect(() => {
@@ -35,6 +37,20 @@ export default function LoginPage() {
   } = useForm<LoginForm>({
     resolver: zodResolver(loginSchema),
   })
+
+  const handleGoogleLogin = async () => {
+    setIsGoogleLoading(true)
+    setGoogleErrorMessage(null)
+    try {
+      const { loginUrl } = await getGoogleLoginUrl()
+      window.location.href = loginUrl
+    } catch (error) {
+      setGoogleErrorMessage(
+        error instanceof Error ? error.message : 'Google 로그인 URL을 받아오지 못했습니다.'
+      )
+      setIsGoogleLoading(false)
+    }
+  }
 
   const onSubmit = async (formData: LoginForm) => {
     setIsLoading(true)
@@ -79,10 +95,12 @@ export default function LoginPage() {
 
       {/* Main Form */}
       <main className="flex w-full max-w-md flex-col gap-10 px-6">
-        {/* Google Login — TODO: API 연동 시 OAuth 흐름 구현 */}
+        {/* Google Login */}
         <button
-          disabled
-          className="group flex w-full items-center justify-center gap-3 rounded-xl border border-primary/10 bg-card px-6 py-4 opacity-50 shadow-sm transition-all duration-300"
+          type="button"
+          onClick={handleGoogleLogin}
+          disabled={isGoogleLoading}
+          className="group flex w-full items-center justify-center gap-3 rounded-xl border border-primary/10 bg-card px-6 py-4 shadow-sm transition-all duration-300 hover:bg-card/80 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <svg className="h-5 w-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
@@ -102,8 +120,18 @@ export default function LoginPage() {
               fill="#EA4335"
             />
           </svg>
-          <span className="text-base font-medium">Google 로그인</span>
+          <span className="text-base font-medium">
+            {isGoogleLoading ? 'Google 로그인 페이지로 이동 중...' : 'Google 로그인'}
+          </span>
         </button>
+        {googleErrorMessage && (
+          <p
+            role="alert"
+            className="-mt-6 rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+          >
+            {googleErrorMessage}
+          </p>
+        )}
 
         {/* Divider */}
         <div className="relative flex items-center py-4">

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,6 +12,7 @@ import NotificationsPage from '@/pages/NotificationsPage'
 import MyLibraryPage from '@/pages/MyLibraryPage'
 import BookReviewsListPage from '@/pages/BookReviewsListPage'
 import OnboardingPage from '@/pages/OnboardingPage'
+import AuthCallbackPage from '@/pages/AuthCallbackPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -34,6 +35,10 @@ export const router = createBrowserRouter([
   {
     path: '/signup',
     element: <SignupPage />,
+  },
+  {
+    path: '/auth/callback/google',
+    element: <AuthCallbackPage />,
   },
   {
     path: '/search',


### PR DESCRIPTION
- src/api/auth.ts: getGoogleLoginUrl()과 googleLogin() 함수 추가. OAuthLoginUrlResponse, GoogleLoginUserInfo, GoogleLoginResponse 타입 정의. 기존 normalizeAxiosError 헬퍼 재사용하여 에러 정규화

- src/pages/AuthCallbackPage.tsx 신규: /auth/callback/google 경로에서 Google이 리다이렉트한 code를 받아 백엔드 googleLogin() 호출. 성공 시 setAuth + 메인 이동, 실패 시 에러 UI + 로그인 페이지로 돌아가기 링크 표시. React StrictMode의 useEffect 이중 실행으로 인한 invalid_grant 에러 방지를 위해 useRef 가드 적용 (OAuth code는 일회성)

- src/pages/LoginPage.tsx: 기존 disabled 상태였던 Google 로그인 버튼 활성화. handleGoogleLogin 핸들러 추가하여 getGoogleLoginUrl() 호출 후 window.location.href로 Google OAuth 페이지 리다이렉트. 로딩 중 버튼 텍스트 전환('Google 로그인 페이지로 이동 중...') + disabled 처리. Google 로그인용 별도 에러 state 추가

- src/router/index.tsx: /auth/callback/google 경로 추가. ProtectedRoute로 감싸지 않음 (로그인 전 접근 가능해야 하므로)