### PR TITLE
Feat/#62 book search api

### DIFF
--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -1,0 +1,24 @@
+import axios from 'axios'
+
+export interface ApiResponse<T> {
+  status: 'SUCCESS' | 'ERROR'
+  code: number
+  message?: string
+  data?: T
+  errors?: Array<{ field: string; message: string }>
+}
+
+export function normalizeAxiosError(error: unknown, fallback: string): Error {
+  if (axios.isAxiosError(error)) {
+    const apiMessage = error.response?.data?.message
+    if (apiMessage) return new Error(apiMessage)
+    if (error.code === 'ECONNABORTED') {
+      return new Error('요청 시간이 초과되었습니다. 다시 시도해주세요.')
+    }
+    if (!error.response) {
+      return new Error('서버에 연결할 수 없습니다. 백엔드 서버 상태를 확인해주세요.')
+    }
+    return new Error(fallback)
+  }
+  return error instanceof Error ? error : new Error(fallback)
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,5 @@
-import axios from 'axios'
 import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
 
 export interface LoginRequest {
   email: string
@@ -65,29 +65,6 @@ export interface GoogleLoginResponse {
   accessTokenExpiresIn: number
   isNewUser: boolean
   user: GoogleLoginUserInfo
-}
-
-interface ApiResponse<T> {
-  status: 'SUCCESS' | 'ERROR'
-  code: number
-  message?: string
-  data?: T
-  errors?: Array<{ field: string; message: string }>
-}
-
-function normalizeAxiosError(error: unknown, fallback: string): Error {
-  if (axios.isAxiosError(error)) {
-    const apiMessage = error.response?.data?.message
-    if (apiMessage) return new Error(apiMessage)
-    if (error.code === 'ECONNABORTED') {
-      return new Error('요청 시간이 초과되었습니다. 다시 시도해주세요.')
-    }
-    if (!error.response) {
-      return new Error('서버에 연결할 수 없습니다. 백엔드 서버 상태를 확인해주세요.')
-    }
-    return new Error(fallback)
-  }
-  return error instanceof Error ? error : new Error(fallback)
 }
 
 export async function login(request: LoginRequest): Promise<LoginResponse> {

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,5 +1,5 @@
-import axios from 'axios'
 import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
 
 export interface BookSummary {
   bookId: number
@@ -19,33 +19,11 @@ export interface BookSearchListResponse {
   size: number
 }
 
-interface ApiResponse<T> {
-  status: 'SUCCESS' | 'ERROR'
-  code: number
-  message?: string
-  data?: T
-  errors?: Array<{ field: string; message: string }>
-}
-
-function normalizeAxiosError(error: unknown, fallback: string): Error {
-  if (axios.isAxiosError(error)) {
-    const apiMessage = error.response?.data?.message
-    if (apiMessage) return new Error(apiMessage)
-    if (error.code === 'ECONNABORTED') {
-      return new Error('요청 시간이 초과되었습니다. 다시 시도해주세요.')
-    }
-    if (!error.response) {
-      return new Error('서버에 연결할 수 없습니다. 백엔드 서버 상태를 확인해주세요.')
-    }
-    return new Error(fallback)
-  }
-  return error instanceof Error ? error : new Error(fallback)
-}
-
 export async function searchBooks(
   query: string,
   limit = 20,
-  cursor?: number | null
+  cursor?: number | null,
+  signal?: AbortSignal
 ): Promise<BookSearchListResponse> {
   try {
     const { data } = await apiClient.get<ApiResponse<BookSearchListResponse>>(
@@ -56,6 +34,7 @@ export async function searchBooks(
           limit,
           ...(cursor != null ? { cursor } : {}),
         },
+        signal,
       }
     )
     if (!data.data) {

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,0 +1,68 @@
+import axios from 'axios'
+import apiClient from './client'
+
+export interface BookSummary {
+  bookId: number
+  isbn13: string
+  title: string
+  author: string
+  publisher: string
+  coverImageUrl: string | null
+  publishedDate: string | null
+  inMyLibrary: boolean
+}
+
+export interface BookSearchListResponse {
+  content: BookSummary[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+interface ApiResponse<T> {
+  status: 'SUCCESS' | 'ERROR'
+  code: number
+  message?: string
+  data?: T
+  errors?: Array<{ field: string; message: string }>
+}
+
+function normalizeAxiosError(error: unknown, fallback: string): Error {
+  if (axios.isAxiosError(error)) {
+    const apiMessage = error.response?.data?.message
+    if (apiMessage) return new Error(apiMessage)
+    if (error.code === 'ECONNABORTED') {
+      return new Error('요청 시간이 초과되었습니다. 다시 시도해주세요.')
+    }
+    if (!error.response) {
+      return new Error('서버에 연결할 수 없습니다. 백엔드 서버 상태를 확인해주세요.')
+    }
+    return new Error(fallback)
+  }
+  return error instanceof Error ? error : new Error(fallback)
+}
+
+export async function searchBooks(
+  query: string,
+  limit = 20,
+  cursor?: number | null
+): Promise<BookSearchListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<BookSearchListResponse>>(
+      '/api/v1/books/search',
+      {
+        params: {
+          query,
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+      }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '도서 검색 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -16,7 +16,7 @@ const statusEmoji: Record<ReadingStatus, string> = {
 }
 
 export default function BookDetailPage() {
-  const { id } = useParams()
+  const { bookId: id } = useParams()
   const navigate = useNavigate()
   const scrollRef = useDragScroll<HTMLDivElement>()
   const [sheetOpen, setSheetOpen] = useState(false)

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -13,7 +13,7 @@ const sortOptions = [
 ]
 
 export default function BookReviewsListPage() {
-  const { id } = useParams()
+  const { bookId: id } = useParams()
   const navigate = useNavigate()
   const [activeSort, setActiveSort] = useState('latest')
   const [revealedSpoilers, setRevealedSpoilers] = useState<Set<number>>(new Set())

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -1,19 +1,136 @@
-import { useState } from 'react'
-import { mockSearchResults } from '@/mocks/data'
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
-import BookListItem from '@/components/common/BookListItem'
+import { searchBooks, type BookSummary } from '@/api/book'
+
+const RECENT_KEYWORDS_KEY = 'booklog-recent-keywords'
+const MAX_RECENT_KEYWORDS = 10
+
+function loadRecentKeywords(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEYWORDS_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function saveRecentKeywords(keywords: string[]) {
+  try {
+    localStorage.setItem(RECENT_KEYWORDS_KEY, JSON.stringify(keywords))
+  } catch {
+    // localStorage 쓰기 실패 시 무시 (용량 초과, private 모드 등)
+  }
+}
 
 export default function BookSearchPage() {
-  const [recentKeywords, setRecentKeywords] = useState(['데미안', '헤르만 헤세', '자기계발'])
+  const [recentKeywords, setRecentKeywords] = useState<string[]>(() => loadRecentKeywords())
   const [searchQuery, setSearchQuery] = useState('')
+  const [results, setResults] = useState<BookSummary[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const trimmedQuery = searchQuery.trim()
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  // 검색어 변경 시 debounce 적용하여 API 호출
+  useEffect(() => {
+    if (!trimmedQuery) {
+      setResults([])
+      setNextCursor(null)
+      setHasNext(false)
+      setErrorMessage(null)
+      return
+    }
+
+    setIsLoading(true)
+    setErrorMessage(null)
+    const handle = setTimeout(async () => {
+      try {
+        const response = await searchBooks(trimmedQuery)
+        setResults(response.content)
+        setNextCursor(response.nextCursor)
+        setHasNext(response.hasNext)
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
+        setResults([])
+        setNextCursor(null)
+        setHasNext(false)
+      } finally {
+        setIsLoading(false)
+      }
+    }, 400)
+
+    return () => clearTimeout(handle)
+  }, [trimmedQuery])
+
+  // 무한 스크롤 — IntersectionObserver로 하단 sentinel 감지
+  useEffect(() => {
+    if (!hasNext || !loadMoreRef.current) return
+    const sentinel = loadMoreRef.current
+
+    const observer = new IntersectionObserver(
+      async entries => {
+        const [entry] = entries
+        if (!entry.isIntersecting || isLoadingMore || isLoading || !hasNext) return
+
+        setIsLoadingMore(true)
+        try {
+          const response = await searchBooks(trimmedQuery, 20, nextCursor)
+          setResults(prev => [...prev, ...response.content])
+          setNextCursor(response.nextCursor)
+          setHasNext(response.hasNext)
+        } catch (error) {
+          setErrorMessage(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+        } finally {
+          setIsLoadingMore(false)
+        }
+      },
+      { rootMargin: '200px' }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.unobserve(sentinel)
+  }, [hasNext, isLoadingMore, isLoading, nextCursor, trimmedQuery])
+
+  const commitKeyword = (keyword: string) => {
+    const value = keyword.trim()
+    if (!value) return
+    setRecentKeywords(prev => {
+      const next = [value, ...prev.filter(k => k !== value)].slice(0, MAX_RECENT_KEYWORDS)
+      saveRecentKeywords(next)
+      return next
+    })
+  }
 
   const removeKeyword = (keyword: string) => {
-    setRecentKeywords(prev => prev.filter(k => k !== keyword))
+    setRecentKeywords(prev => {
+      const next = prev.filter(k => k !== keyword)
+      saveRecentKeywords(next)
+      return next
+    })
   }
 
   const clearAllKeywords = () => {
     setRecentKeywords([])
+    saveRecentKeywords([])
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && trimmedQuery) {
+      commitKeyword(trimmedQuery)
+    }
+  }
+
+  const handleKeywordClick = (keyword: string) => {
+    setSearchQuery(keyword)
+    commitKeyword(keyword)
   }
 
   return (
@@ -30,6 +147,7 @@ export default function BookSearchPage() {
             type="text"
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="도서 제목, 저자, ISBN 검색"
             className="h-full min-w-0 flex-1 border-none bg-transparent px-3 text-base font-normal outline-none placeholder:text-primary/40 focus:ring-0"
           />
@@ -39,14 +157,15 @@ export default function BookSearchPage() {
         </div>
       </div>
 
-      {/* Recent Keywords */}
-      {recentKeywords.length > 0 && (
+      {/* Recent Keywords — 검색어가 비어있을 때만 표시 */}
+      {!trimmedQuery && recentKeywords.length > 0 && (
         <div className="border-b border-border px-4 py-4">
           <div className="mb-2 flex items-center justify-between">
             <h4 className="text-xs font-bold uppercase tracking-wider text-primary/70">
               최근 검색어
             </h4>
             <button
+              type="button"
               onClick={clearAllKeywords}
               className="text-xs text-primary/40 hover:text-primary"
             >
@@ -59,8 +178,14 @@ export default function BookSearchPage() {
                 key={keyword}
                 className="flex h-8 shrink-0 items-center justify-center gap-x-1 rounded-full border border-primary/5 bg-primary/10 px-3"
               >
-                <p className="text-sm font-medium leading-normal text-primary">{keyword}</p>
-                <button onClick={() => removeKeyword(keyword)}>
+                <button
+                  type="button"
+                  onClick={() => handleKeywordClick(keyword)}
+                  className="text-sm font-medium leading-normal text-primary"
+                >
+                  {keyword}
+                </button>
+                <button type="button" onClick={() => removeKeyword(keyword)}>
                   <span className="material-symbols-outlined cursor-pointer text-[16px] text-primary/60">
                     close
                   </span>
@@ -73,18 +198,80 @@ export default function BookSearchPage() {
 
       {/* Search Results */}
       <main className="flex-1 overflow-y-auto px-4 pb-24">
-        <div className="flex flex-col">
-          {mockSearchResults
-            .filter(
-              book =>
-                searchQuery === '' ||
-                book.title.includes(searchQuery) ||
-                book.author.includes(searchQuery)
-            )
-            .map(book => (
-              <BookListItem key={book.isbn} book={book} />
+        {trimmedQuery && isLoading && results.length === 0 && (
+          <p className="py-10 text-center text-sm text-muted-foreground">검색 중...</p>
+        )}
+
+        {trimmedQuery && !isLoading && errorMessage && (
+          <p role="alert" className="py-10 text-center text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        {trimmedQuery && !isLoading && !errorMessage && results.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16 text-center">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              search_off
+            </span>
+            <p className="text-sm text-muted-foreground">
+              '{trimmedQuery}'에 대한 검색 결과가 없습니다.
+            </p>
+          </div>
+        )}
+
+        {results.length > 0 && (
+          <div className="flex flex-col">
+            {results.map(book => (
+              <Link
+                key={book.bookId}
+                to={`/book/${book.bookId}`}
+                onClick={() => commitKeyword(trimmedQuery)}
+                className="flex items-start gap-4 border-b border-primary/5 py-5"
+              >
+                <div className="h-36 w-24 shrink-0 overflow-hidden rounded-lg bg-primary/5 shadow-sm">
+                  {book.coverImageUrl ? (
+                    <img
+                      src={book.coverImageUrl}
+                      alt={book.title}
+                      className="size-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex size-full items-center justify-center">
+                      <span className="material-symbols-outlined text-2xl text-muted-foreground/40">
+                        menu_book
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <h3 className="line-clamp-2 text-lg font-bold leading-tight text-primary">
+                    {book.title}
+                  </h3>
+                  <p className="truncate text-sm text-muted-foreground">{book.author} 저</p>
+                  <p className="truncate text-xs text-muted-foreground/70">{book.publisher}</p>
+                  {book.inMyLibrary && (
+                    <span className="mt-1 w-fit rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                      내 서재에 있음
+                    </span>
+                  )}
+                </div>
+              </Link>
             ))}
-        </div>
+
+            {/* 무한 스크롤 sentinel */}
+            <div ref={loadMoreRef} className="h-10" />
+
+            {isLoadingMore && (
+              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+            )}
+
+            {!hasNext && !isLoadingMore && (
+              <p className="py-4 text-center text-xs text-muted-foreground/50">
+                모든 결과를 확인했습니다
+              </p>
+            )}
+          </div>
+        )}
       </main>
 
       <BottomNav />

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -42,6 +42,7 @@ export default function BookSearchPage() {
 
   const trimmedQuery = searchQuery.trim()
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
 
   // observer 콜백에서 최신 state를 읽기 위한 ref (deps 폭주 방지)
   const stateRef = useRef({
@@ -63,19 +64,22 @@ export default function BookSearchPage() {
 
   // 검색어 debounce + AbortController로 stale 응답 방지
   useEffect(() => {
+    // 검색어가 바뀌면 in-flight 상태를 전부 초기화 (MEDIUM 1: 깜빡임 방지)
+    setIsLoadingMore(false)
+    setLoadMoreError(null)
+    moreControllerRef.current?.abort()
+
     if (!trimmedQuery) {
       setResults([])
       setNextCursor(null)
       setHasNext(false)
       setErrorMessage(null)
-      setLoadMoreError(null)
       return
     }
 
     const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
-    setLoadMoreError(null)
 
     const handle = setTimeout(async () => {
       try {
@@ -98,6 +102,7 @@ export default function BookSearchPage() {
     return () => {
       clearTimeout(handle)
       controller.abort()
+      moreControllerRef.current?.abort()
     }
   }, [trimmedQuery])
 
@@ -107,24 +112,33 @@ export default function BookSearchPage() {
     if (s.isLoadingMore || s.isLoading || !s.hasNext) return
     const requestedQuery = s.trimmedQuery
     const requestedCursor = s.nextCursor
+
+    // 이전 pagination 요청 취소 후 새 controller 생성
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
     setIsLoadingMore(true)
     setLoadMoreError(null)
     try {
-      const response = await searchBooks(requestedQuery, 20, requestedCursor)
+      const response = await searchBooks(requestedQuery, 20, requestedCursor, controller.signal)
+      if (controller.signal.aborted) return
       // stale guard: 검색어가 바뀐 경우 결과 버림
       if (stateRef.current.trimmedQuery !== requestedQuery) return
       setResults(prev => [...prev, ...response.content])
       setNextCursor(response.nextCursor)
       setHasNext(response.hasNext)
     } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
       if (stateRef.current.trimmedQuery !== requestedQuery) return
       setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
     } finally {
-      setIsLoadingMore(false)
+      if (!controller.signal.aborted) setIsLoadingMore(false)
     }
   }, [])
 
-  // IntersectionObserver는 단 한 번만 생성, 최신값은 ref로 읽기
+  // IntersectionObserver — sentinel이 조건부 렌더되므로 hasResults 변화 시 재생성
+  const hasResults = results.length > 0
   useEffect(() => {
     const sentinel = loadMoreRef.current
     if (!sentinel) return
@@ -140,7 +154,7 @@ export default function BookSearchPage() {
 
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [fetchMore])
+  }, [fetchMore, hasResults])
 
   const retryLoadMore = () => {
     setLoadMoreError(null)

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import { searchBooks, type BookSummary } from '@/api/book'
@@ -12,7 +13,9 @@ function loadRecentKeywords(): string[] {
     const raw = localStorage.getItem(RECENT_KEYWORDS_KEY)
     if (!raw) return []
     const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : []
+    return Array.isArray(parsed)
+      ? parsed.filter((k): k is string => typeof k === 'string').slice(0, MAX_RECENT_KEYWORDS)
+      : []
   } catch {
     return []
   }
@@ -22,7 +25,7 @@ function saveRecentKeywords(keywords: string[]) {
   try {
     localStorage.setItem(RECENT_KEYWORDS_KEY, JSON.stringify(keywords))
   } catch {
-    // localStorage 쓰기 실패 시 무시 (용량 초과, private 모드 등)
+    // localStorage 쓰기 실패 시 무시 (private 모드, 용량 초과 등)
   }
 }
 
@@ -35,74 +38,120 @@ export default function BookSearchPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
 
   const trimmedQuery = searchQuery.trim()
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
-  // 검색어 변경 시 debounce 적용하여 API 호출
+  // observer 콜백에서 최신 state를 읽기 위한 ref (deps 폭주 방지)
+  const stateRef = useRef({
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    trimmedQuery,
+    loadMoreError,
+  })
+  stateRef.current = {
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    trimmedQuery,
+    loadMoreError,
+  }
+
+  // 검색어 debounce + AbortController로 stale 응답 방지
   useEffect(() => {
     if (!trimmedQuery) {
       setResults([])
       setNextCursor(null)
       setHasNext(false)
       setErrorMessage(null)
+      setLoadMoreError(null)
       return
     }
 
+    const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
+    setLoadMoreError(null)
+
     const handle = setTimeout(async () => {
       try {
-        const response = await searchBooks(trimmedQuery)
+        const response = await searchBooks(trimmedQuery, 20, null, controller.signal)
+        if (controller.signal.aborted) return
         setResults(response.content)
         setNextCursor(response.nextCursor)
         setHasNext(response.hasNext)
       } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
         setErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
         setResults([])
         setNextCursor(null)
         setHasNext(false)
       } finally {
-        setIsLoading(false)
+        if (!controller.signal.aborted) setIsLoading(false)
       }
     }, 400)
 
-    return () => clearTimeout(handle)
+    return () => {
+      clearTimeout(handle)
+      controller.abort()
+    }
   }, [trimmedQuery])
 
-  // 무한 스크롤 — IntersectionObserver로 하단 sentinel 감지
+  // 다음 페이지 로딩 (observer + 수동 retry에서 공유)
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
+    const requestedQuery = s.trimmedQuery
+    const requestedCursor = s.nextCursor
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await searchBooks(requestedQuery, 20, requestedCursor)
+      // stale guard: 검색어가 바뀐 경우 결과 버림
+      if (stateRef.current.trimmedQuery !== requestedQuery) return
+      setResults(prev => [...prev, ...response.content])
+      setNextCursor(response.nextCursor)
+      setHasNext(response.hasNext)
+    } catch (error) {
+      if (stateRef.current.trimmedQuery !== requestedQuery) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [])
+
+  // IntersectionObserver는 단 한 번만 생성, 최신값은 ref로 읽기
   useEffect(() => {
-    if (!hasNext || !loadMoreRef.current) return
     const sentinel = loadMoreRef.current
+    if (!sentinel) return
 
     const observer = new IntersectionObserver(
-      async entries => {
-        const [entry] = entries
-        if (!entry.isIntersecting || isLoadingMore || isLoading || !hasNext) return
-
-        setIsLoadingMore(true)
-        try {
-          const response = await searchBooks(trimmedQuery, 20, nextCursor)
-          setResults(prev => [...prev, ...response.content])
-          setNextCursor(response.nextCursor)
-          setHasNext(response.hasNext)
-        } catch (error) {
-          setErrorMessage(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
-        } finally {
-          setIsLoadingMore(false)
-        }
+      entries => {
+        if (!entries[0].isIntersecting) return
+        if (stateRef.current.loadMoreError) return
+        fetchMore()
       },
       { rootMargin: '200px' }
     )
 
     observer.observe(sentinel)
-    return () => observer.unobserve(sentinel)
-  }, [hasNext, isLoadingMore, isLoading, nextCursor, trimmedQuery])
+    return () => observer.disconnect()
+  }, [fetchMore])
+
+  const retryLoadMore = () => {
+    setLoadMoreError(null)
+    fetchMore()
+  }
 
   const commitKeyword = (keyword: string) => {
     const value = keyword.trim()
     if (!value) return
     setRecentKeywords(prev => {
+      if (prev[0] === value) return prev
       const next = [value, ...prev.filter(k => k !== value)].slice(0, MAX_RECENT_KEYWORDS)
       saveRecentKeywords(next)
       return next
@@ -138,22 +187,32 @@ export default function BookSearchPage() {
       <AppHeader title="BookLog" showBack />
 
       {/* Search Bar */}
-      <div className="border-b border-border px-4 py-3">
+      <div className="border-b border-border px-4 py-3" role="search">
+        <label htmlFor="book-search-input" className="sr-only">
+          도서 검색
+        </label>
         <div className="flex h-12 w-full items-stretch rounded-xl border border-primary/10 bg-primary/5">
           <div className="flex items-center justify-center pl-4 text-primary/60">
             <span className="material-symbols-outlined text-[22px]">search</span>
           </div>
           <input
+            id="book-search-input"
             type="text"
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             onKeyDown={handleKeyDown}
+            aria-label="도서 제목, 저자, ISBN 검색"
             placeholder="도서 제목, 저자, ISBN 검색"
             className="h-full min-w-0 flex-1 border-none bg-transparent px-3 text-base font-normal outline-none placeholder:text-primary/40 focus:ring-0"
           />
-          <div className="flex cursor-pointer items-center justify-center pr-4 text-primary">
+          <button
+            type="button"
+            disabled
+            aria-label="바코드 스캔 (준비 중)"
+            className="flex items-center justify-center pr-4 text-primary/40"
+          >
             <span className="material-symbols-outlined text-[24px]">barcode_scanner</span>
-          </div>
+          </button>
         </div>
       </div>
 
@@ -185,7 +244,11 @@ export default function BookSearchPage() {
                 >
                   {keyword}
                 </button>
-                <button type="button" onClick={() => removeKeyword(keyword)}>
+                <button
+                  type="button"
+                  onClick={() => removeKeyword(keyword)}
+                  aria-label={`'${keyword}' 최근 검색어 삭제`}
+                >
                   <span className="material-symbols-outlined cursor-pointer text-[16px] text-primary/60">
                     close
                   </span>
@@ -213,7 +276,7 @@ export default function BookSearchPage() {
             <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
               search_off
             </span>
-            <p className="text-sm text-muted-foreground">
+            <p className="max-w-full truncate text-sm text-muted-foreground">
               '{trimmedQuery}'에 대한 검색 결과가 없습니다.
             </p>
           </div>
@@ -265,7 +328,22 @@ export default function BookSearchPage() {
               <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
             )}
 
-            {!hasNext && !isLoadingMore && (
+            {loadMoreError && !isLoadingMore && (
+              <div className="flex flex-col items-center gap-2 py-4">
+                <p role="alert" className="text-sm text-destructive">
+                  {loadMoreError}
+                </p>
+                <button
+                  type="button"
+                  onClick={retryLoadMore}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                >
+                  다시 불러오기
+                </button>
+              </div>
+            )}
+
+            {!hasNext && !isLoadingMore && !loadMoreError && (
               <p className="py-4 text-center text-xs text-muted-foreground/50">
                 모든 결과를 확인했습니다
               </p>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -59,7 +59,7 @@ export const router = createBrowserRouter([
     ),
   },
   {
-    path: '/book/:id',
+    path: '/book/:bookId',
     element: (
       <ProtectedRoute>
         <BookDetailPage />
@@ -67,7 +67,7 @@ export const router = createBrowserRouter([
     ),
   },
   {
-    path: '/book/:id/reviews',
+    path: '/book/:bookId/reviews',
     element: (
       <ProtectedRoute>
         <BookReviewsListPage />


### PR DESCRIPTION
## 📌 개요
`BookSearchPage`의 mock 데이터를 제거하고 백엔드 `GET /api/v1/books/search` API와 연동합니다. 실시간 debounce 검색, 커서 기반 무한 스크롤, 최근 검색어 localStorage 영속화, 라우트 식별자를 `bookId` 기반으로 통일했습니다.

Closes #62

## 🔧 주요 변경

### 공통 helper 추출
- `src/api/_helpers.ts` 신설 — `ApiResponse<T>`, `normalizeAxiosError` 공통 추출
- `src/api/auth.ts` 로컬 중복 정의 제거 후 import로 교체

### 도서 검색 API 연동
- `src/api/book.ts` 신규 — `searchBooks(query, limit, cursor, signal)` + `BookSummary`, `BookSearchListResponse` 타입
- `AbortSignal` 지원으로 pagination 요청 취소 가능

### BookSearchPage 재작성
- debounce(400ms) + `AbortController`로 stale 응답 차단
- `IntersectionObserver` 무한 스크롤 (커서 기반)
- `localStorage`에 최근 검색어 영속화 (`booklog-recent-keywords`, 최대 10개)
- 상태 분기: 검색 중 / 에러 / 빈 결과 / 결과 / 더보기 로딩 / 더보기 실패(재시도)
- `inMyLibrary` 뱃지 표시
- 접근성: `role="search"`, `sr-only label`, `aria-label`
- 바코드 스캐너 아이콘을 `<button disabled>`로 변경

### 라우트 파라미터 통일
- `/book/:id` → `/book/:bookId`
- `/book/:id/reviews` → `/book/:bookId/reviews`
- BookDetailPage, BookReviewsListPage에서 `useParams().id` → `useParams().bookId`

## 📎 코드 리뷰 이력
- OMC code-reviewer 1차: **REQUEST CHANGES** → HIGH 2, MEDIUM 3, LOW 5 전부 반영
- OMC code-reviewer 2차: **COMMENT** → MEDIUM 1, LOW 2 추가 반영

## ⚠️ 알려진 한계 (후속 이슈에서 해결)
- `BookListItem` 컴포넌트, `MyLibraryPage`는 여전히 mock의 `isbn` 문자열을 `/book/` 경로에 전달 중. **검색 → 도서 상세 이동 시 `BookDetailPage`가 mock 데이터로 조회하지 못해 "도서를 찾을 수 없습니다" 화면이 나옵니다.** 이는 후속 B2 이슈(도서 상세 API 연동)에서 실제 API 교체 및 식별자 정리와 함께 해결됩니다.
- 바코드 스캐너 아이콘은 UI 유지 + disabled 상태. ISBN 조회 API + 카메라 접근 구현은 별도 이슈로 분리합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 책 검색이 서버 기반 실시간 검색으로 전환되어 더 정확한 결과를 제공합니다
- 검색 결과를 무한 스크롤로 불러올 수 있습니다
- 최근 검색 키워드를 자동으로 저장하고 관리할 수 있습니다
- 검색 중 로딩 상태 및 오류 메시지가 개선되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->