### PR TITLE
feat: 도서 상세 페이지 API 연동 (#64)

### DIFF
--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -8,8 +8,12 @@ export interface ApiResponse<T> {
   errors?: Array<{ field: string; message: string }>
 }
 
+/**
+ * Axios 에러를 한국어 메시지의 일반 Error로 정규화한다.
+ * 취소 에러(CanceledError / AbortError)는 원본 그대로 rethrow하여
+ * 호출자가 `axios.isCancel`로 분기할 수 있게 한다.
+ */
 export function normalizeAxiosError(error: unknown, fallback: string): Error {
-  // AbortController에 의한 취소는 원본 그대로 전파 (호출자에서 axios.isCancel로 분기)
   if (axios.isCancel(error) || (error instanceof DOMException && error.name === 'AbortError')) {
     throw error
   }

--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -9,6 +9,10 @@ export interface ApiResponse<T> {
 }
 
 export function normalizeAxiosError(error: unknown, fallback: string): Error {
+  // AbortController에 의한 취소는 원본 그대로 전파 (호출자에서 axios.isCancel로 분기)
+  if (axios.isCancel(error) || (error instanceof DOMException && error.name === 'AbortError')) {
+    throw error
+  }
   if (axios.isAxiosError(error)) {
     const apiMessage = error.response?.data?.message
     if (apiMessage) return new Error(apiMessage)

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -19,6 +19,39 @@ export interface BookSearchListResponse {
   size: number
 }
 
+export type BackendReadingStatus = 'WANT_TO_READ' | 'READING' | 'FINISHED' | 'STOPPED'
+
+export interface BookDetail {
+  bookId: number
+  isbn13: string
+  title: string
+  author: string
+  publisher: string
+  coverImageUrl: string | null
+  description: string | null
+  totalPages: number | null
+  publishedDate: string | null
+  aladinItemId: string | null
+  averageRating: number | null
+  reviewCount: number | null
+  myLibraryStatus: BackendReadingStatus | null
+  myReviewId: number | null
+}
+
+export async function getBook(bookId: number, signal?: AbortSignal): Promise<BookDetail> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<BookDetail>>(`/api/v1/books/${bookId}`, {
+      signal,
+    })
+    if (!data.data) {
+      throw new Error(data.message ?? '도서 조회 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '도서 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 export async function searchBooks(
   query: string,
   limit = 20,

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -158,7 +158,7 @@ export default function BookDetailPage() {
             {book.totalPages != null && book.totalPages > 0 && (
               <>
                 <span className="size-1 rounded-full bg-muted-foreground/30" />
-                <span>{book.totalPages} pages</span>
+                <span>{book.totalPages}쪽</span>
               </>
             )}
           </div>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { mockBooks, mockBookDetailReviews } from '@/mocks/data'
+import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
-import { useDragScroll } from '@/hooks/useDragScroll'
+import { getBook, type BookDetail, type BackendReadingStatus } from '@/api/book'
 import type { ReadingStatus } from '@/types'
 
 const statusEmoji: Record<ReadingStatus, string> = {
@@ -15,15 +15,66 @@ const statusEmoji: Record<ReadingStatus, string> = {
   stopped: '⏸️ 중단',
 }
 
-export default function BookDetailPage() {
-  const { bookId: id } = useParams()
-  const navigate = useNavigate()
-  const scrollRef = useDragScroll<HTMLDivElement>()
-  const [sheetOpen, setSheetOpen] = useState(false)
-  const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
-  const book = mockBooks.find(b => b.isbn === id)
+const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
+  WANT_TO_READ: 'want_to_read',
+  READING: 'reading',
+  FINISHED: 'finished',
+  STOPPED: 'stopped',
+}
 
-  if (!book) {
+export default function BookDetailPage() {
+  const { bookId } = useParams()
+  const navigate = useNavigate()
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [book, setBook] = useState<BookDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // TODO(B3): Library API 연동 시 savedStatus를 API 호출로 대체하고 myLibraryStatus와 동기화
+  const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
+
+  const parsedBookId = bookId ? Number(bookId) : NaN
+
+  useEffect(() => {
+    if (!Number.isFinite(parsedBookId)) {
+      setIsLoading(false)
+      setErrorMessage('유효하지 않은 도서 ID입니다.')
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const result = await getBook(parsedBookId, controller.signal)
+        if (controller.signal.aborted) return
+        setBook(result)
+        setSavedStatus(result.myLibraryStatus ? backendToFrontStatus[result.myLibraryStatus] : null)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '도서 정보를 불러오지 못했습니다.')
+        setBook(null)
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [parsedBookId])
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="BookLog" showBack />
+        <main className="flex flex-1 items-center justify-center pb-24">
+          <p className="text-sm text-muted-foreground">불러오는 중...</p>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (errorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="BookLog" showBack />
@@ -31,8 +82,11 @@ export default function BookDetailPage() {
           <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
             search_off
           </span>
-          <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
+          <p className="text-lg font-bold text-muted-foreground">
+            {errorMessage ?? '도서를 찾을 수 없습니다'}
+          </p>
           <button
+            type="button"
             onClick={() => navigate(-1)}
             className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
           >
@@ -44,13 +98,24 @@ export default function BookDetailPage() {
     )
   }
 
+  const handleReviewClick = () => {
+    if (book.myReviewId != null) {
+      navigate(`/review/${book.myReviewId}`)
+    } else {
+      navigate(`/review/write/${book.bookId}`)
+    }
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <AppHeader
         title="BookLog"
         showBack
         rightAction={
-          <button className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10">
+          <button
+            type="button"
+            className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
+          >
             <span className="material-symbols-outlined">share</span>
           </button>
         }
@@ -60,7 +125,15 @@ export default function BookDetailPage() {
         {/* Hero: Book Cover */}
         <div className="flex justify-center px-6 py-8">
           <div className="relative aspect-[2/3] w-2/3 overflow-hidden rounded-lg border border-primary/5 shadow-2xl">
-            <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
+            {book.coverImageUrl ? (
+              <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
+            ) : (
+              <div className="flex size-full items-center justify-center bg-primary/5">
+                <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+                  menu_book
+                </span>
+              </div>
+            )}
           </div>
         </div>
 
@@ -70,10 +143,10 @@ export default function BookDetailPage() {
           <p className="mb-1 text-lg font-medium text-primary">{book.author}</p>
           <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
             <span>{book.publisher}</span>
-            {book.pageCount && (
+            {book.totalPages && (
               <>
                 <span className="size-1 rounded-full bg-muted-foreground/30" />
-                <span>{book.pageCount} pages</span>
+                <span>{book.totalPages} pages</span>
               </>
             )}
           </div>
@@ -83,78 +156,67 @@ export default function BookDetailPage() {
         <section className="mt-8 px-6">
           <div className="flex flex-col items-center rounded-xl bg-primary/5 p-6">
             <div className="mb-2 flex items-center gap-1">
-              <span className="text-3xl font-bold">{book.rating}</span>
+              <span className="text-3xl font-bold">
+                {book.averageRating != null ? book.averageRating.toFixed(1) : '-'}
+              </span>
               <span className="text-muted-foreground">/ 5.0</span>
             </div>
-            <StarRating rating={book.rating ?? 0} size="md" />
+            <StarRating rating={book.averageRating ?? 0} size="md" />
             <p className="mt-2 text-xs font-medium text-muted-foreground">
-              {book.reviewCount?.toLocaleString()} reviews from readers
+              {book.reviewCount != null
+                ? `${book.reviewCount.toLocaleString()}개의 감상`
+                : '아직 감상이 없습니다'}
             </p>
           </div>
         </section>
 
+        {/* Description */}
+        {book.description && (
+          <section className="mt-8 px-6">
+            <h3 className="mb-3 text-lg font-bold">책 소개</h3>
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+              {book.description}
+            </p>
+          </section>
+        )}
+
         {/* CTA */}
-        <section className="mt-8 px-6">
+        <section className="mt-8 flex flex-col gap-3 px-6">
           <button
+            type="button"
             onClick={() => setSheetOpen(true)}
             className="w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98]"
           >
             {savedStatus ? `${statusEmoji[savedStatus]} ✏️` : '내 서재에 추가'}
           </button>
+          <button
+            type="button"
+            onClick={handleReviewClick}
+            className="w-full rounded-xl border border-primary/20 bg-card py-4 text-base font-semibold text-primary transition-colors hover:bg-primary/5"
+          >
+            {book.myReviewId != null ? '내 감상 보기' : '감상 쓰기'}
+          </button>
         </section>
 
-        {/* Reviews */}
+        {/* Reviews — 전체보기 링크 */}
         <section className="mt-12">
           <div className="mb-4 flex items-center justify-between px-6">
             <h3 className="text-xl font-bold">독자들의 감상</h3>
-            <Link to={`/book/${id}/reviews`} className="text-sm font-semibold text-primary">
+            <Link
+              to={`/book/${book.bookId}/reviews`}
+              className="text-sm font-semibold text-primary"
+            >
               전체보기
             </Link>
           </div>
-          <div ref={scrollRef} className="no-scrollbar flex gap-4 overflow-x-auto px-6 pb-4">
-            {mockBookDetailReviews.map(review => (
-              <Link
-                key={review.id}
-                to={`/review/${review.id}`}
-                className="min-w-[280px] rounded-xl border border-primary/5 bg-card p-4 shadow-sm"
-              >
-                {/* Reviewer */}
-                <div className="mb-3 flex items-center gap-3">
-                  <div className="size-8 overflow-hidden rounded-full border border-primary/10">
-                    {review.author.profileImageUrl && (
-                      <img
-                        src={review.author.profileImageUrl}
-                        alt={review.author.nickname}
-                        className="size-full object-cover"
-                      />
-                    )}
-                  </div>
-                  <div className="flex-1">
-                    <p className="text-sm font-bold leading-none">{review.author.nickname}</p>
-                    <div className="-mt-1 origin-left scale-75">
-                      <StarRating rating={review.rating ?? 0} size="sm" />
-                    </div>
-                  </div>
-                </div>
-
-                {/* Review Content */}
-                {review.hasSpoiler ? (
-                  <div className="relative">
-                    <p className="select-none text-sm text-muted-foreground blur-sm">
-                      {review.content}
-                    </p>
-                    <div className="absolute inset-0 flex items-center justify-center bg-card/40 backdrop-blur-[2px]">
-                      <div className="flex items-center gap-1 rounded-full bg-primary/90 px-3 py-1.5 text-xs font-bold text-primary-foreground">
-                        <span className="material-symbols-outlined text-sm">visibility_off</span>
-                        스포일러 포함 리뷰
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <p className="line-clamp-3 text-sm text-muted-foreground">{review.content}</p>
-                )}
-              </Link>
-            ))}
+          {/* TODO(B3): 도서별 감상 목록 API 연동 시 미리보기 리스트 표시 */}
+          <div className="px-6">
+            <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-primary/10 py-8 text-center">
+              <span className="material-symbols-outlined text-3xl text-muted-foreground/40">
+                menu_book
+              </span>
+              <p className="text-sm text-muted-foreground">전체보기에서 모든 감상을 확인하세요</p>
+            </div>
           </div>
         </section>
       </main>
@@ -163,7 +225,7 @@ export default function BookDetailPage() {
         isOpen={sheetOpen}
         onClose={() => setSheetOpen(false)}
         onSave={setSavedStatus}
-        bookId={id ?? book.isbn}
+        bookId={String(book.bookId)}
         defaultStatus={savedStatus ?? undefined}
       />
 

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -22,6 +22,13 @@ const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
   STOPPED: 'stopped',
 }
 
+function toFrontStatus(s: string | null): ReadingStatus | null {
+  if (s && s in backendToFrontStatus) {
+    return backendToFrontStatus[s as BackendReadingStatus]
+  }
+  return null
+}
+
 export default function BookDetailPage() {
   const { bookId } = useParams()
   const navigate = useNavigate()
@@ -33,9 +40,10 @@ export default function BookDetailPage() {
   const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
 
   const parsedBookId = bookId ? Number(bookId) : NaN
+  const isValidBookId = Number.isInteger(parsedBookId) && parsedBookId > 0
 
   useEffect(() => {
-    if (!Number.isFinite(parsedBookId)) {
+    if (!isValidBookId) {
       setIsLoading(false)
       setErrorMessage('유효하지 않은 도서 ID입니다.')
       return
@@ -49,7 +57,7 @@ export default function BookDetailPage() {
         const result = await getBook(parsedBookId, controller.signal)
         if (controller.signal.aborted) return
         setBook(result)
-        setSavedStatus(result.myLibraryStatus ? backendToFrontStatus[result.myLibraryStatus] : null)
+        setSavedStatus(toFrontStatus(result.myLibraryStatus))
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setErrorMessage(error instanceof Error ? error.message : '도서 정보를 불러오지 못했습니다.')
@@ -60,14 +68,16 @@ export default function BookDetailPage() {
     })()
 
     return () => controller.abort()
-  }, [parsedBookId])
+  }, [parsedBookId, isValidBookId])
 
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="BookLog" showBack />
-        <main className="flex flex-1 items-center justify-center pb-24">
-          <p className="text-sm text-muted-foreground">불러오는 중...</p>
+        <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
         </main>
         <BottomNav />
       </div>
@@ -82,7 +92,7 @@ export default function BookDetailPage() {
           <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
             search_off
           </span>
-          <p className="text-lg font-bold text-muted-foreground">
+          <p role="alert" className="text-lg font-bold text-muted-foreground">
             {errorMessage ?? '도서를 찾을 수 없습니다'}
           </p>
           <button
@@ -114,7 +124,9 @@ export default function BookDetailPage() {
         rightAction={
           <button
             type="button"
-            className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
+            disabled
+            aria-label="공유 (준비 중)"
+            className="flex size-10 items-center justify-center rounded-full text-primary/40"
           >
             <span className="material-symbols-outlined">share</span>
           </button>
@@ -143,7 +155,7 @@ export default function BookDetailPage() {
           <p className="mb-1 text-lg font-medium text-primary">{book.author}</p>
           <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
             <span>{book.publisher}</span>
-            {book.totalPages && (
+            {book.totalPages != null && book.totalPages > 0 && (
               <>
                 <span className="size-1 rounded-full bg-muted-foreground/30" />
                 <span>{book.totalPages} pages</span>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -197,6 +197,7 @@ export default function BookDetailPage() {
           <button
             type="button"
             onClick={() => setSheetOpen(true)}
+            aria-label={savedStatus ? '내 서재 상태 수정' : '내 서재에 추가'}
             className="w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98]"
           >
             {savedStatus ? `${statusEmoji[savedStatus]} ✏️` : '내 서재에 추가'}


### PR DESCRIPTION
## 📌 개요
`BookDetailPage`의 mock 데이터를 제거하고 백엔드 `GET /api/v1/books/{bookId}` API와 연동합니다. 서버가 내려주는 `myLibraryStatus`와 `myReviewId`를 활용해 서재/감상 버튼을 상태별로 분기하고, 책 소개 섹션을 추가합니다. 또한 공통 `normalizeAxiosError`가 취소 에러를 잘못 정규화하던 문제를 수정합니다.

Closes #64

## 🔧 주요 변경

### 도서 상세 API 연동
- `src/api/book.ts` — `BookDetail`, `BackendReadingStatus` 타입 및 `getBook(bookId, signal?)` 함수 추가
- `AbortSignal` 지원으로 언마운트 / `bookId` 변경 시 요청 취소 가능

### BookDetailPage 재작성
- mock(`mockBooks`, `mockBookDetailReviews`) 제거 후 실제 API 호출로 교체
- `bookId` 파싱 검증 강화 — `Number.isInteger && > 0`
- 로딩 / 에러 / 성공 상태 분기 UI
- 백엔드 `UPPER_CASE` 상태 → 프론트 `ReadingStatus` 안전 매핑 (`toFrontStatus` 가드)
- 버튼 분기
  - 서재: `myLibraryStatus` 기반 초기값 + "내 서재에 추가" / 상태 이모지 + ✏️
  - 감상: `myReviewId` 있으면 "내 감상 보기" → `/review/{myReviewId}`, 없으면 "감상 쓰기" → `/review/write/{bookId}`
- 책 소개(`description`) 섹션 추가, 표지 없음 placeholder
- 평점/리뷰수 표시 (`averageRating`, `reviewCount`)
- 공유 버튼 `disabled` + `aria-label` 처리 (MVP 단계 무동작 방지)
- 감상 미리보기 리스트 제거 → "전체보기" 링크만 유지 (B3 예정)

### 공통 helper 수정
- `src/api/_helpers.ts` — `normalizeAxiosError` 진입부에서 `axios.isCancel` / `AbortError` 원본 그대로 rethrow
- JSDoc으로 취소 rethrow 의도 명시
- 기존에 취소 에러가 "서버에 연결할 수 없습니다"로 잘못 변환되어 사용자에게 오류 화면이 노출되던 버그 수정

### 접근성
- 로딩 `aria-busy="true"` + `role="status"`
- 에러 `role="alert"`
- 서재 버튼 `aria-label` ("내 서재에 추가" / "내 서재 상태 수정")
- 공유 버튼 `aria-label` ("공유 (준비 중)")

## 📎 코드 리뷰 이력
- OMC code-reviewer 1차: **REQUEST CHANGES** → HIGH 2, MEDIUM 2, LOW 2 반영 (MEDIUM 1건은 B3 예정으로 유예)
- OMC code-reviewer 2차: **APPROVE** — 스펙 준수, 취소 경로 3중 방어, `tsc` 통과 확인
- CodeRabbit: merge 전 자동 실행 예정

## ⚠️ 알려진 한계 (후속 이슈에서 해결)
- `AddToLibrarySheet`의 저장은 여전히 로컬 state만 갱신 — Library API 연동 이슈에서 `POST /api/v1/library` 호출 + `savedStatus ↔ myLibraryStatus` 재동기화 훅 추가 예정 (TODO(B3) 주석으로 명시)
- 도서별 감상 미리보기 리스트(수평 스크롤)는 B3에서 `GET /api/v1/books/{bookId}/reviews` 연동 시 복원
- `BookListItem` / `MyLibraryPage`의 `/book/{isbn}` 기반 링크는 Library API 연동 시 실제 `bookId`로 교체 예정
- 공유 버튼 실제 구현은 별도 이슈로 분리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도서 상세 페이지가 실제 API 기반으로 동작하며 표지, 페이지 수, 평점/리뷰 수, 책 소개 등을 백엔드 데이터로 표시
  * 리뷰 보기/작성으로 이동하는 버튼 추가 및 리뷰 섹션 자리표시자 개선

* **개선사항**
  * 네트워크 요청 취소 시 오류 처리 개선(취소된 요청은 원래 오류 재전파)
  * 공유 버튼 비활성화 처리 및 접근성 속성 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->