### PR TITLE
55 feat api password reset request pages

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -149,6 +149,25 @@ export async function getGoogleLoginUrl(): Promise<OAuthLoginUrlResponse> {
   }
 }
 
+export async function requestPasswordReset(email: string): Promise<void> {
+  try {
+    await apiClient.post('/api/v1/auth/password/reset-request', { email })
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '비밀번호 재설정 요청에 실패했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<void> {
+  try {
+    await apiClient.post('/api/v1/auth/password/reset', { token, newPassword })
+  } catch (error) {
+    throw normalizeAxiosError(error, '비밀번호 변경에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 export async function logout(): Promise<void> {
   try {
     await apiClient.post('/api/v1/auth/logout')

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,3 @@
+export const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/
+
+export const PASSWORD_HINT = '영문, 숫자, 특수문자 포함 8자 이상'

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -159,9 +159,12 @@ export default function LoginPage() {
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between px-1">
               <label className="text-sm font-semibold">비밀번호</label>
-              <span className="cursor-pointer text-[13px] text-primary hover:underline">
+              <Link
+                to="/password-reset-request"
+                className="text-[13px] text-primary hover:underline"
+              >
                 비밀번호를 잊으셨나요?
-              </span>
+              </Link>
             </div>
             <input
               {...register('password')}

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import AppHeader from '@/components/layout/AppHeader'
+import { resetPassword } from '@/api/auth'
+import { PASSWORD_REGEX } from '@/constants/validation'
+
+const schema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, '비밀번호는 8자 이상이어야 합니다')
+      .regex(PASSWORD_REGEX, '영문, 숫자, 특수문자를 모두 포함해야 합니다'),
+    confirmPassword: z.string(),
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['confirmPassword'],
+  })
+
+type FormData = z.infer<typeof schema>
+
+export default function PasswordResetPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="새 비밀번호 설정" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+          <span className="material-symbols-outlined text-5xl text-destructive">error</span>
+          <p className="text-center text-lg font-medium text-foreground">
+            유효하지 않은 링크입니다.
+          </p>
+          <p className="text-center text-sm text-muted-foreground">
+            비밀번호 재설정을 다시 요청해주세요.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/password-reset-request')}
+            className="mt-4 rounded-xl bg-primary px-8 py-3 text-base font-bold text-primary-foreground transition-all hover:opacity-95"
+          >
+            재설정 요청하기
+          </button>
+        </main>
+      </div>
+    )
+  }
+
+  const onSubmit = async (data: FormData) => {
+    if (isLoading) return
+    setIsLoading(true)
+    setErrorMessage(null)
+    try {
+      await resetPassword(token, data.newPassword)
+      setIsSuccess(true)
+      window.history.replaceState({}, '', '/password-reset')
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '비밀번호 변경에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="새 비밀번호 설정" showBack />
+
+      <main className="flex flex-1 flex-col px-6 pt-12">
+        {isSuccess ? (
+          <div className="flex flex-col items-center gap-4 pt-16 text-center">
+            <span className="material-symbols-outlined text-5xl text-primary">check_circle</span>
+            <h2 className="text-2xl font-bold text-foreground">비밀번호가 변경되었습니다</h2>
+            <p className="text-base text-muted-foreground">새 비밀번호로 로그인해주세요.</p>
+            <button
+              type="button"
+              onClick={() => navigate('/login', { replace: true })}
+              className="mt-4 rounded-xl bg-primary px-8 py-3 text-base font-bold text-primary-foreground transition-all hover:opacity-95"
+            >
+              로그인하기
+            </button>
+          </div>
+        ) : (
+          <>
+            <h2 className="text-2xl font-bold text-foreground">비밀번호 재설정</h2>
+            <p className="mt-3 text-base text-muted-foreground">새로운 비밀번호를 입력해주세요.</p>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="mt-10 flex flex-col gap-6">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="new-password" className="ml-1 text-sm font-semibold">
+                  새 비밀번호
+                </label>
+                <input
+                  id="new-password"
+                  {...register('newPassword')}
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="8자 이상 입력해주세요"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.newPassword && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.newPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label htmlFor="confirm-password" className="ml-1 text-sm font-semibold">
+                  새 비밀번호 확인
+                </label>
+                <input
+                  id="confirm-password"
+                  {...register('confirmPassword')}
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="비밀번호를 다시 입력해주세요"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.confirmPassword && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.confirmPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <p className="ml-1 text-xs text-muted-foreground">
+                영문, 숫자, 특수문자 포함 8자 이상
+              </p>
+
+              {errorMessage && (
+                <p
+                  role="alert"
+                  className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+                >
+                  {errorMessage}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoading ? '변경 중...' : '비밀번호 변경'}
+              </button>
+            </form>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/pages/PasswordResetRequestPage.tsx
+++ b/src/pages/PasswordResetRequestPage.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate } from 'react-router-dom'
+import AppHeader from '@/components/layout/AppHeader'
+import { requestPasswordReset } from '@/api/auth'
+
+const schema = z.object({
+  email: z.string().email('올바른 이메일 형식을 입력해주세요'),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function PasswordResetRequestPage() {
+  const navigate = useNavigate()
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSent, setIsSent] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  const onSubmit = async (data: FormData) => {
+    if (isLoading) return
+    setIsLoading(true)
+    setErrorMessage(null)
+    try {
+      await requestPasswordReset(data.email)
+      setIsSent(true)
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : '요청에 실패했습니다. 잠시 후 다시 시도해주세요.'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="비밀번호 재설정" showBack />
+
+      <main className="flex flex-1 flex-col px-6 pt-12">
+        {isSent ? (
+          <div className="flex flex-col items-center gap-4 pt-16 text-center">
+            <span className="material-symbols-outlined text-5xl text-primary">mark_email_read</span>
+            <h2 className="text-2xl font-bold text-foreground">메일을 보냈습니다</h2>
+            <p className="text-base leading-relaxed text-muted-foreground">
+              입력하신 이메일로 비밀번호 재설정 링크를
+              <br />
+              보내드렸습니다. 메일함을 확인해주세요.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate('/login')}
+              className="mt-4 rounded-xl bg-primary px-8 py-3 text-base font-bold text-primary-foreground transition-all hover:opacity-95"
+            >
+              로그인으로 돌아가기
+            </button>
+          </div>
+        ) : (
+          <>
+            <h2 className="text-2xl font-bold text-foreground">비밀번호 재설정</h2>
+            <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+              가입 시 사용한 이메일을 입력하시면
+              <br />
+              비밀번호 재설정 링크를 보내드립니다.
+            </p>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="mt-10 flex flex-col gap-6">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="reset-email" className="ml-1 text-sm font-semibold">
+                  이메일
+                </label>
+                <input
+                  id="reset-email"
+                  {...register('email')}
+                  type="email"
+                  autoComplete="email"
+                  placeholder="email@example.com"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.email && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.email.message}
+                  </p>
+                )}
+              </div>
+
+              {errorMessage && (
+                <p
+                  role="alert"
+                  className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+                >
+                  {errorMessage}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoading ? '전송 중...' : '재설정 링크 보내기'}
+              </button>
+            </form>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/pages/PasswordResetRequestPage.tsx
+++ b/src/pages/PasswordResetRequestPage.tsx
@@ -16,7 +16,6 @@ export default function PasswordResetRequestPage() {
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(false)
   const [isSent, setIsSent] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const {
     register,
@@ -29,15 +28,12 @@ export default function PasswordResetRequestPage() {
   const onSubmit = async (data: FormData) => {
     if (isLoading) return
     setIsLoading(true)
-    setErrorMessage(null)
     try {
       await requestPasswordReset(data.email)
-      setIsSent(true)
-    } catch (error) {
-      setErrorMessage(
-        error instanceof Error ? error.message : '요청에 실패했습니다. 잠시 후 다시 시도해주세요.'
-      )
+    } catch {
+      // 이메일 존재 여부 노출 방지: 성공/실패 무관하게 동일한 안내 화면 표시
     } finally {
+      setIsSent(true)
       setIsLoading(false)
     }
   }
@@ -92,15 +88,6 @@ export default function PasswordResetRequestPage() {
                   </p>
                 )}
               </div>
-
-              {errorMessage && (
-                <p
-                  role="alert"
-                  className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
-                >
-                  {errorMessage}
-                </p>
-              )}
 
               <button
                 type="submit"

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -5,9 +5,7 @@ import { z } from 'zod'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { signup, checkEmail } from '@/api/auth'
-
-// 백엔드 SignupRequest의 비밀번호 정규식과 동일하게 유지
-const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/
+import { PASSWORD_REGEX } from '@/constants/validation'
 
 const step1Schema = z
   .object({

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -13,6 +13,8 @@ import MyLibraryPage from '@/pages/MyLibraryPage'
 import BookReviewsListPage from '@/pages/BookReviewsListPage'
 import OnboardingPage from '@/pages/OnboardingPage'
 import AuthCallbackPage from '@/pages/AuthCallbackPage'
+import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
+import PasswordResetPage from '@/pages/PasswordResetPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -39,6 +41,14 @@ export const router = createBrowserRouter([
   {
     path: '/auth/callback/google',
     element: <AuthCallbackPage />,
+  },
+  {
+    path: '/password-reset-request',
+    element: <PasswordResetRequestPage />,
+  },
+  {
+    path: '/password-reset',
+    element: <PasswordResetPage />,
   },
   {
     path: '/search',


### PR DESCRIPTION
- api/auth.ts에 requestPasswordReset, resetPassword 함수 추가
- PasswordResetRequestPage 신규: 이메일 입력 후 재설정 링크 발송
- PasswordResetPage 신규: URL token으로 새 비밀번호 설정 (zod 검증 백엔드 정규식 일치)
- LoginPage '비밀번호를 잊으셨나요?' span을 Link로 변경
- 라우터에 /password-reset-request, /password-reset 경로 등록

- PASSWORD_REGEX 공통 상수 추출 (constants/validation.ts)
- SignupPage, PasswordResetPage에서 공통 상수 import로 교체
- autoComplete 속성 추가 (new-password, email)
- 성공 시 URL에서 token 제거 (window.history.replaceState)
- 필드 검증 에러에 role=alert 추가 (접근성)
- PasswordResetRequestPage 성공 화면에 로그인 돌아가기 버튼 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비밀번호 재설정 흐름 추가(요청 → 링크 기반 재설정 → 완료)
  * 이메일로 비밀번호 재설정 요청 발송 가능
  * 토큰 기반 안전한 비밀번호 변경 지원
  * 강화된 비밀번호 유효성 검사 및 안내 문구 적용
  * 로그인 화면에 비밀번호 재설정으로 이동하는 링크 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->