### PR TITLE
feat: 회원가입/로그인 bio 풀스택 연결 (#51)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -11,6 +11,7 @@ export interface LoginUserInfo {
   email: string
   nickname: string
   profileImageUrl: string | null
+  bio: string | null
   emailVerified: boolean
   onboardingCompleted: boolean
 }
@@ -25,12 +26,14 @@ export interface SignupRequest {
   email: string
   password: string
   nickname: string
+  bio?: string
 }
 
 export interface SignupUserInfo {
   userId: number
   email: string
   nickname: string
+  bio: string | null
   emailVerified: boolean
 }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -66,6 +66,7 @@ export default function LoginPage() {
           nickname: result.user.nickname,
           profileImageUrl: result.user.profileImageUrl ?? undefined,
           email: result.user.email,
+          bio: result.user.bio,
           emailVerified: result.user.emailVerified,
           onboardingCompleted: result.user.onboardingCompleted,
         },

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -24,9 +24,7 @@ const step1Schema = z
 
 const step2Schema = z.object({
   nickname: z.string().min(2, '닉네임은 2자 이상이어야 합니다'),
-  // 백엔드 SignupRequest에 bio 필드가 아직 없어서 회원가입 호출 시 전송하지 않음.
-  // 백엔드 bio 지원 머지 후 별도 이슈에서 전송 로직 추가 예정.
-  bio: z.string().optional(),
+  bio: z.string().max(300, '소개글은 300자 이하로 입력해주세요').optional(),
 })
 
 type Step1Form = z.infer<typeof step1Schema>
@@ -73,16 +71,19 @@ export default function SignupPage() {
     setStep2ErrorMessage(null)
     try {
       const { email, password } = step1Form.getValues()
+      const trimmedBio = data.bio?.trim()
       const result = await signup({
         email,
         password,
         nickname: data.nickname,
+        ...(trimmedBio ? { bio: trimmedBio } : {}),
       })
       setAuth(
         {
           id: result.user.userId,
           nickname: result.user.nickname,
           email: result.user.email,
+          bio: result.user.bio,
           emailVerified: result.user.emailVerified,
         },
         result.accessToken
@@ -267,9 +268,22 @@ export default function SignupPage() {
                 <label className="ml-1 text-base font-semibold">소개글 (선택)</label>
                 <textarea
                   {...step2Form.register('bio')}
+                  maxLength={300}
                   placeholder="당신의 독서 취향이나 간단한 소개를 남겨보세요."
                   className="min-h-[100px] w-full resize-none rounded-xl border border-primary/20 bg-card p-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
                 />
+                <div className="flex items-center justify-between px-1">
+                  {step2Form.formState.errors.bio ? (
+                    <p className="text-xs text-destructive">
+                      {step2Form.formState.errors.bio.message}
+                    </p>
+                  ) : (
+                    <span />
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    {step2Form.watch('bio')?.length ?? 0}/300
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -265,10 +265,13 @@ export default function SignupPage() {
               </div>
 
               <div className="flex flex-col gap-2">
-                <label className="ml-1 text-base font-semibold">소개글 (선택)</label>
+                <label className="ml-1 text-base font-semibold" htmlFor="signup-bio">
+                  소개글 (선택)
+                </label>
                 <textarea
+                  id="signup-bio"
                   {...step2Form.register('bio')}
-                  maxLength={300}
+                  aria-describedby="signup-bio-counter"
                   placeholder="당신의 독서 취향이나 간단한 소개를 남겨보세요."
                   className="min-h-[100px] w-full resize-none rounded-xl border border-primary/20 bg-card p-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
                 />
@@ -280,7 +283,15 @@ export default function SignupPage() {
                   ) : (
                     <span />
                   )}
-                  <p className="text-xs text-muted-foreground">
+                  <p
+                    id="signup-bio-counter"
+                    aria-live="polite"
+                    className={`text-xs ${
+                      (step2Form.watch('bio')?.length ?? 0) > 300
+                        ? 'text-destructive'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
                     {step2Form.watch('bio')?.length ?? 0}/300
                   </p>
                 </div>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -6,6 +6,7 @@ interface User {
   nickname: string
   profileImageUrl?: string
   email?: string
+  bio?: string | null
   emailVerified?: boolean
   onboardingCompleted?: boolean
 }


### PR DESCRIPTION
- SignupRequest에 bio 필드 추가, SignupPage step2에서 trim 후 전송

- step2 zod 스키마 max(300) 제한, textarea maxLength 및 글자수 카운터 추가

- LoginUserInfo/SignupUserInfo에 bio 필드 추가, authStore User 타입 확장

- 일반 로그인/회원가입 응답의 bio를 setAuth로 전달해 전역 상태에 반영