### PR TITLE
feat: 서재 도서 제거 DELETE API 연동 (#91)

### DIFF
--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -123,6 +123,19 @@ export async function getMyLibrary({
   }
 }
 
+// AbortSignal 미지원 유지: DELETE는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
+// (실제로 DB 삭제가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
+export async function removeLibraryBook(libraryBookId: number): Promise<void> {
+  try {
+    await apiClient.delete(`/api/v1/library/${libraryBookId}`)
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '서재에서 도서를 제거하지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
 // AbortSignal 미지원 유지: POST는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
 // (실제로 DB 쓰기가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
 export async function addLibraryBook(

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -1,9 +1,22 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams, Link } from 'react-router-dom'
 import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import StarRating from '@/components/common/StarRating'
-import { getLibraryBookDetail, backendToFrontStatus, type LibraryBookDetail } from '@/api/library'
+import {
+  getLibraryBookDetail,
+  removeLibraryBook,
+  backendToFrontStatus,
+  type LibraryBookDetail,
+} from '@/api/library'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import type { ReadingStatus } from '@/types'
 
 const statusLabel: Record<ReadingStatus, { text: string; emoji: string; bg: string }> = {
@@ -42,6 +55,20 @@ export default function LibraryBookDetailPage() {
   const [detail, setDetail] = useState<LibraryBookDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [removeError, setRemoveError] = useState<string | null>(null)
+  const isMountedRef = useRef(true)
+  // 액션시트 → 확인 다이얼로그 전환 시, 닫기 직후 띄울 단계를 보관 (HIGH 1: 두 Dialog 동시 활성 회피)
+  const pendingActionRef = useRef<'remove' | null>(null)
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false
+    },
+    []
+  )
 
   useEffect(() => {
     // 파생값을 effect 내부에서 다시 산출해 deps를 libraryBookId 하나로 단순화
@@ -110,6 +137,42 @@ export default function LibraryBookDetailPage() {
     )
   }
 
+  const handleConfirmRemove = async () => {
+    if (isProcessing) return
+    setIsProcessing(true)
+    setRemoveError(null)
+    try {
+      await removeLibraryBook(detail.libraryBookId)
+      if (!isMountedRef.current) return
+      setIsConfirmOpen(false)
+      setIsProcessing(false)
+      navigate('/library', { replace: true })
+    } catch (error) {
+      // unmount 이후 setState 방지 (브라우저 뒤로가기 등)
+      if (!isMountedRef.current) return
+      setRemoveError(error instanceof Error ? error.message : '서재에서 제거하지 못했습니다.')
+      setIsProcessing(false)
+    }
+  }
+
+  const openRemoveConfirm = () => {
+    setRemoveError(null)
+    pendingActionRef.current = 'remove'
+    setIsMenuOpen(false)
+  }
+
+  // 액션시트가 닫힌 직후, 보류된 다음 단계가 있으면 실행 (Dialog 동시 활성 회피)
+  const handleMenuOpenChange = (open: boolean) => {
+    setIsMenuOpen(open)
+    if (!open && pendingActionRef.current === 'remove') {
+      pendingActionRef.current = null
+      // requestAnimationFrame으로 Radix Dialog가 unmount/포커스 복귀를 마친 다음 프레임에 confirm을 띄운다.
+      requestAnimationFrame(() => {
+        if (isMountedRef.current) setIsConfirmOpen(true)
+      })
+    }
+  }
+
   // 백엔드 enum이 미지원 값이어도 페이지가 크래시하지 않도록 방어
   const frontStatus: ReadingStatus | undefined = backendToFrontStatus[detail.status]
   const status = frontStatus ? statusLabel[frontStatus] : null
@@ -130,9 +193,9 @@ export default function LibraryBookDetailPage() {
         rightAction={
           <button
             type="button"
-            disabled
-            aria-label="더보기 (준비 중)"
-            className="flex size-10 items-center justify-center rounded-full text-primary/40"
+            onClick={() => setIsMenuOpen(true)}
+            aria-label="더보기"
+            className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
           >
             <span className="material-symbols-outlined">more_vert</span>
           </button>
@@ -262,6 +325,82 @@ export default function LibraryBookDetailPage() {
           </Link>
         </section>
       </main>
+
+      {/* 더보기 액션시트 (TODO(L4): 독서 상태 변경 / 감상 쓰기 항목 추가 예정) */}
+      <Dialog open={isMenuOpen} onOpenChange={handleMenuOpenChange}>
+        {/* pt-12: Dialog 내장 X 닫기 버튼(우상단)이 첫 메뉴 항목과 겹치지 않도록 여백 확보 */}
+        <DialogContent className="max-w-sm gap-0 p-0 pt-12">
+          <DialogHeader className="sr-only">
+            <DialogTitle>서재 도서 액션</DialogTitle>
+            <DialogDescription>이 서재 도서에 대해 수행할 동작을 선택하세요.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col">
+            <button
+              type="button"
+              onClick={openRemoveConfirm}
+              className="flex items-center gap-3 px-6 py-4 text-left text-base font-semibold text-destructive transition-colors hover:bg-destructive/5"
+            >
+              <span aria-hidden="true" className="material-symbols-outlined text-[20px]">
+                delete
+              </span>
+              서재에서 제거
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 제거 확인 다이얼로그 */}
+      <Dialog
+        open={isConfirmOpen}
+        onOpenChange={open => {
+          if (isProcessing && !open) return
+          setIsConfirmOpen(open)
+        }}
+      >
+        <DialogContent
+          aria-busy={isProcessing}
+          onInteractOutside={e => {
+            if (isProcessing) e.preventDefault()
+          }}
+          onEscapeKeyDown={e => {
+            if (isProcessing) e.preventDefault()
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>서재에서 제거하시겠습니까?</DialogTitle>
+            <DialogDescription>
+              제거하면 이 도서의 독서 기록과 감상이 모두 삭제될 수 있으며, 되돌릴 수 없습니다.
+            </DialogDescription>
+          </DialogHeader>
+          {removeError && (
+            <p
+              role="alert"
+              aria-atomic="true"
+              className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {removeError}
+            </p>
+          )}
+          <DialogFooter className="gap-2">
+            <button
+              type="button"
+              onClick={() => setIsConfirmOpen(false)}
+              disabled={isProcessing}
+              className="rounded-lg border border-primary/20 bg-card px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-primary/5 disabled:opacity-60"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmRemove}
+              disabled={isProcessing}
+              className="rounded-lg bg-destructive px-5 py-3 text-sm font-semibold text-destructive-foreground transition-all hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isProcessing ? '처리 중...' : '제거하기'}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -60,15 +60,15 @@ export default function LibraryBookDetailPage() {
   const [isProcessing, setIsProcessing] = useState(false)
   const [removeError, setRemoveError] = useState<string | null>(null)
   const isMountedRef = useRef(true)
-  // 액션시트 → 확인 다이얼로그 전환 시, 닫기 직후 띄울 단계를 보관 (HIGH 1: 두 Dialog 동시 활성 회피)
-  const pendingActionRef = useRef<'remove' | null>(null)
 
-  useEffect(
-    () => () => {
+  // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
+  // setup에서 명시적으로 true로 리셋해 ref가 false로 stuck되지 않도록 한다.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
       isMountedRef.current = false
-    },
-    []
-  )
+    }
+  }, [])
 
   useEffect(() => {
     // 파생값을 effect 내부에서 다시 산출해 deps를 libraryBookId 하나로 단순화
@@ -157,20 +157,13 @@ export default function LibraryBookDetailPage() {
 
   const openRemoveConfirm = () => {
     setRemoveError(null)
-    pendingActionRef.current = 'remove'
     setIsMenuOpen(false)
-  }
-
-  // 액션시트가 닫힌 직후, 보류된 다음 단계가 있으면 실행 (Dialog 동시 활성 회피)
-  const handleMenuOpenChange = (open: boolean) => {
-    setIsMenuOpen(open)
-    if (!open && pendingActionRef.current === 'remove') {
-      pendingActionRef.current = null
-      // requestAnimationFrame으로 Radix Dialog가 unmount/포커스 복귀를 마친 다음 프레임에 confirm을 띄운다.
-      requestAnimationFrame(() => {
-        if (isMountedRef.current) setIsConfirmOpen(true)
-      })
-    }
+    // Radix는 programmatic close 시 onOpenChange를 발화하지 않으므로,
+    // 액션시트 unmount/포커스 복귀를 기다린 다음 프레임에 confirm을 직접 띄운다.
+    // (HIGH 1: 두 Dialog 동시 활성 회피)
+    requestAnimationFrame(() => {
+      if (isMountedRef.current) setIsConfirmOpen(true)
+    })
   }
 
   // 백엔드 enum이 미지원 값이어도 페이지가 크래시하지 않도록 방어
@@ -327,7 +320,7 @@ export default function LibraryBookDetailPage() {
       </main>
 
       {/* 더보기 액션시트 (TODO(L4): 독서 상태 변경 / 감상 쓰기 항목 추가 예정) */}
-      <Dialog open={isMenuOpen} onOpenChange={handleMenuOpenChange}>
+      <Dialog open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         {/* pt-12: Dialog 내장 X 닫기 버튼(우상단)이 첫 메뉴 항목과 겹치지 않도록 여백 확보 */}
         <DialogContent className="max-w-sm gap-0 p-0 pt-12">
           <DialogHeader className="sr-only">


### PR DESCRIPTION
- api/library.ts에 removeLibraryBook() 함수 추가 (AbortSignal 미지원 사유 주석)

- LibraryBookDetailPage 헤더 더보기 버튼 활성화

- 액션시트 Dialog → 확인 Dialog 2단계 흐름 (WithdrawPage 패턴 미러링)

- 성공 시 /library replace navigate, 실패 시 다이얼로그 내부에 에러 표시

- HIGH: requestAnimationFrame으로 두 Dialog 동시 활성 회피

- MEDIUM: isMountedRef로 unmount 후 setState 방지, 액션시트 X 버튼 겹침 패딩 추가, 처리 중 aria-busy 표시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서관 도서 상세 페이지에서 도서 제거 기능 추가: "더보기" 메뉴로 작업을 선택하면 확인 대화상자가 표시되며, 삭제 완료 시 자동으로 도서관 목록으로 이동합니다.

* **버그 수정 / 안정성**
  * 삭제 처리 중 UI 상호작용이 비활성화되어 중복 요청을 방지합니다.
  * 삭제 실패 시 사용자에게 경고 메시지를 표시하고 대화상자를 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->