### PR TITLE
feat: 닉네임 중복 확인 연동 (#60)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -43,7 +43,7 @@ export interface SignupResponse {
   user: SignupUserInfo
 }
 
-export interface CheckEmailResponse {
+export interface CheckAvailabilityResponse {
   available: boolean
 }
 
@@ -117,9 +117,24 @@ export async function signup(request: SignupRequest): Promise<SignupResponse> {
   }
 }
 
-export async function checkEmail(email: string): Promise<CheckEmailResponse> {
+export async function checkNickname(nickname: string): Promise<CheckAvailabilityResponse> {
   try {
-    const { data } = await apiClient.get<ApiResponse<CheckEmailResponse>>(
+    const { data } = await apiClient.get<ApiResponse<CheckAvailabilityResponse>>(
+      '/api/v1/auth/check-nickname',
+      { params: { nickname } }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '닉네임 확인 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '닉네임 확인에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function checkEmail(email: string): Promise<CheckAvailabilityResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<CheckAvailabilityResponse>>(
       '/api/v1/auth/check-email',
       { params: { email } }
     )

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -103,7 +103,14 @@ export default function SignupPage() {
   }
 
   const onStep2Submit = async (data: Step2Form) => {
-    if (nicknameStatus === 'taken' || nicknameStatus === 'checking') return
+    if (nicknameStatus === 'taken') {
+      setStep2ErrorMessage('이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.')
+      return
+    }
+    if (nicknameStatus === 'checking') {
+      setStep2ErrorMessage('닉네임 중복 확인 중입니다. 잠시 후 다시 시도해주세요.')
+      return
+    }
     setIsStep2Loading(true)
     setStep2ErrorMessage(null)
     try {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -77,6 +77,7 @@ export default function SignupPage() {
 
   const watchedNickname = step2Form.watch('nickname')
   useEffect(() => {
+    setStep2ErrorMessage(null)
     debouncedCheckNickname(watchedNickname ?? '')
     return () => {
       if (nicknameTimerRef.current) clearTimeout(nicknameTimerRef.current)

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
-import { signup, checkEmail } from '@/api/auth'
+import { signup, checkEmail, checkNickname } from '@/api/auth'
 import { PASSWORD_REGEX } from '@/constants/validation'
 
 const step1Schema = z
@@ -34,6 +34,10 @@ export default function SignupPage() {
   const [isStep1Loading, setIsStep1Loading] = useState(false)
   const [isStep2Loading, setIsStep2Loading] = useState(false)
   const [step2ErrorMessage, setStep2ErrorMessage] = useState<string | null>(null)
+  const [nicknameStatus, setNicknameStatus] = useState<'idle' | 'checking' | 'available' | 'taken'>(
+    'idle'
+  )
+  const nicknameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const navigate = useNavigate()
   const setAuth = useAuthStore(state => state.setAuth)
 
@@ -44,6 +48,37 @@ export default function SignupPage() {
   const step2Form = useForm<Step2Form>({
     resolver: zodResolver(step2Schema),
   })
+
+  const debouncedCheckNickname = useCallback(
+    (nickname: string) => {
+      if (nicknameTimerRef.current) clearTimeout(nicknameTimerRef.current)
+      if (nickname.length < 2) {
+        setNicknameStatus('idle')
+        return
+      }
+      setNicknameStatus('checking')
+      nicknameTimerRef.current = setTimeout(async () => {
+        try {
+          const result = await checkNickname(nickname)
+          const current = step2Form.getValues('nickname')
+          if (current === nickname) {
+            setNicknameStatus(result.available ? 'available' : 'taken')
+          }
+        } catch {
+          setNicknameStatus('idle')
+        }
+      }, 400)
+    },
+    [step2Form]
+  )
+
+  const watchedNickname = step2Form.watch('nickname')
+  useEffect(() => {
+    debouncedCheckNickname(watchedNickname ?? '')
+    return () => {
+      if (nicknameTimerRef.current) clearTimeout(nicknameTimerRef.current)
+    }
+  }, [watchedNickname, debouncedCheckNickname])
 
   const onStep1Submit = async () => {
     setIsStep1Loading(true)
@@ -65,6 +100,7 @@ export default function SignupPage() {
   }
 
   const onStep2Submit = async (data: Step2Form) => {
+    if (nicknameStatus === 'taken' || nicknameStatus === 'checking') return
     setIsStep2Loading(true)
     setStep2ErrorMessage(null)
     try {
@@ -247,12 +283,16 @@ export default function SignupPage() {
           >
             <div className="space-y-6 px-6">
               <div className="flex flex-col gap-2">
-                <label className="ml-1 text-base font-semibold">닉네임</label>
+                <label htmlFor="signup-nickname" className="ml-1 text-base font-semibold">
+                  닉네임
+                </label>
                 <input
+                  id="signup-nickname"
                   {...step2Form.register('nickname')}
                   type="text"
                   autoComplete="one-time-code" // Chrome이 autoComplete="off"를 무시하므로 인식 불가한 값 사용
                   placeholder="사용할 닉네임을 입력하세요"
+                  aria-describedby="nickname-status"
                   className="h-14 w-full rounded-xl border border-primary/20 bg-card px-4 text-base outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
                 />
                 {step2Form.formState.errors.nickname && (
@@ -260,6 +300,17 @@ export default function SignupPage() {
                     {step2Form.formState.errors.nickname.message}
                   </p>
                 )}
+                <div id="nickname-status" aria-live="polite">
+                  {!step2Form.formState.errors.nickname && nicknameStatus === 'checking' && (
+                    <p className="ml-1 text-xs text-muted-foreground">확인 중...</p>
+                  )}
+                  {!step2Form.formState.errors.nickname && nicknameStatus === 'available' && (
+                    <p className="ml-1 text-xs text-green-600">사용 가능한 닉네임입니다</p>
+                  )}
+                  {!step2Form.formState.errors.nickname && nicknameStatus === 'taken' && (
+                    <p className="ml-1 text-xs text-destructive">이미 사용 중인 닉네임입니다</p>
+                  )}
+                </div>
               </div>
 
               <div className="flex flex-col gap-2">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -65,7 +65,10 @@ export default function SignupPage() {
             setNicknameStatus(result.available ? 'available' : 'taken')
           }
         } catch {
-          setNicknameStatus('idle')
+          const current = step2Form.getValues('nickname')
+          if (current === nickname) {
+            setNicknameStatus('idle')
+          }
         }
       }, 400)
     },


### PR DESCRIPTION
- api/auth.ts에 checkNickname 함수 추가 (GET /api/v1/auth/check-nickname)

- CheckEmailResponse → CheckAvailabilityResponse로 일반화

- SignupPage step2에 debounce(400ms) 실시간 닉네임 중복 체크

- 상태별 피드백: 확인 중/사용 가능/이미 사용 중

- race condition 방지: 응답 시 현재 닉네임과 비교 가드

- 닉네임 중복 또는 확인 중이면 가입 제출 차단

- 접근성: label-input 연결, aria-live 피드백

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경사항

* **새 기능**
  * 회원가입에서 닉네임 가용성 실시간 확인이 추가되었습니다.
  * 닉네임이 사용 중이거나 검사 중이면 다음 단계 진행이 차단됩니다.

* **개선사항**
  * 닉네임 입력 UI에 상태 메시지(확인 중…, 사용 가능, 이미 사용 중)가 추가되었습니다.
  * 라벨·라이브 리전 등 접근성이 개선되어 스크린 리더 지원이 강화되었습니다.

* **개선사항**
  * 가용성 검사 관련 API 응답 형식이 통일되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->