### PR TITLE
feat: 온보딩 상태 관리를 authStore로 통합 (#78)

### DIFF
--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -48,7 +48,7 @@ export default function AuthCallbackPage() {
           },
           result.accessToken
         )
-        navigate('/', { replace: true })
+        navigate(result.user.onboardingCompleted ? '/' : '/onboarding', { replace: true })
       })
       .catch(err => {
         setErrorMessage(err instanceof Error ? err.message : 'Google 로그인에 실패했습니다.')

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { login, getGoogleLoginUrl } from '@/api/auth'
-
-const ONBOARDING_KEY = 'booklog-onboarding-complete'
 
 const loginSchema = z.object({
   email: z.string().email('올바른 이메일을 입력하세요'),
@@ -24,12 +22,6 @@ export default function LoginPage() {
   const [isGoogleLoading, setIsGoogleLoading] = useState(false)
   const [googleErrorMessage, setGoogleErrorMessage] = useState<string | null>(null)
 
-  // 온보딩을 완료하지 않은 사용자는 온보딩 페이지로 리다이렉트
-  useEffect(() => {
-    if (localStorage.getItem(ONBOARDING_KEY) !== 'true') {
-      navigate('/onboarding', { replace: true })
-    }
-  }, [navigate])
   const {
     register,
     handleSubmit,
@@ -72,7 +64,7 @@ export default function LoginPage() {
         },
         result.accessToken
       )
-      navigate('/')
+      navigate(result.user.onboardingCompleted ? '/' : '/onboarding', { replace: true })
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '로그인에 실패했습니다.')
     } finally {

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
-
-const ONBOARDING_KEY = 'booklog-onboarding-complete'
+import { useAuthStore } from '@/store/authStore'
 
 const slides = [
   {
@@ -46,17 +45,14 @@ const slides = [
 export default function OnboardingPage() {
   const [step, setStep] = useState(0)
   const navigate = useNavigate()
+  const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
+  const completeOnboardingStore = useAuthStore(state => state.completeOnboarding)
 
-  // 이미 온보딩을 완료한 사용자는 바로 로그인 페이지로
-  useEffect(() => {
-    if (localStorage.getItem(ONBOARDING_KEY) === 'true') {
-      navigate('/login', { replace: true })
-    }
-  }, [navigate])
+  if (onboardingCompleted) return <Navigate to="/" replace />
 
   const completeOnboarding = () => {
-    localStorage.setItem(ONBOARDING_KEY, 'true')
-    navigate('/login', { replace: true })
+    completeOnboardingStore()
+    navigate('/', { replace: true })
   }
 
   const handleNext = () => {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -31,7 +31,11 @@ export const router = createBrowserRouter([
   },
   {
     path: '/onboarding',
-    element: <OnboardingPage />,
+    element: (
+      <ProtectedRoute>
+        <OnboardingPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/login',

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -17,6 +17,7 @@ interface AuthState {
   isAuthenticated: boolean
   setAuth: (user: User, accessToken: string) => void
   clearAuth: () => void
+  completeOnboarding: () => void
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -30,6 +31,10 @@ export const useAuthStore = create<AuthState>()(
         set({ user: null, accessToken: null, isAuthenticated: false })
         useAuthStore.persist.clearStorage?.()
       },
+      completeOnboarding: () =>
+        set(state => ({
+          user: state.user ? { ...state.user, onboardingCompleted: true } : null,
+        })),
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
- authStore에 completeOnboarding() 액션 추가
- LoginPage: pre-login localStorage 체크 제거, 로그인 성공 후 onboardingCompleted 분기
- AuthCallbackPage: Google 로그인 성공 후 동일 분기 적용
- OnboardingPage: localStorage → authStore 전환, 완료 유저 가드 추가
- router: OnboardingPage를 ProtectedRoute로 감싸서 인증 필수화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 로그인 후 사용자 온보딩 상태에 따른 경로 이동 로직을 개선했습니다.
  * 온보딩 완료 상태 관리 방식을 업데이트했습니다.
  * 온보딩 페이지 접근 제어를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->