### PR TITLE
Feat/#74 password change api

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -28,3 +28,11 @@ export async function getMyProfile(signal?: AbortSignal): Promise<MyProfile> {
     throw normalizeAxiosError(error, '프로필을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
+
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  try {
+    await apiClient.put('/api/v1/users/me/password', { currentPassword, newPassword })
+  } catch (error) {
+    throw normalizeAxiosError(error, '비밀번호 변경에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/pages/PasswordChangePage.tsx
+++ b/src/pages/PasswordChangePage.tsx
@@ -7,51 +7,60 @@ import AppHeader from '@/components/layout/AppHeader'
 import { changePassword } from '@/api/member'
 import { PASSWORD_HINT, PASSWORD_REGEX } from '@/constants/validation'
 
+const PASSWORD_MAX_LENGTH = 64
+
 const schema = z
   .object({
-    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요'),
+    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요').max(PASSWORD_MAX_LENGTH),
     newPassword: z
       .string()
       .min(8, '비밀번호는 8자 이상이어야 합니다')
+      .max(PASSWORD_MAX_LENGTH, `비밀번호는 ${PASSWORD_MAX_LENGTH}자 이하여야 합니다`)
       .regex(PASSWORD_REGEX, '영문, 숫자, 특수문자를 모두 포함해야 합니다'),
-    confirmPassword: z.string(),
+    confirmPassword: z.string().max(PASSWORD_MAX_LENGTH),
   })
-  .refine(data => data.newPassword === data.confirmPassword, {
-    message: '새 비밀번호가 일치하지 않습니다',
-    path: ['confirmPassword'],
-  })
-  .refine(data => data.currentPassword !== data.newPassword, {
-    message: '현재 비밀번호와 다른 비밀번호를 입력해주세요',
-    path: ['newPassword'],
+  .superRefine((data, ctx) => {
+    if (data.newPassword !== data.confirmPassword) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['confirmPassword'],
+        message: '새 비밀번호가 일치하지 않습니다',
+      })
+    }
+    if (data.currentPassword && data.currentPassword === data.newPassword) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['newPassword'],
+        message: '현재 비밀번호와 다른 비밀번호를 입력해주세요',
+      })
+    }
   })
 
 type FormData = z.infer<typeof schema>
 
 export default function PasswordChangePage() {
   const navigate = useNavigate()
-  const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isSuccess, setIsSuccess] = useState(false)
 
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    reset,
+    formState: { errors, isSubmitting },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
   })
 
   const onSubmit = async (data: FormData) => {
-    if (isLoading) return
-    setIsLoading(true)
+    if (isSubmitting) return
     setErrorMessage(null)
     try {
       await changePassword(data.currentPassword, data.newPassword)
+      reset()
       setIsSuccess(true)
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '비밀번호 변경에 실패했습니다.')
-    } finally {
-      setIsLoading(false)
     }
   }
 
