### PR TITLE
feat: 서재 도서 추가 API 연동 (#84)

### DIFF
--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -1,0 +1,49 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
+import type { BackendReadingStatus } from './book'
+import type { ReadingStatus } from '@/types'
+
+export const frontToBackendStatus: Record<ReadingStatus, BackendReadingStatus> = {
+  want_to_read: 'WANT_TO_READ',
+  reading: 'READING',
+  finished: 'FINISHED',
+  stopped: 'STOPPED',
+}
+
+export const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
+  WANT_TO_READ: 'want_to_read',
+  READING: 'reading',
+  FINISHED: 'finished',
+  STOPPED: 'stopped',
+}
+
+export interface LibraryBookAddResponse {
+  libraryBookId: number
+  bookId: number
+  status: BackendReadingStatus
+  startedAt: string | null
+  finishedAt: string | null
+}
+
+// AbortSignal 미지원 유지: POST는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
+// (실제로 DB 쓰기가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
+export async function addLibraryBook(
+  bookId: number,
+  status: ReadingStatus
+): Promise<LibraryBookAddResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<LibraryBookAddResponse>>('/api/v1/library', {
+      bookId,
+      status: frontToBackendStatus[status],
+    })
+    if (!data.data) {
+      throw new Error(data.message ?? '서재 추가 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '서재에 도서를 추가하지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}

--- a/src/components/common/AddToLibrarySheet.tsx
+++ b/src/components/common/AddToLibrarySheet.tsx
@@ -2,12 +2,10 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ReadingStatus } from '@/types'
 
-// API 연동 시 props에 book: Book 추가하고,
-// handleSave에서 POST /api/v1/library { isbn: book.isbn, status: selected } 형태로 사용.
 interface AddToLibrarySheetProps {
   isOpen: boolean
   onClose: () => void
-  onSave: (status: ReadingStatus) => void
+  onSave: (status: ReadingStatus) => void | Promise<void>
   bookId: string
   defaultStatus?: ReadingStatus
 }
