### PR TITLE
feat: 타 유저 프로필 조회 페이지 및 GET API 연동 (#82)

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -55,6 +55,33 @@ export async function updateProfile(data: UpdateProfileRequest): Promise<UpdateP
   }
 }
 
+export interface UserProfile {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+  bio: string | null
+  libraryVisibility: LibraryVisibility
+  followerCount: number
+  followingCount: number
+  reviewCount: number
+  isFollowing: boolean
+  isFollowedBy: boolean
+}
+
+export async function getUserProfile(userId: number, signal?: AbortSignal): Promise<UserProfile> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<UserProfile>>(`/api/v1/users/${userId}`, {
+      signal,
+    })
+    if (!data.data) {
+      throw new Error(data.message ?? '프로필 조회 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '프로필을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
   try {
     await apiClient.put('/api/v1/users/me/password', { currentPassword, newPassword })

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -14,8 +14,8 @@ export default function UserProfilePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const numericUserId = Number(userId)
-  const isValidId = Number.isInteger(numericUserId) && numericUserId > 0
+  const isValidId = /^\d+$/.test(userId ?? '')
+  const numericUserId = isValidId ? parseInt(userId!, 10) : 0
 
   useEffect(() => {
     if (!userId || !isValidId) {

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import axios from 'axios'
+import AppHeader from '@/components/layout/AppHeader'
+import { getUserProfile, type UserProfile } from '@/api/member'
+import { useAuthStore } from '@/store/authStore'
+
+export default function UserProfilePage() {
+  const { userId } = useParams<{ userId: string }>()
+  const navigate = useNavigate()
+  const myUserId = useAuthStore(state => state.user?.id)
+
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const numericUserId = Number(userId)
+  const isValidId = Number.isInteger(numericUserId) && numericUserId > 0
+
+  useEffect(() => {
+    if (!userId || !isValidId) {
+      setErrorMessage('잘못된 사용자 ID입니다.')
+      setIsLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const result = await getUserProfile(numericUserId, controller.signal)
+        if (controller.signal.aborted) return
+        setProfile(result)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '프로필을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [userId, isValidId, numericUserId])
+
+  if (myUserId && numericUserId === myUserId) {
+    return <Navigate to="/profile" replace />
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="프로필" showBack />
+        <main aria-busy="true" className="flex flex-1 items-center justify-center">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        </main>
+      </div>
+    )
+  }
+
+  if (errorMessage || !profile) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="프로필" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4">
+          <span className="material-symbols-outlined text-6xl text-muted-foreground/30">error</span>
+          <p role="alert" className="text-lg font-bold text-muted-foreground">
+            {errorMessage ?? '프로필을 불러올 수 없습니다.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            돌아가기
+          </button>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="프로필" showBack />
+
+      <main className="flex-1 overflow-y-auto pb-12">
+        {/* Profile Intro */}
+        <section className="px-6 pt-8 text-center">
+          <div className="mx-auto mb-5 flex h-36 w-36 items-center justify-center rounded-full bg-primary/10">
+            {profile.profileImageUrl ? (
+              <img
+                src={profile.profileImageUrl}
+                alt={`${profile.nickname} 프로필 이미지`}
+                className="h-32 w-32 rounded-full object-cover"
+              />
+            ) : (
+              <span className="material-symbols-outlined text-6xl text-muted-foreground/40">
+                person
+              </span>
+            )}
+          </div>
+
+          <h1 className="text-3xl font-bold tracking-tight">{profile.nickname}</h1>
+          {profile.bio && (
+            <p className="mx-auto mt-3 max-w-[320px] whitespace-pre-wrap text-base leading-7 text-primary/80">
+              {profile.bio}
+            </p>
+          )}
+
+          {/* TODO(Follow): 팔로워/팔로잉 목록 페이지 연동 시 disabled 제거 + onClick 추가 */}
+          <div className="mt-6 flex items-center justify-center gap-4 text-base font-medium text-primary/80">
+            <button type="button" disabled aria-disabled="true">
+              팔로워 {profile.followerCount}
+            </button>
+            <span className="text-primary/30">|</span>
+            <button type="button" disabled aria-disabled="true">
+              팔로잉 {profile.followingCount}
+            </button>
+          </div>
+        </section>
+
+        {/* Follow Button */}
+        <section className="px-6 pt-6">
+          {/* TODO(Follow): Follow 도메인 개발 시 isFollowing 상태에 따라 팔로우/언팔로우 토글 구현 */}
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className="w-full rounded-xl bg-primary/60 py-4 text-lg font-bold text-primary-foreground shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            팔로우 (준비 중)
+          </button>
+        </section>
+
+        {/* Stats */}
+        <section className="px-6 pt-8">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-[24px] bg-card px-3 py-5 text-center shadow-sm">
+              <p className="text-xs font-semibold text-primary/60">팔로워</p>
+              <p className="mt-2 text-3xl font-bold text-primary">{profile.followerCount}</p>
+            </div>
+            <div className="rounded-[24px] bg-card px-3 py-5 text-center shadow-sm">
+              <p className="text-xs font-semibold text-primary/60">팔로잉</p>
+              <p className="mt-2 text-3xl font-bold text-primary">{profile.followingCount}</p>
+            </div>
+            <div className="rounded-[24px] bg-card px-3 py-5 text-center shadow-sm">
+              <p className="text-xs font-semibold text-primary/60">감상</p>
+              <p className="mt-2 text-3xl font-bold text-primary">{profile.reviewCount}개</p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -19,6 +19,7 @@ import EmailVerificationPage from '@/pages/EmailVerificationPage'
 import PasswordChangePage from '@/pages/PasswordChangePage'
 import WithdrawPage from '@/pages/WithdrawPage'
 import EditProfilePage from '@/pages/EditProfilePage'
+import UserProfilePage from '@/pages/UserProfilePage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -115,6 +116,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <MyProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/user/:userId',
+    element: (
+      <ProtectedRoute>
+        <UserProfilePage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
- api/member.ts에 getUserProfile() 함수 및 UserProfile 타입 추가
- UserProfilePage 신규 생성 (프로필 정보, 팔로워/팔로잉/리뷰 수 표시)
- 자기 자신 접근 시 /profile로 리다이렉트
- 팔로우/팔로워/팔로잉 버튼 disabled + TODO(Follow) 주석
- /user/:userId 라우트 추가 (ProtectedRoute)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 다른 사용자의 프로필 페이지가 추가되었습니다. 프로필 이미지(기본 아이콘 포함), 닉네임, 소개, 팔로워/팔로잉/리뷰 통계가 표시됩니다.
  * 인증된 사용자만 접근 가능한 사용자별 프로필 경로가 추가되며, 본인 페이지 요청 시 개인 프로필로 리다이렉트됩니다.
  * 잘못된 ID나 로딩/오류 상황에 대한 사용자 메시지와 뒤로가기 버튼이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->