### PR TITLE
Feat/#76 withdraw api 회원 탈퇴 API 연동

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -36,3 +36,13 @@ export async function changePassword(currentPassword: string, newPassword: strin
     throw normalizeAxiosError(error, '비밀번호 변경에 실패했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
+
+export async function withdrawAccount(password: string, reason?: string): Promise<void> {
+  try {
+    await apiClient.delete('/api/v1/users/me', {
+      data: { password, ...(reason ? { reason } : {}) },
+    })
+  } catch (error) {
+    throw normalizeAxiosError(error, '회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -260,7 +260,8 @@ export default function SettingsPage() {
           <div className="text-center">
             <button
               type="button"
-              className="text-base font-medium text-destructive/70 underline underline-offset-4"
+              onClick={() => navigate('/settings/withdraw')}
+              className="text-base font-medium text-destructive/70 underline underline-offset-4 transition-colors hover:text-destructive"
             >
               회원 탈퇴
             </button>

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -175,8 +175,8 @@ export default function WithdrawPage() {
       <Dialog
         open={isConfirmOpen}
         onOpenChange={open => {
-          // API 인플라이트 중에는 다이얼로그 닫기 차단
           if (isProcessing && !open) return
+          if (!open) setPendingData(null)
           setIsConfirmOpen(open)
         }}
       >
@@ -197,7 +197,10 @@ export default function WithdrawPage() {
           <DialogFooter className="gap-2">
             <button
               type="button"
-              onClick={() => setIsConfirmOpen(false)}
+              onClick={() => {
+                setPendingData(null)
+                setIsConfirmOpen(false)
+              }}
               disabled={isProcessing}
               className="rounded-lg border border-primary/20 bg-card px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-primary/5 disabled:opacity-60"
             >

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -68,6 +68,7 @@ export default function WithdrawPage() {
     setErrorMessage(null)
     try {
       await withdrawAccount(pendingData.password, pendingData.reason?.trim() || undefined)
+      setPendingData(null)
       setIsConfirmOpen(false)
       clearAuth()
       navigate('/login', { replace: true })

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useEffect, useRef, useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useNavigate } from 'react-router-dom'
@@ -33,18 +33,28 @@ export default function WithdrawPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
   const [pendingData, setPendingData] = useState<FormData | null>(null)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const errorRef = useRef<HTMLParagraphElement | null>(null)
 
   const {
     register,
     handleSubmit,
-    watch,
-    formState: { errors, isSubmitting },
+    control,
+    formState: { errors },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: { password: '', reason: '' },
   })
 
-  const reasonLength = watch('reason')?.length ?? 0
+  const reason = useWatch({ control, name: 'reason' })
+  const reasonLength = reason?.length ?? 0
+
+  // 에러 발생 시 에러 메시지로 스크롤 이동 (LOW 8)
+  useEffect(() => {
+    if (errorMessage && errorRef.current) {
+      errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [errorMessage])
 
   const onSubmit = (data: FormData) => {
     setErrorMessage(null)
@@ -53,7 +63,8 @@ export default function WithdrawPage() {
   }
 
   const handleConfirmWithdraw = async () => {
-    if (!pendingData || isSubmitting) return
+    if (!pendingData || isProcessing) return
+    setIsProcessing(true)
     setErrorMessage(null)
     try {
       await withdrawAccount(pendingData.password, pendingData.reason?.trim() || undefined)
@@ -62,7 +73,10 @@ export default function WithdrawPage() {
       navigate('/login', { replace: true })
     } catch (error) {
       setIsConfirmOpen(false)
+      setPendingData(null)
       setErrorMessage(error instanceof Error ? error.message : '회원 탈퇴에 실패했습니다.')
+    } finally {
+      setIsProcessing(false)
     }
   }
 
@@ -111,6 +125,7 @@ export default function WithdrawPage() {
             <textarea
               id="withdraw-reason"
               {...register('reason')}
+              maxLength={REASON_MAX_LENGTH}
               placeholder="서비스 개선에 참고할 수 있도록 탈퇴하시는 이유를 알려주시면 감사하겠습니다."
               aria-describedby="withdraw-reason-counter"
               className="min-h-[120px] w-full resize-none rounded-xl border-none bg-card px-5 py-4 text-sm shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
@@ -137,8 +152,10 @@ export default function WithdrawPage() {
 
           {errorMessage && (
             <p
+              ref={errorRef}
               role="alert"
               aria-atomic="true"
+              tabIndex={-1}
               className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
             >
               {errorMessage}
@@ -147,16 +164,30 @@ export default function WithdrawPage() {
 
           <button
             type="submit"
-            disabled={isSubmitting}
+            disabled={isProcessing}
             className="mt-4 w-full rounded-xl bg-destructive py-4 text-lg font-bold text-destructive-foreground shadow-lg shadow-destructive/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isSubmitting ? '처리 중...' : '탈퇴하기'}
+            {isProcessing ? '처리 중...' : '탈퇴하기'}
           </button>
         </form>
       </main>
 
-      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
-        <DialogContent>
+      <Dialog
+        open={isConfirmOpen}
+        onOpenChange={open => {
+          // API 인플라이트 중에는 다이얼로그 닫기 차단
+          if (isProcessing && !open) return
+          setIsConfirmOpen(open)
+        }}
+      >
+        <DialogContent
+          onInteractOutside={e => {
+            if (isProcessing) e.preventDefault()
+          }}
+          onEscapeKeyDown={e => {
+            if (isProcessing) e.preventDefault()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>정말로 탈퇴하시겠습니까?</DialogTitle>
             <DialogDescription>
@@ -167,7 +198,7 @@ export default function WithdrawPage() {
             <button
               type="button"
               onClick={() => setIsConfirmOpen(false)}
-              disabled={isSubmitting}
+              disabled={isProcessing}
               className="rounded-lg border border-primary/20 bg-card px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-primary/5 disabled:opacity-60"
             >
               취소
@@ -175,10 +206,10 @@ export default function WithdrawPage() {
             <button
               type="button"
               onClick={handleConfirmWithdraw}
-              disabled={isSubmitting}
+              disabled={isProcessing}
               className="rounded-lg bg-destructive px-5 py-3 text-sm font-semibold text-destructive-foreground transition-all hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSubmitting ? '처리 중...' : '탈퇴하기'}
+              {isProcessing ? '처리 중...' : '탈퇴하기'}
             </button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate } from 'react-router-dom'
+import AppHeader from '@/components/layout/AppHeader'
+import { withdrawAccount } from '@/api/member'
+import { useAuthStore } from '@/store/authStore'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+const REASON_MAX_LENGTH = 500
+
+const schema = z.object({
+  password: z.string().min(1, '현재 비밀번호를 입력해주세요'),
+  reason: z
+    .string()
+    .max(REASON_MAX_LENGTH, `사유는 ${REASON_MAX_LENGTH}자 이하로 입력해주세요`)
+    .optional(),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function WithdrawPage() {
+  const navigate = useNavigate()
+  const clearAuth = useAuthStore(state => state.clearAuth)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [pendingData, setPendingData] = useState<FormData | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { password: '', reason: '' },
+  })
+
+  const reasonLength = watch('reason')?.length ?? 0
+
+  const onSubmit = (data: FormData) => {
+    setErrorMessage(null)
+    setPendingData(data)
+    setIsConfirmOpen(true)
+  }
+
+  const handleConfirmWithdraw = async () => {
+    if (!pendingData || isSubmitting) return
+    setErrorMessage(null)
+    try {
+      await withdrawAccount(pendingData.password, pendingData.reason?.trim() || undefined)
+      setIsConfirmOpen(false)
+      clearAuth()
+      navigate('/login', { replace: true })
+    } catch (error) {
+      setIsConfirmOpen(false)
+      setErrorMessage(error instanceof Error ? error.message : '회원 탈퇴에 실패했습니다.')
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="회원 탈퇴" showBack />
+
+      <main className="flex flex-1 flex-col px-6 pb-24 pt-8">
+        {/* Warning Notice */}
+        <section className="flex flex-col gap-3 rounded-2xl border border-destructive/20 bg-destructive/5 p-5">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-[24px] text-destructive">warning</span>
+            <h2 className="text-base font-bold text-destructive">계정 삭제 시 주의사항</h2>
+          </div>
+          <ul className="ml-6 list-disc space-y-1 text-sm text-foreground/80">
+            <li>작성하신 감상, 댓글, 서재 도서가 영구 삭제됩니다.</li>
+            <li>팔로우·팔로워 관계가 모두 해제됩니다.</li>
+            <li>탈퇴 후에는 계정 복구가 불가능합니다.</li>
+          </ul>
+        </section>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-8 flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="withdraw-password" className="ml-1 text-sm font-semibold">
+              현재 비밀번호
+            </label>
+            <input
+              id="withdraw-password"
+              {...register('password')}
+              type="password"
+              autoComplete="current-password"
+              placeholder="본인 확인을 위해 현재 비밀번호를 입력해주세요"
+              className="w-full rounded-xl border-none bg-card px-5 py-4 shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+            />
+            {errors.password && (
+              <p role="alert" className="ml-1 text-xs text-destructive">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="withdraw-reason" className="ml-1 text-sm font-semibold">
+              탈퇴 사유 (선택)
+            </label>
+            <textarea
+              id="withdraw-reason"
+              {...register('reason')}
+              placeholder="서비스 개선에 참고할 수 있도록 탈퇴하시는 이유를 알려주시면 감사하겠습니다."
+              aria-describedby="withdraw-reason-counter"
+              className="min-h-[120px] w-full resize-none rounded-xl border-none bg-card px-5 py-4 text-sm shadow-sm transition-all placeholder:text-muted-foreground/40 focus:ring-2 focus:ring-primary/20"
+            />
+            <div className="flex items-center justify-between px-1">
+              {errors.reason ? (
+                <p role="alert" className="text-xs text-destructive">
+                  {errors.reason.message}
+                </p>
+              ) : (
+                <span />
+              )}
+              <p
+                id="withdraw-reason-counter"
+                aria-live="polite"
+                className={`text-xs ${
+                  reasonLength > REASON_MAX_LENGTH ? 'text-destructive' : 'text-muted-foreground'
+                }`}
+              >
+                {reasonLength}/{REASON_MAX_LENGTH}
+              </p>
+            </div>
+          </div>
+
+          {errorMessage && (
+            <p
+              role="alert"
+              aria-atomic="true"
+              className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {errorMessage}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="mt-4 w-full rounded-xl bg-destructive py-4 text-lg font-bold text-destructive-foreground shadow-lg shadow-destructive/20 transition-all hover:opacity-95 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? '처리 중...' : '탈퇴하기'}
+          </button>
+        </form>
+      </main>
+
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>정말로 탈퇴하시겠습니까?</DialogTitle>
+            <DialogDescription>
+              이 동작은 되돌릴 수 없습니다. 계정과 모든 관련 데이터가 영구적으로 삭제됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <button
+              type="button"
+              onClick={() => setIsConfirmOpen(false)}
+              disabled={isSubmitting}
+              className="rounded-lg border border-primary/20 bg-card px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-primary/5 disabled:opacity-60"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmWithdraw}
+              disabled={isSubmitting}
+              className="rounded-lg bg-destructive px-5 py-3 text-sm font-semibold text-destructive-foreground transition-all hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? '처리 중...' : '탈퇴하기'}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
 import PasswordResetPage from '@/pages/PasswordResetPage'
 import EmailVerificationPage from '@/pages/EmailVerificationPage'
 import PasswordChangePage from '@/pages/PasswordChangePage'
+import WithdrawPage from '@/pages/WithdrawPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -141,6 +142,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <PasswordChangePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/settings/withdraw',
+    element: (
+      <ProtectedRoute>
+        <WithdrawPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
- api/member.ts에 withdrawAccount 함수 추가 (DELETE /api/v1/users/me)
- WithdrawPage 신규: 경고 섹션 + 비밀번호/사유 입력 + shadcn Dialog 2중 확인
- SettingsPage '회원 탈퇴' 버튼에 onClick 연결
- 라우터에 /settings/withdraw 경로 등록
- HIGH: isProcessing local state 도입 (다이얼로그 단계 isSubmitting 미작동 해결)
- HIGH: 다이얼로그에 onInteractOutside/onEscapeKeyDown 가드 (API 인플라이트 중 닫힘 방지)
- MEDIUM: textarea maxLength={500} 추가
- MEDIUM: watch → useWatch로 교체 (전체 리렌더 감소)
- MEDIUM: 실패 시 pendingData 리셋 (평문 비밀번호 잔존 방지)
- LOW: 에러 메시지 영역 scrollIntoView로 접근성 강화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 탈퇴 API 및 탈퇴 페이지/라우트 추가 — 비밀번호(필수)와 사유(선택)로 탈퇴 요청 처리.
  * 탈퇴 확인 대화상자 도입: 첫 제출 시 확인 단계를 거쳐 확정 시 탈퇴 실행, 성공 시 인증 삭제 후 로그인 화면으로 이동.

* **입력 검증**
  * 비밀번호 필수화 및 사유 글자 수 제한, 인라인 오류 메시지 및 사유 문자 수 실시간 표시.

* **UI 개선**
  * 설정 페이지 탈퇴 버튼에 클릭 동작과 호버 전환 효과 추가; 처리 중엔 대화상자 닫기 제한 및 실패 안내 표시.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->