### PR TITLE
feat: 독서 상태 변경 PATCH API 연동 (#95)

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -35,6 +35,7 @@ export interface BookDetail {
   averageRating: number | null
   reviewCount: number | null
   myLibraryStatus: BackendReadingStatus | null
+  myLibraryBookId: number | null
   myReviewId: number | null
 }
 

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -169,6 +169,33 @@ export async function getMyLibrary({
   }
 }
 
+export interface LibraryStatusUpdateResponse {
+  libraryBookId: number
+  status: BackendReadingStatus
+  startedAt: string | null
+  finishedAt: string | null
+}
+
+// AbortSignal 미지원 유지: PATCH는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
+// (실제로 DB 쓰기가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
+export async function updateLibraryBookStatus(
+  libraryBookId: number,
+  status: ReadingStatus
+): Promise<LibraryStatusUpdateResponse> {
+  try {
+    const { data } = await apiClient.patch<ApiResponse<LibraryStatusUpdateResponse>>(
+      `/api/v1/library/${libraryBookId}/status`,
+      { status: frontToBackendStatus[status] }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '독서 상태 변경 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '독서 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
 // AbortSignal 미지원 유지: DELETE는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
 // (실제로 DB 삭제가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
 export async function removeLibraryBook(libraryBookId: number): Promise<void> {

--- a/src/components/common/AddToLibrarySheet.tsx
+++ b/src/components/common/AddToLibrarySheet.tsx
@@ -29,9 +29,6 @@ export default function AddToLibrarySheet({
   const [saveError, setSaveError] = useState<string | null>(null)
   const navigate = useNavigate()
 
-  // 이미 서재에 있는 도서의 상태 변경은 L4(PATCH /library/{id}/status)에서 처리 예정
-  const isAlreadyInLibrary = defaultStatus != null
-
   useEffect(() => {
     setSelected(defaultStatus ?? 'want_to_read')
     setSaveError(null)
@@ -79,23 +76,12 @@ export default function AddToLibrarySheet({
             독서 상태 선택
           </h1>
 
-          {isAlreadyInLibrary && (
-            <p
-              role="status"
-              className="mx-6 mb-3 rounded-lg bg-primary/5 px-4 py-3 text-center text-xs text-muted-foreground"
-            >
-              이미 서재에 있는 도서입니다. 상태 변경 기능은 준비 중입니다.
-            </p>
-          )}
-
           <div className="flex flex-col gap-3 px-6 py-2">
             {statusOptions.map(option => (
               <label
                 key={option.value}
                 className={`flex flex-row-reverse items-center gap-4 rounded-xl border border-primary/10 p-4 transition-colors ${
-                  isAlreadyInLibrary || isSaving
-                    ? 'cursor-not-allowed opacity-60'
-                    : 'cursor-pointer hover:bg-primary/5'
+                  isSaving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-primary/5'
                 }`}
               >
                 <input
@@ -103,7 +89,7 @@ export default function AddToLibrarySheet({
                   name="reading-status"
                   checked={selected === option.value}
                   onChange={() => setSelected(option.value)}
-                  disabled={isAlreadyInLibrary || isSaving}
+                  disabled={isSaving}
                   className="size-5 border-2 border-primary/30 bg-transparent text-primary focus:outline-none focus:ring-0 focus:ring-offset-0"
                 />
                 <div className="flex grow items-center gap-3">
@@ -127,7 +113,7 @@ export default function AddToLibrarySheet({
           <div className="flex flex-col gap-4 px-6 py-6 pb-10">
             <button
               onClick={handleSave}
-              disabled={isAlreadyInLibrary || isSaving}
+              disabled={isSaving}
               className="flex h-14 w-full items-center justify-center rounded-xl bg-primary text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isSaving ? '저장 중...' : '저장'}

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
@@ -6,7 +6,7 @@ import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
 import { getBook, type BookDetail, type BackendReadingStatus } from '@/api/book'
-import { addLibraryBook } from '@/api/library'
+import { addLibraryBook, updateLibraryBookStatus } from '@/api/library'
 import type { ReadingStatus } from '@/types'
 
 const statusEmoji: Record<ReadingStatus, string> = {
@@ -42,6 +42,16 @@ export default function BookDetailPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
+  const isMountedRef = useRef(true)
+
+  // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
+  // setup에서 명시적으로 true로 리셋해 ref가 false로 stuck되지 않도록 한다.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   const parsedBookId = bookId ? Number(bookId) : NaN
   const isValidBookId = Number.isInteger(parsedBookId) && parsedBookId > 0
@@ -121,12 +131,19 @@ export default function BookDetailPage() {
   }
 
   const handleSaveLibraryStatus = async (status: ReadingStatus) => {
-    // TODO(L4): 이미 서재에 있는 도서의 상태 변경은 PATCH /api/v1/library/{libraryBookId}/status 연동 필요.
-    // 현재는 AddToLibrarySheet에서 disabled 처리되어 이 경로는 호출되지 않지만 방어적으로 유지한다.
-    if (savedStatus) return
-
+    if (book.myLibraryBookId != null) {
+      // 이미 서재에 있는 도서 → PATCH로 상태만 변경
+      const result = await updateLibraryBookStatus(book.myLibraryBookId, status)
+      if (!isMountedRef.current) return
+      // unknown enum 응답이면 사용자가 방금 선택한 status를 fallback으로 유지 (CTA가 "내 서재에 추가"로 회귀하는 오해 방지)
+      setSavedStatus(toFrontStatus(result.status) ?? status)
+      return
+    }
+    // 신규 추가 → POST. 응답의 libraryBookId를 로컬 book 상태에 반영해 다음 수정이 PATCH로 가도록 한다.
     const result = await addLibraryBook(book.bookId, status)
-    setSavedStatus(toFrontStatus(result.status))
+    if (!isMountedRef.current) return
+    setSavedStatus(toFrontStatus(result.status) ?? status)
+    setBook(prev => (prev ? { ...prev, myLibraryBookId: result.libraryBookId } : prev))
   }
 
   return (

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -6,9 +6,11 @@ import StarRating from '@/components/common/StarRating'
 import {
   getLibraryBookDetail,
   removeLibraryBook,
+  updateLibraryBookStatus,
   backendToFrontStatus,
   type LibraryBookDetail,
 } from '@/api/library'
+import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
 import {
   Dialog,
   DialogContent,
@@ -57,6 +59,7 @@ export default function LibraryBookDetailPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isStatusSheetOpen, setIsStatusSheetOpen] = useState(false)
   const [isProcessing, setIsProcessing] = useState(false)
   const [removeError, setRemoveError] = useState<string | null>(null)
   const isMountedRef = useRef(true)
@@ -155,6 +158,21 @@ export default function LibraryBookDetailPage() {
     }
   }
 
+  const handleStatusChange = async (status: ReadingStatus) => {
+    const result = await updateLibraryBookStatus(detail.libraryBookId, status)
+    if (!isMountedRef.current) return
+    setDetail(prev =>
+      prev
+        ? {
+            ...prev,
+            status: result.status,
+            startedAt: result.startedAt,
+            finishedAt: result.finishedAt,
+          }
+        : prev
+    )
+  }
+
   const openRemoveConfirm = () => {
     setRemoveError(null)
     setIsMenuOpen(false)
@@ -235,12 +253,10 @@ export default function LibraryBookDetailPage() {
                 </span>
                 <span className="text-lg font-bold">{status.text}</span>
               </div>
-              {/* TODO(L4): 백엔드 myLibraryBookId 필드 추가 후 활성화 → AddToLibrarySheet 또는 액션시트 트리거 */}
               <button
                 type="button"
-                disabled
-                aria-label="독서 상태 변경 (준비 중)"
-                className="rounded-full border border-primary/40 px-4 py-2 text-sm font-semibold text-primary/40"
+                onClick={() => setIsStatusSheetOpen(true)}
+                className="rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary/5"
               >
                 상태 변경
               </button>
@@ -319,7 +335,16 @@ export default function LibraryBookDetailPage() {
         </section>
       </main>
 
-      {/* 더보기 액션시트 (TODO(L4): 독서 상태 변경 / 감상 쓰기 항목 추가 예정) */}
+      {/* 독서 상태 변경 시트 */}
+      <AddToLibrarySheet
+        isOpen={isStatusSheetOpen}
+        onClose={() => setIsStatusSheetOpen(false)}
+        onSave={handleStatusChange}
+        bookId={String(detail.book.bookId)}
+        defaultStatus={frontStatus}
+      />
+
+      {/* 더보기 액션시트 (TODO: 감상 쓰기 항목 추가 예정) */}
       <Dialog open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         {/* pt-12: Dialog 내장 X 닫기 버튼(우상단)이 첫 메뉴 항목과 겹치지 않도록 여백 확보 */}
         <DialogContent className="max-w-sm gap-0 p-0 pt-12">

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   removeLibraryBook,
   updateLibraryBookStatus,
   backendToFrontStatus,
+  frontToBackendStatus,
   type LibraryBookDetail,
 } from '@/api/library'
 import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
@@ -161,11 +162,14 @@ export default function LibraryBookDetailPage() {
   const handleStatusChange = async (status: ReadingStatus) => {
     const result = await updateLibraryBookStatus(detail.libraryBookId, status)
     if (!isMountedRef.current) return
+    // unknown enum 응답 시 사용자가 방금 선택한 status로 fallback (BookDetailPage와 동일 정책)
+    const nextStatus =
+      backendToFrontStatus[result.status] != null ? result.status : frontToBackendStatus[status]
     setDetail(prev =>
       prev
         ? {
             ...prev,
-            status: result.status,
+            status: nextStatus,
             startedAt: result.startedAt,
             finishedAt: result.finishedAt,
           }


### PR DESCRIPTION
- api/library.ts: updateLibraryBookStatus() + LibraryStatusUpdateResponse 타입 추가

- api/book.ts: BookDetail.myLibraryBookId 필드 추가

- BookDetailPage: handleSaveLibraryStatus를 add/patch로 분기, POST 성공 시 myLibraryBookId 로컬 반영

- AddToLibrarySheet: isAlreadyInLibrary disabled/안내 제거, add/patch 모두 동일하게 동작

- LibraryBookDetailPage: 상태 변경 버튼 활성화, AddToLibrarySheet 통합, handleStatusChange로 detail 로컬 갱신

- 리뷰 반영: BookDetailPage isMountedRef 가드, unknown enum 시 사용자 선택 status fallback, 중복 aria-label 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도서관에 추가된 책의 읽기 상태를 화면에서 직접 수정할 수 있습니다.
  * 상태 변경 시 시작일/완료일을 포함한 상태 정보가 동기화됩니다.
  * 상태 변경용 시트(모달)가 상세 화면에 통합되어 즉시 편집 가능합니다.

* **개선 사항**
  * 신규 추가와 기존 도서 상태 업데이트가 자동으로 구분되어 원활하게 저장됩니다.
  * 저장 화면의 인터랙션과 비활성화 로직이 단순화되어 더 일관된 UI가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->