@@ -61,7 +70,11 @@ export default function PasswordChangePage() {
 
       <main className="flex flex-1 flex-col px-6 pt-12">
         {isSuccess ? (
-          <div className="flex flex-col items-center gap-4 pt-16 text-center">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex flex-col items-center gap-4 pt-16 text-center"
+          >
             <span className="material-symbols-outlined text-5xl text-primary">check_circle</span>
             <h2 className="text-2xl font-bold text-foreground">비밀번호가 변경되었습니다</h2>
             <p className="text-base text-muted-foreground">
@@ -92,6 +105,7 @@ export default function PasswordChangePage() {
                   {...register('currentPassword')}
                   type="password"
                   autoComplete="current-password"
+                  maxLength={PASSWORD_MAX_LENGTH}
                   placeholder="현재 비밀번호를 입력해주세요"
                   className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
                 />
@@ -111,6 +125,7 @@ export default function PasswordChangePage() {
                   {...register('newPassword')}
                   type="password"
                   autoComplete="new-password"
+                  maxLength={PASSWORD_MAX_LENGTH}
                   placeholder="8자 이상 입력해주세요"
                   aria-describedby="password-hint"
                   className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
@@ -131,6 +146,7 @@ export default function PasswordChangePage() {
                   {...register('confirmPassword')}
                   type="password"
                   autoComplete="new-password"
+                  maxLength={PASSWORD_MAX_LENGTH}
                   placeholder="비밀번호를 다시 입력해주세요"
                   className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
                 />
@@ -148,6 +164,7 @@ export default function PasswordChangePage() {
               {errorMessage && (
                 <p
                   role="alert"
+                  aria-atomic="true"
                   className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
                 >
                   {errorMessage}
@@ -156,10 +173,10 @@ export default function PasswordChangePage() {
 
               <button
                 type="submit"
-                disabled={isLoading}
+                disabled={isSubmitting}
                 className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {isLoading ? '변경 중...' : '비밀번호 변경'}
+                {isSubmitting ? '변경 중...' : '비밀번호 변경'}
               </button>
             </form>
           </>

--- a/src/pages/PasswordChangePage.tsx
+++ b/src/pages/PasswordChangePage.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate } from 'react-router-dom'
+import AppHeader from '@/components/layout/AppHeader'
+import { changePassword } from '@/api/member'
+import { PASSWORD_HINT, PASSWORD_REGEX } from '@/constants/validation'
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요'),
+    newPassword: z
+      .string()
+      .min(8, '비밀번호는 8자 이상이어야 합니다')
+      .regex(PASSWORD_REGEX, '영문, 숫자, 특수문자를 모두 포함해야 합니다'),
+    confirmPassword: z.string(),
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: '새 비밀번호가 일치하지 않습니다',
+    path: ['confirmPassword'],
+  })
+  .refine(data => data.currentPassword !== data.newPassword, {
+    message: '현재 비밀번호와 다른 비밀번호를 입력해주세요',
+    path: ['newPassword'],
+  })
+
+type FormData = z.infer<typeof schema>
+
+export default function PasswordChangePage() {
+  const navigate = useNavigate()
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  const onSubmit = async (data: FormData) => {
+    if (isLoading) return
+    setIsLoading(true)
+    setErrorMessage(null)
+    try {
+      await changePassword(data.currentPassword, data.newPassword)
+      setIsSuccess(true)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '비밀번호 변경에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="비밀번호 변경" showBack />
+
+      <main className="flex flex-1 flex-col px-6 pt-12">
+        {isSuccess ? (
+          <div className="flex flex-col items-center gap-4 pt-16 text-center">
+            <span className="material-symbols-outlined text-5xl text-primary">check_circle</span>
+            <h2 className="text-2xl font-bold text-foreground">비밀번호가 변경되었습니다</h2>
+            <p className="text-base text-muted-foreground">
+              변경된 비밀번호로 계속 이용하실 수 있습니다.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate('/settings', { replace: true })}
+              className="mt-4 rounded-xl bg-primary px-8 py-3 text-base font-bold text-primary-foreground transition-all hover:opacity-95"
+            >
+              설정으로 돌아가기
+            </button>
+          </div>
+        ) : (
+          <>
+            <h2 className="text-2xl font-bold text-foreground">비밀번호 변경</h2>
+            <p className="mt-3 text-base text-muted-foreground">
+              현재 비밀번호를 확인한 뒤 새 비밀번호를 설정합니다.
+            </p>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="mt-10 flex flex-col gap-6">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="current-password" className="ml-1 text-sm font-semibold">
+                  현재 비밀번호
+                </label>
+                <input
+                  id="current-password"
+                  {...register('currentPassword')}
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder="현재 비밀번호를 입력해주세요"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.currentPassword && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.currentPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label htmlFor="new-password" className="ml-1 text-sm font-semibold">
+                  새 비밀번호
+                </label>
+                <input
+                  id="new-password"
+                  {...register('newPassword')}
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="8자 이상 입력해주세요"
+                  aria-describedby="password-hint"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.newPassword && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.newPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label htmlFor="confirm-password" className="ml-1 text-sm font-semibold">
+                  새 비밀번호 확인
+                </label>
+                <input
+                  id="confirm-password"
+                  {...register('confirmPassword')}
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="비밀번호를 다시 입력해주세요"
+                  className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+                />
+                {errors.confirmPassword && (
+                  <p role="alert" className="ml-1 text-xs text-destructive">
+                    {errors.confirmPassword.message}
+                  </p>
+                )}
+              </div>
+
+              <p id="password-hint" className="ml-1 text-xs text-muted-foreground">
+                {PASSWORD_HINT}
+              </p>
+
+              {errorMessage && (
+                <p
+                  role="alert"
+                  className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+                >
+                  {errorMessage}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="mt-4 w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoading ? '변경 중...' : '비밀번호 변경'}
+              </button>
+            </form>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,6 +5,75 @@ import BottomNav from '@/components/layout/BottomNav'
 import { logout, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
 
+function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      className={`relative h-8 w-14 rounded-full transition-colors ${
+        checked ? 'bg-primary' : 'bg-primary/10'
+      }`}
+    >
+      <span
+        className={`absolute top-1 left-1 h-6 w-6 rounded-full bg-background shadow-sm transition-transform ${
+          checked ? 'translate-x-6' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  )
+}
+
+interface SettingRowProps {
+  title: string
+  description?: string
+  right?: React.ReactNode
+  noBorder?: boolean
+}
+
+function SettingRow({ title, description, right, noBorder = false }: SettingRowProps) {
+  return (
+    <div
+      className={`flex items-center justify-between gap-4 px-5 py-5 ${
+        noBorder ? '' : 'border-b border-border'
+      }`}
+    >
+      <div className="min-w-0">
+        <p className="text-[18px] font-medium leading-tight text-foreground">{title}</p>
+        {description && <p className="mt-2 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {right}
+    </div>
+  )
+}
+
+interface LinkRowProps {
+  title: string
+  description?: string
+  onClick?: () => void
+  noBorder?: boolean
+}
+
+function LinkRow({ title, description, onClick, noBorder = false }: LinkRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      className={`flex w-full items-center justify-between gap-4 px-5 py-5 text-left transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:hover:bg-transparent ${
+        noBorder ? '' : 'border-b border-border'
+      }`}
+    >
+      <div className="min-w-0">
+        <p className="text-[18px] font-medium leading-tight text-foreground">{title}</p>
+        {description && <p className="mt-2 text-sm text-primary/80">{description}</p>}
+      </div>
+      <span className="material-symbols-outlined text-[24px] text-muted-foreground">
+        chevron_right
+      </span>
+    </button>
+  )
+}
+
 export default function SettingsPage() {
   const navigate = useNavigate()
   const clearAuth = useAuthStore(state => state.clearAuth)
@@ -50,75 +119,6 @@ export default function SettingsPage() {
   const [newFollowerAlert, setNewFollowerAlert] = useState(true)
   const [followingReviewAlert, setFollowingReviewAlert] = useState(false)
   const [libraryPublic, setLibraryPublic] = useState(true)
-
-  const Toggle = ({ checked, onChange }: { checked: boolean; onChange: () => void }) => (
-    <button
-      type="button"
-      onClick={onChange}
-      className={`relative h-8 w-14 rounded-full transition-colors ${
-        checked ? 'bg-primary' : 'bg-primary/10'
-      }`}
-    >
-      <span
-        className={`absolute top-1 left-1 h-6 w-6 rounded-full bg-background shadow-sm transition-transform ${
-          checked ? 'translate-x-6' : 'translate-x-0'
-        }`}
-      />
-    </button>
-  )
-
-  const SettingRow = ({
-    title,
-    description,
-    right,
-    noBorder = false,
-  }: {
-    title: string
-    description?: string
-    right?: React.ReactNode
-    noBorder?: boolean
-  }) => (
-    <div
-      className={`flex items-center justify-between gap-4 px-5 py-5 ${
-        noBorder ? '' : 'border-b border-border'
-      }`}
-    >
-      <div className="min-w-0">
-        <p className="text-[18px] font-medium leading-tight text-foreground">{title}</p>
-        {description && <p className="mt-2 text-sm text-muted-foreground">{description}</p>}
-      </div>
-      {right}
-    </div>
-  )
-
-  const LinkRow = ({
-    title,
-    description,
-    onClick,
-    noBorder = false,
-  }: {
-    title: string
-    description?: string
-    onClick?: () => void
-    noBorder?: boolean
-  }) => (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!onClick}
-      className={`flex w-full items-center justify-between gap-4 px-5 py-5 text-left transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:hover:bg-transparent ${
-        noBorder ? '' : 'border-b border-border'
-      }`}
-    >
-      <div className="min-w-0">
-        <p className="text-[18px] font-medium leading-tight text-foreground">{title}</p>
-        {description && <p className="mt-2 text-sm text-primary/80">{description}</p>}
-      </div>
-      <span className="material-symbols-outlined text-[24px] text-muted-foreground">
-        chevron_right
-      </span>
-    </button>
-  )
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -212,7 +212,7 @@ export default function SettingsPage() {
           <h2 className="mb-3 text-lg font-bold text-primary/80">계정 관리</h2>
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
             <LinkRow title="비밀번호 변경" onClick={() => navigate('/settings/password')} />
-            <LinkRow title="연동 소셜 계정" description="Google 연동 중" noBorder />
+            <SettingRow title="연동 소셜 계정" description="Google 연동 중" noBorder />
           </div>
         </section>
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,10 +5,21 @@ import BottomNav from '@/components/layout/BottomNav'
 import { logout, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
 
-function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+function Toggle({
+  checked,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean
+  onChange: () => void
+  ariaLabel: string
+}) {
   return (
     <button
       type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
       onClick={onChange}
       className={`relative h-8 w-14 rounded-full transition-colors ${
         checked ? 'bg-primary' : 'bg-primary/10'
@@ -162,12 +173,22 @@ export default function SettingsPage() {
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
             <SettingRow
               title="좋아요"
-              right={<Toggle checked={likeAlert} onChange={() => setLikeAlert(prev => !prev)} />}
+              right={
+                <Toggle
+                  checked={likeAlert}
+                  onChange={() => setLikeAlert(prev => !prev)}
+                  ariaLabel="좋아요 알림"
+                />
+              }
             />
             <SettingRow
               title="댓글"
               right={
-                <Toggle checked={commentAlert} onChange={() => setCommentAlert(prev => !prev)} />
+                <Toggle
+                  checked={commentAlert}
+                  onChange={() => setCommentAlert(prev => !prev)}
+                  ariaLabel="댓글 알림"
+                />
               }
             />
             <SettingRow
@@ -176,6 +197,7 @@ export default function SettingsPage() {
                 <Toggle
                   checked={newFollowerAlert}
                   onChange={() => setNewFollowerAlert(prev => !prev)}
+                  ariaLabel="새 팔로워 알림"
                 />
               }
             />
@@ -186,6 +208,7 @@ export default function SettingsPage() {
                 <Toggle
                   checked={followingReviewAlert}
                   onChange={() => setFollowingReviewAlert(prev => !prev)}
+                  ariaLabel="팔로잉 새 감상 알림"
                 />
               }
             />
@@ -201,7 +224,11 @@ export default function SettingsPage() {
               description="다른 사용자가 내 서재를 방문할 수 있습니다."
               noBorder
               right={
-                <Toggle checked={libraryPublic} onChange={() => setLibraryPublic(prev => !prev)} />
+                <Toggle
+                  checked={libraryPublic}
+                  onChange={() => setLibraryPublic(prev => !prev)}
+                  ariaLabel="서재 공개"
+                />
               }
             />
           </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -94,15 +94,19 @@ export default function SettingsPage() {
   const LinkRow = ({
     title,
     description,
+    onClick,
     noBorder = false,
   }: {
     title: string
     description?: string
+    onClick?: () => void
     noBorder?: boolean
   }) => (
     <button
       type="button"
-      className={`flex w-full items-center justify-between gap-4 px-5 py-5 text-left transition-colors hover:bg-primary/5 ${
+      onClick={onClick}
+      disabled={!onClick}
+      className={`flex w-full items-center justify-between gap-4 px-5 py-5 text-left transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:hover:bg-transparent ${
         noBorder ? '' : 'border-b border-border'
       }`}
     >
@@ -207,7 +211,7 @@ export default function SettingsPage() {
         <section className="px-5 pt-8">
           <h2 className="mb-3 text-lg font-bold text-primary/80">계정 관리</h2>
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
-            <LinkRow title="비밀번호 변경" />
+            <LinkRow title="비밀번호 변경" onClick={() => navigate('/settings/password')} />
             <LinkRow title="연동 소셜 계정" description="Google 연동 중" noBorder />
           </div>
         </section>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -16,6 +16,7 @@ import AuthCallbackPage from '@/pages/AuthCallbackPage'
 import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
 import PasswordResetPage from '@/pages/PasswordResetPage'
 import EmailVerificationPage from '@/pages/EmailVerificationPage'
+import PasswordChangePage from '@/pages/PasswordChangePage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -132,6 +133,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <SettingsPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/settings/password',
+    element: (
+      <ProtectedRoute>
+        <PasswordChangePage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
- api/member.ts에 changePassword 함수 추가 (PUT /api/v1/users/me/password)

- PasswordChangePage 신규: 현재/새/새 비밀번호 확인 3필드 + zod 검증

- 검증: PASSWORD_REGEX 일치, 비밀번호 확인 일치, 현재 != 새 (재사용 차단)

- SettingsPage LinkRow에 onClick prop 지원 (미연결 메뉴는 disabled 처리)

- '비밀번호 변경' 메뉴 onClick으로 /settings/password 이동 연결

- 라우터에 /settings/password 경로 등록 (ProtectedRoute)

- 접근성: htmlFor/id, autoComplete 3필드 구분, aria-describedby, role=alert

- 성공 후 /settings로 replace:true 이동 (세션 유지, 히스토리 오염 방지)

- zod refine 2개를 superRefine으로 통합 (병합 안정성)

- 성공 화면에 role=status, aria-live=polite 접근성 강화

- Toggle/SettingRow/LinkRow를 모듈 스코프로 추출 (리렌더마다 재생성 방지)

- '연동 소셜 계정'을 LinkRow → SettingRow로 교체 (disabled+chevron UI 모순 제거)

- 성공 시 form.reset() 호출 (비밀번호 평문 메모리 잔존 방지)

- isLoading state → formState.isSubmitting으로 대체

- 비밀번호 필드 maxLength=64 + zod .max(64)

- 서버 에러 메시지에 aria-atomic 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설정에서 현재 비밀번호 확인 후 새 비밀번호로 변경하는 페이지와 흐름이 추가되었습니다. 유효성 검사(길이·형식·확인 일치)와 변경 완료 확인 화면이 포함됩니다.

* **개선**
  * 설정 목록의 항목 접근성 및 상호작용을 개선하여 내비게이션과 비활성화 상태 표시가 명확해졌습니다. 제출 오류 처리와 중복 제출 방지도 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->