### PR TITLE
feat: 이메일 인증 플로우 구현 (#57)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -149,6 +149,34 @@ export async function getGoogleLoginUrl(): Promise<OAuthLoginUrlResponse> {
   }
 }
 
+export interface EmailVerifyResponse {
+  email: string
+  emailVerified: boolean
+}
+
+export async function verifyEmail(email: string, code: string): Promise<EmailVerifyResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<EmailVerifyResponse>>(
+      '/api/v1/auth/email/verify',
+      { email, code }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '이메일 인증 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '이메일 인증에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function resendEmailCode(email: string): Promise<void> {
+  try {
+    await apiClient.post('/api/v1/auth/email/resend', { email })
+  } catch (error) {
+    throw normalizeAxiosError(error, '인증 코드 재발송에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 export async function requestPasswordReset(email: string): Promise<void> {
   try {
     await apiClient.post('/api/v1/auth/password/reset-request', { email })

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -1,0 +1,190 @@
+import { useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { verifyEmail, resendEmailCode } from '@/api/auth'
+import { useAuthStore } from '@/store/authStore'
+
+export default function EmailVerificationPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const email = (location.state as { email?: string })?.email ?? useAuthStore.getState().user?.email
+
+  const [code, setCode] = useState(['', '', '', '', '', ''])
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [isResending, setIsResending] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [resendMessage, setResendMessage] = useState<string | null>(null)
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([])
+
+  if (!email) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6">
+        <span className="material-symbols-outlined text-5xl text-destructive">error</span>
+        <p className="mt-4 text-center text-lg font-medium text-foreground">
+          이메일 정보를 찾을 수 없습니다.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/login')}
+          className="mt-6 rounded-xl bg-primary px-8 py-3 text-base font-bold text-primary-foreground transition-all hover:opacity-95"
+        >
+          로그인으로 돌아가기
+        </button>
+      </div>
+    )
+  }
+
+  const handleChange = (index: number, value: string) => {
+    if (!/^\d*$/.test(value)) return
+    const digit = value.slice(-1)
+    const newCode = [...code]
+    newCode[index] = digit
+    setCode(newCode)
+    setErrorMessage(null)
+
+    if (digit && index < 5) {
+      inputRefs.current[index + 1]?.focus()
+    }
+  }
+
+  const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && !code[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus()
+    }
+  }
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6)
+    if (!pasted) return
+    const newCode = [...code]
+    for (let i = 0; i < 6; i++) {
+      newCode[i] = pasted[i] ?? ''
+    }
+    setCode(newCode)
+    const focusIndex = Math.min(pasted.length, 5)
+    inputRefs.current[focusIndex]?.focus()
+  }
+
+  const handleVerify = async () => {
+    const fullCode = code.join('')
+    if (fullCode.length !== 6) {
+      setErrorMessage('6자리 코드를 모두 입력해주세요.')
+      return
+    }
+    if (isVerifying) return
+    setIsVerifying(true)
+    setErrorMessage(null)
+    try {
+      const result = await verifyEmail(email, fullCode)
+      if (result.emailVerified) {
+        const currentUser = useAuthStore.getState().user
+        if (currentUser) {
+          const token = useAuthStore.getState().accessToken
+          if (token) {
+            useAuthStore.getState().setAuth({ ...currentUser, emailVerified: true }, token)
+          }
+        }
+        setCode(['', '', '', '', '', ''])
+        navigate('/', { replace: true })
+      } else {
+        setErrorMessage('인증 코드가 올바르지 않습니다. 다시 확인해주세요.')
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '인증에 실패했습니다.')
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
+  const handleResend = async () => {
+    if (isResending) return
+    setIsResending(true)
+    setResendMessage(null)
+    setErrorMessage(null)
+    try {
+      await resendEmailCode(email)
+      setResendMessage('인증 코드가 재발송되었습니다.')
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : '재발송에 실패했습니다. 잠시 후 다시 시도해주세요.'
+      )
+    } finally {
+      setIsResending(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="flex items-center justify-center border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md">
+        <h1 className="text-xl font-bold tracking-tight text-primary">BookLog</h1>
+      </header>
+
+      <main className="flex flex-1 flex-col items-center px-6 pt-16">
+        <span className="material-symbols-outlined text-6xl text-primary">mail</span>
+
+        <h2 className="mt-6 text-2xl font-bold text-foreground">인증 메일을 보냈어요</h2>
+
+        <p className="mt-3 text-center text-base leading-relaxed text-muted-foreground">
+          <span className="font-medium text-primary">{email}</span>으로 인증 코드를 보냈습니다.
+        </p>
+        <p className="mt-1 text-center text-sm text-muted-foreground">
+          아래에 6자리 코드를 입력해주세요.
+        </p>
+
+        <div className="mt-8 flex gap-3">
+          {code.map((digit, index) => (
+            <input
+              key={index}
+              ref={el => {
+                inputRefs.current[index] = el
+              }}
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={1}
+              value={digit}
+              onChange={e => handleChange(index, e.target.value)}
+              onKeyDown={e => handleKeyDown(index, e)}
+              onPaste={index === 0 ? handlePaste : undefined}
+              className="h-14 w-11 rounded-xl border border-primary/20 bg-card text-center text-xl font-bold shadow-sm outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20"
+              aria-label={`인증 코드 ${index + 1}번째 자리`}
+            />
+          ))}
+        </div>
+
+        {errorMessage && (
+          <p role="alert" className="mt-4 text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        {resendMessage && (
+          <p role="status" className="mt-4 text-sm text-primary">
+            {resendMessage}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={handleVerify}
+          disabled={isVerifying}
+          className="mt-8 w-full max-w-xs rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isVerifying ? '인증 중...' : '인증하기'}
+        </button>
+
+        <p className="mt-6 text-sm text-muted-foreground">
+          메일이 오지 않았나요?{' '}
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={isResending}
+            className="font-medium text-primary hover:underline disabled:opacity-60"
+          >
+            {isResending ? '발송 중...' : '재발송'}
+          </button>
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -6,7 +6,8 @@ import { useAuthStore } from '@/store/authStore'
 export default function EmailVerificationPage() {
   const navigate = useNavigate()
   const location = useLocation()
-  const email = (location.state as { email?: string })?.email ?? useAuthStore.getState().user?.email
+  const userEmail = useAuthStore(state => state.user?.email)
+  const email = (location.state as { email?: string } | null)?.email ?? userEmail
 
   const [code, setCode] = useState(['', '', '', '', '', ''])
   const [isVerifying, setIsVerifying] = useState(false)

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
-import { logout } from '@/api/auth'
+import { logout, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
 
 export default function SettingsPage() {
   const navigate = useNavigate()
   const clearAuth = useAuthStore(state => state.clearAuth)
+  const user = useAuthStore(state => state.user)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   const handleLogout = async () => {
@@ -16,10 +17,33 @@ export default function SettingsPage() {
     try {
       await logout()
     } catch (error) {
+      // TODO: [코드 리뷰 LOW] 프로덕션에서 console.error 잔류 이슈
+      // 공용 토스트/알림 시스템 도입 후 console.error 대신 사용자 피드백으로 교체하거나,
+      // 로그아웃은 실패해도 UX상 무조건 성공으로 처리하므로 로깅 자체를 제거할 것
       console.error('로그아웃 API 호출 실패:', error)
     } finally {
       clearAuth()
       navigate('/login', { replace: true })
+    }
+  }
+
+  const [isSendingVerification, setIsSendingVerification] = useState(false)
+
+  const [verificationError, setVerificationError] = useState<string | null>(null)
+
+  const handleVerifyEmail = async () => {
+    if (isSendingVerification || !user?.email) return
+    setIsSendingVerification(true)
+    setVerificationError(null)
+    try {
+      await resendEmailCode(user.email)
+      navigate('/verify-email', { state: { email: user.email } })
+    } catch (error) {
+      setVerificationError(
+        error instanceof Error ? error.message : '인증 코드 발송에 실패했습니다.'
+      )
+    } finally {
+      setIsSendingVerification(false)
     }
   }
 
@@ -99,6 +123,37 @@ export default function SettingsPage() {
       <AppHeader title="설정" showBack />
 
       <main className="flex-1 overflow-y-auto pb-24">
+        {/* Email Verification Banner */}
+        {user && !user.emailVerified && (
+          <section className="px-5 pt-6">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between rounded-2xl bg-amber-50 px-5 py-4">
+                <div className="flex items-center gap-3">
+                  <span className="material-symbols-outlined text-[20px] text-amber-600">
+                    warning
+                  </span>
+                  <span className="text-sm font-medium text-foreground">
+                    이메일 인증이 완료되지 않았습니다.
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleVerifyEmail}
+                  disabled={isSendingVerification}
+                  className="text-sm font-semibold text-primary hover:underline disabled:opacity-60"
+                >
+                  {isSendingVerification ? '발송 중...' : '인증하기'}
+                </button>
+              </div>
+              {verificationError && (
+                <p role="alert" className="px-2 text-xs text-destructive">
+                  {verificationError}
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+
         {/* Notification Settings */}
         <section className="px-5 pt-6">
           <h2 className="mb-3 text-lg font-bold text-primary/80">알림 설정</h2>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -124,7 +124,7 @@ export default function SettingsPage() {
 
       <main className="flex-1 overflow-y-auto pb-24">
         {/* Email Verification Banner */}
-        {user && !user.emailVerified && (
+        {user?.email && !user.emailVerified && (
           <section className="px-5 pt-6">
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between rounded-2xl bg-amber-50 px-5 py-4">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -86,7 +86,7 @@ export default function SignupPage() {
         },
         result.accessToken
       )
-      navigate('/')
+      navigate('/verify-email', { state: { email } })
     } catch (error) {
       setStep2ErrorMessage(error instanceof Error ? error.message : '회원가입에 실패했습니다.')
     } finally {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -15,6 +15,7 @@ import OnboardingPage from '@/pages/OnboardingPage'
 import AuthCallbackPage from '@/pages/AuthCallbackPage'
 import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
 import PasswordResetPage from '@/pages/PasswordResetPage'
+import EmailVerificationPage from '@/pages/EmailVerificationPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -49,6 +50,10 @@ export const router = createBrowserRouter([
   {
     path: '/password-reset',
     element: <PasswordResetPage />,
+  },
+  {
+    path: '/verify-email',
+    element: <EmailVerificationPage />,
   },
   {
     path: '/search',


### PR DESCRIPTION
- api/auth.ts에 verifyEmail, resendEmailCode 함수 추가

- EmailVerificationPage 신규: 6자리 OTP 코드 입력 UI + 인증/재발송

- SignupPage 회원가입 성공 후 /verify-email로 이동 (email state 전달)

- SettingsPage emailVerified 미인증 시 경고 배너 + 인증하기 버튼

- 라우터에 /verify-email 경로 등록

- SignupPage: step1Data ReferenceError 수정 → email 변수 활용

- EmailVerificationPage: emailVerified=false 시 에러 메시지 표시

- EmailVerificationPage: 인증 성공 후 OTP code 초기화, autoComplete 추가

- SettingsPage: 재발송 실패 시 현재 페이지 유지 + 에러 표시

- SettingsPage: emailVerified === false → !emailVerified로 변경 (undefined 대응)"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 6자리 숫자 코드 기반 이메일 인증 페이지 추가(입력 자동포커스·붙여넣기 지원, 오류/성공 메시지 표시)
  * 설정 페이지에 이메일 인증 배너 및 인증 요청 버튼 추가(재전송 가능, 상태 표시)
  * 인증 코드 재발송 기능 추가
  * 회원가입 완료 후 이메일 인증 페이지로 자동 이동 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->