### PR TITLE
53 feat logout api settingspage

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -149,6 +149,14 @@ export async function getGoogleLoginUrl(): Promise<OAuthLoginUrlResponse> {
   }
 }
 
+export async function logout(): Promise<void> {
+  try {
+    await apiClient.post('/api/v1/auth/logout')
+  } catch (error) {
+    throw normalizeAxiosError(error, '로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 export async function googleLogin(code: string, redirectUri: string): Promise<GoogleLoginResponse> {
   try {
     const { data } = await apiClient.post<ApiResponse<GoogleLoginResponse>>(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -23,7 +23,9 @@ apiClient.interceptors.request.use(config => {
 apiClient.interceptors.response.use(
   response => response,
   async error => {
-    if (error.response?.status === 401) {
+    const requestUrl: string = error.config?.url ?? ''
+    const isLogoutCall = requestUrl.includes('/api/v1/auth/logout')
+    if (error.response?.status === 401 && !isLogoutCall) {
       const wasAuthenticated = useAuthStore.getState().isAuthenticated
       if (wasAuthenticated) {
         useAuthStore.getState().clearAuth()

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,28 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
+import { logout } from '@/api/auth'
+import { useAuthStore } from '@/store/authStore'
 
 export default function SettingsPage() {
+  const navigate = useNavigate()
+  const clearAuth = useAuthStore(state => state.clearAuth)
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  const handleLogout = async () => {
+    if (isLoggingOut) return
+    setIsLoggingOut(true)
+    try {
+      await logout()
+    } catch (error) {
+      console.error('로그아웃 API 호출 실패:', error)
+    } finally {
+      clearAuth()
+      navigate('/login', { replace: true })
+    }
+  }
+
   const [likeAlert, setLikeAlert] = useState(true)
   const [commentAlert, setCommentAlert] = useState(true)
   const [newFollowerAlert, setNewFollowerAlert] = useState(true)
@@ -143,9 +163,11 @@ export default function SettingsPage() {
         <section className="px-5 pt-10">
           <button
             type="button"
-            className="h-16 w-full rounded-full bg-primary text-xl font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.99]"
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            className="h-16 w-full rounded-full bg-primary text-xl font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.99] disabled:opacity-60"
           >
-            로그아웃
+            {isLoggingOut ? '로그아웃 중...' : '로그아웃'}
           </button>
         </section>
 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -26,10 +26,18 @@ export const useAuthStore = create<AuthState>()(
       accessToken: null,
       isAuthenticated: false,
       setAuth: (user, accessToken) => set({ user, accessToken, isAuthenticated: true }),
-      clearAuth: () => set({ user: null, accessToken: null, isAuthenticated: false }),
+      clearAuth: () => {
+        set({ user: null, accessToken: null, isAuthenticated: false })
+        useAuthStore.persist.clearStorage?.()
+      },
     }),
     {
       name: 'auth-storage',
+      partialize: state => ({
+        user: state.user,
+        accessToken: state.accessToken,
+        isAuthenticated: state.isAuthenticated,
+      }),
     }
   )
 )


### PR DESCRIPTION
- api/auth.ts에 logout() 함수 추가 (POST /api/v1/auth/logout)
- SettingsPage 로그아웃 버튼에 onClick 핸들러 연결
- API 실패 시에도 clearAuth + /login 이동은 무조건 실행 (finally)
- isLoggingOut 가드로 중복 클릭 방지, 로딩 중 라벨 표시