@@ -24,30 +22,55 @@ export default function AddToLibrarySheet({
   onClose,
   onSave,
   bookId,
-  defaultStatus = 'want_to_read',
+  defaultStatus,
 }: AddToLibrarySheetProps) {
-  const [selected, setSelected] = useState<ReadingStatus>(defaultStatus)
-  useEffect(() => {
-    setSelected(defaultStatus)
-  }, [defaultStatus])
+  const [selected, setSelected] = useState<ReadingStatus>(defaultStatus ?? 'want_to_read')
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const navigate = useNavigate()
+
+  // 이미 서재에 있는 도서의 상태 변경은 L4(PATCH /library/{id}/status)에서 처리 예정
+  const isAlreadyInLibrary = defaultStatus != null
+
+  useEffect(() => {
+    setSelected(defaultStatus ?? 'want_to_read')
+    setSaveError(null)
+  }, [defaultStatus, isOpen])
 
   if (!isOpen) return null
 
-  const handleSave = () => {
-    onSave(selected)
+  const handleSave = async () => {
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await onSave(selected)
+      onClose()
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : '저장에 실패했습니다.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleOverlayClose = () => {
+    if (isSaving) return
     onClose()
   }
 
   return (
     <div className="fixed inset-0 z-50 mx-auto flex max-w-[430px] flex-col justify-end">
       {/* Overlay */}
-      <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" onClick={handleOverlayClose} />
 
       {/* Bottom Sheet */}
       <div className="relative flex flex-col items-stretch overflow-hidden rounded-t-xl bg-card shadow-2xl ring-1 ring-black/5">
         {/* Handle */}
-        <button className="flex h-6 w-full items-center justify-center pt-2" onClick={onClose}>
+        <button
+          className="flex h-6 w-full items-center justify-center pt-2"
+          onClick={handleOverlayClose}
+          disabled={isSaving}
+          aria-label="시트 닫기"
+        >
           <div className="h-1.5 w-12 rounded-full bg-primary/20" />
         </button>
 
@@ -56,17 +79,31 @@ export default function AddToLibrarySheet({
             독서 상태 선택
           </h1>
 
+          {isAlreadyInLibrary && (
+            <p
+              role="status"
+              className="mx-6 mb-3 rounded-lg bg-primary/5 px-4 py-3 text-center text-xs text-muted-foreground"
+            >
+              이미 서재에 있는 도서입니다. 상태 변경 기능은 준비 중입니다.
+            </p>
+          )}
+
           <div className="flex flex-col gap-3 px-6 py-2">
             {statusOptions.map(option => (
               <label
                 key={option.value}
-                className="flex cursor-pointer flex-row-reverse items-center gap-4 rounded-xl border border-primary/10 p-4 transition-colors hover:bg-primary/5"
+                className={`flex flex-row-reverse items-center gap-4 rounded-xl border border-primary/10 p-4 transition-colors ${
+                  isAlreadyInLibrary || isSaving
+                    ? 'cursor-not-allowed opacity-60'
+                    : 'cursor-pointer hover:bg-primary/5'
+                }`}
               >
                 <input
                   type="radio"
                   name="reading-status"
                   checked={selected === option.value}
                   onChange={() => setSelected(option.value)}
+                  disabled={isAlreadyInLibrary || isSaving}
                   className="size-5 border-2 border-primary/30 bg-transparent text-primary focus:outline-none focus:ring-0 focus:ring-offset-0"
                 />
                 <div className="flex grow items-center gap-3">
@@ -77,19 +114,31 @@ export default function AddToLibrarySheet({
             ))}
           </div>
 
+          {saveError && (
+            <p
+              role="alert"
+              aria-atomic="true"
+              className="mx-6 mt-3 rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {saveError}
+            </p>
+          )}
+
           <div className="flex flex-col gap-4 px-6 py-6 pb-10">
             <button
               onClick={handleSave}
-              className="flex h-14 w-full cursor-pointer items-center justify-center rounded-xl bg-primary text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98]"
+              disabled={isAlreadyInLibrary || isSaving}
+              className="flex h-14 w-full items-center justify-center rounded-xl bg-primary text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
             >
-              저장
+              {isSaving ? '저장 중...' : '저장'}
             </button>
             <button
               onClick={() => {
                 onClose()
                 navigate(`/review/write/${bookId}`)
               }}
-              className="text-sm font-semibold text-primary underline decoration-primary/30 underline-offset-4 transition-colors hover:text-primary/80"
+              disabled={isSaving}
+              className="text-sm font-semibold text-primary underline decoration-primary/30 underline-offset-4 transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-60"
             >
               감상 메모 남기기
             </button>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -6,6 +6,7 @@ import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
 import { getBook, type BookDetail, type BackendReadingStatus } from '@/api/book'
+import { addLibraryBook } from '@/api/library'
 import type { ReadingStatus } from '@/types'
 
 const statusEmoji: Record<ReadingStatus, string> = {
@@ -15,6 +16,7 @@ const statusEmoji: Record<ReadingStatus, string> = {
   stopped: '⏸️ 중단',
 }
 
+// TODO(후속): backendToFrontStatus 맵이 @/api/library 에도 동일하게 export되어 있어 중복. 후속 리팩터 이슈에서 통합 예정.
 const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
   WANT_TO_READ: 'want_to_read',
   READING: 'reading',
@@ -22,6 +24,9 @@ const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
   STOPPED: 'stopped',
 }
 
+// toFrontStatus 유지 이유: getBook 응답의 myLibraryStatus는 string | null 타입(백엔드 Nullable)으로 내려오므로
+// 방어적 null 변환이 필요하다. addLibraryBook 응답은 BackendReadingStatus로 타입 보장되지만, 여기서는
+// 동일한 변환기를 재사용하여 호출부 단순화를 유지한다. 백엔드 enum이 확장되면 exhaustive map으로 이행 고려.
 function toFrontStatus(s: string | null): ReadingStatus | null {
   if (s && s in backendToFrontStatus) {
     return backendToFrontStatus[s as BackendReadingStatus]
@@ -36,7 +41,6 @@ export default function BookDetailPage() {
   const [book, setBook] = useState<BookDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  // TODO(B3): Library API 연동 시 savedStatus를 API 호출로 대체하고 myLibraryStatus와 동기화
   const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
 
   const parsedBookId = bookId ? Number(bookId) : NaN
@@ -114,6 +118,15 @@ export default function BookDetailPage() {
     } else {
       navigate(`/review/write/${book.bookId}`)
     }
+  }
+
+  const handleSaveLibraryStatus = async (status: ReadingStatus) => {
+    // TODO(L4): 이미 서재에 있는 도서의 상태 변경은 PATCH /api/v1/library/{libraryBookId}/status 연동 필요.
+    // 현재는 AddToLibrarySheet에서 disabled 처리되어 이 경로는 호출되지 않지만 방어적으로 유지한다.
+    if (savedStatus) return
+
+    const result = await addLibraryBook(book.bookId, status)
+    setSavedStatus(toFrontStatus(result.status))
   }
 
   return (
@@ -237,7 +250,7 @@ export default function BookDetailPage() {
       <AddToLibrarySheet
         isOpen={sheetOpen}
         onClose={() => setSheetOpen(false)}
-        onSave={setSavedStatus}
+        onSave={handleSaveLibraryStatus}
         bookId={String(book.bookId)}
         defaultStatus={savedStatus ?? undefined}
       />


### PR DESCRIPTION
- api/library.ts 신규 - addLibraryBook() 및 frontToBackendStatus 맵 추가

- BookDetailPage에서 AddToLibrarySheet onSave를 POST API 호출로 교체

- AddToLibrarySheet: onSave await 후 성공 시에만 close, 에러는 내부에서 표시

- 이미 서재에 있는 도서는 라디오/저장 disabled + L4 준비중 안내 (TODO L4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서를 라이브러리에 추가하는 기능 추가
  * 저장 중 진행 상태를 실시간으로 표시
  * 저장 실패 시 오류 메시지 표시
  * 저장 진행 중 시트 닫기 방지
  * 이미 라이브러리에 있는 도서의 상태 변경 지원 (나중에 적용)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->