### PR TITLE
feat: 팔로우/언팔로우 API 연동 (#97)

### DIFF
--- a/src/api/follow.ts
+++ b/src/api/follow.ts
@@ -1,0 +1,48 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
+
+export interface FollowResponse {
+  followId: number
+  followingUserId: number
+  followerCount: number
+  followingCount: number
+}
+
+// 백엔드 명세상 unfollow 응답은 카운트만 반환 (followId/followingUserId 없음)
+export interface UnfollowResponse {
+  followerCount: number
+  followingCount: number
+}
+
+// AbortSignal 미지원 유지: POST는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
+// (실제로 DB 쓰기가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
+export async function followUser(userId: number): Promise<FollowResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<FollowResponse>>(
+      `/api/v1/users/${userId}/follow`,
+      null
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '팔로우 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '팔로우에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+// AbortSignal 미지원 유지: DELETE는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
+// (실제로 DB 삭제가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
+export async function unfollowUser(userId: number): Promise<UnfollowResponse> {
+  try {
+    const { data } = await apiClient.delete<ApiResponse<UnfollowResponse>>(
+      `/api/v1/users/${userId}/follow`
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '언팔로우 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '언팔로우에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import { getUserProfile, type UserProfile } from '@/api/member'
+import { followUser, unfollowUser } from '@/api/follow'
 import { useAuthStore } from '@/store/authStore'
 
 export default function UserProfilePage() {
@@ -13,6 +14,18 @@ export default function UserProfilePage() {
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isFollowProcessing, setIsFollowProcessing] = useState(false)
+  const [followError, setFollowError] = useState<string | null>(null)
+  const isMountedRef = useRef(true)
+
+  // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
+  // setup에서 명시적으로 true로 리셋해 ref가 false로 stuck되지 않도록 한다.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   const isValidId = /^\d+$/.test(userId ?? '')
   const numericUserId = isValidId ? parseInt(userId!, 10) : 0
@@ -81,6 +94,51 @@ export default function UserProfilePage() {
     )
   }
 
+  const handleToggleFollow = async () => {
+    if (isFollowProcessing) return
+    // 결정 시점 스냅샷: 호출 직후 외부에서 profile.isFollowing이 바뀌어도 분기를 일관되게 유지
+    // (미래 옵티미스틱 업데이트/외부 갱신 도입 시 회귀 방지)
+    const wasFollowing = profile.isFollowing
+    setIsFollowProcessing(true)
+    setFollowError(null)
+    try {
+      if (wasFollowing) {
+        const result = await unfollowUser(profile.userId)
+        if (!isMountedRef.current) return
+        setProfile(prev =>
+          prev
+            ? {
+                ...prev,
+                isFollowing: false,
+                followerCount: Number.isFinite(result.followerCount)
+                  ? result.followerCount
+                  : prev.followerCount,
+              }
+            : prev
+        )
+      } else {
+        const result = await followUser(profile.userId)
+        if (!isMountedRef.current) return
+        setProfile(prev =>
+          prev
+            ? {
+                ...prev,
+                isFollowing: true,
+                followerCount: Number.isFinite(result.followerCount)
+                  ? result.followerCount
+                  : prev.followerCount,
+              }
+            : prev
+        )
+      }
+    } catch (error) {
+      if (!isMountedRef.current) return
+      setFollowError(error instanceof Error ? error.message : '요청에 실패했습니다.')
+    } finally {
+      if (isMountedRef.current) setIsFollowProcessing(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <AppHeader title="프로필" showBack />
@@ -122,16 +180,29 @@ export default function UserProfilePage() {
         </section>
 
         {/* Follow Button */}
-        <section className="px-6 pt-6">
-          {/* TODO(Follow): Follow 도메인 개발 시 isFollowing 상태에 따라 팔로우/언팔로우 토글 구현 */}
+        <section className="flex flex-col gap-2 px-6 pt-6">
           <button
             type="button"
-            disabled
-            aria-disabled="true"
-            className="w-full rounded-xl bg-primary/60 py-4 text-lg font-bold text-primary-foreground shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handleToggleFollow}
+            disabled={isFollowProcessing}
+            aria-pressed={profile.isFollowing}
+            className={
+              profile.isFollowing
+                ? 'w-full rounded-xl border border-primary/30 bg-card py-4 text-lg font-bold text-primary shadow-sm transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:opacity-60'
+                : 'w-full rounded-xl bg-primary py-4 text-lg font-bold text-primary-foreground shadow-lg shadow-primary/20 transition-transform active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60'
+            }
           >
-            팔로우 (준비 중)
+            {isFollowProcessing ? '처리 중...' : profile.isFollowing ? '팔로잉' : '팔로우'}
           </button>
+          {followError && (
+            <p
+              role="alert"
+              aria-atomic="true"
+              className="rounded-lg bg-destructive/10 px-4 py-2 text-center text-sm text-destructive"
+            >
+              {followError}
+            </p>
+          )}
         </section>
 
         {/* 서재 보기 진입점 */}

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -17,6 +17,8 @@ export default function UserProfilePage() {
   const [isFollowProcessing, setIsFollowProcessing] = useState(false)
   const [followError, setFollowError] = useState<string | null>(null)
   const isMountedRef = useRef(true)
+  // 토글 진행 중 사용자가 다른 프로필로 이동하면, 늦게 도착한 응답이 새 프로필에 잘못 반영되는 것을 방지하기 위한 추적 ref
+  const profileIdRef = useRef<number | null>(null)
 
   // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
   // setup에서 명시적으로 true로 리셋해 ref가 false로 stuck되지 않도록 한다.
@@ -26,6 +28,11 @@ export default function UserProfilePage() {
       isMountedRef.current = false
     }
   }, [])
+
+  // profile.userId가 바뀔 때마다 ref 동기화 — 토글 핸들러가 stale 응답을 가드하기 위함
+  useEffect(() => {
+    profileIdRef.current = profile?.userId ?? null
+  }, [profile?.userId])
 
   const isValidId = /^\d+$/.test(userId ?? '')
   const numericUserId = isValidId ? parseInt(userId!, 10) : 0
@@ -99,14 +106,18 @@ export default function UserProfilePage() {
     // 결정 시점 스냅샷: 호출 직후 외부에서 profile.isFollowing이 바뀌어도 분기를 일관되게 유지
     // (미래 옵티미스틱 업데이트/외부 갱신 도입 시 회귀 방지)
     const wasFollowing = profile.isFollowing
+    // 토글 대상 userId 캡처: await 도중 사용자가 다른 프로필로 이동하면 응답을 무시하기 위함
+    const targetId = profile.userId
     setIsFollowProcessing(true)
     setFollowError(null)
+    // 응답 도착 시 현재 프로필이 여전히 동일 사용자인지 확인하는 stale guard
+    const isStale = () => !isMountedRef.current || profileIdRef.current !== targetId
     try {
       if (wasFollowing) {
-        const result = await unfollowUser(profile.userId)
-        if (!isMountedRef.current) return
+        const result = await unfollowUser(targetId)
+        if (isStale()) return
         setProfile(prev =>
-          prev
+          prev && prev.userId === targetId
             ? {
                 ...prev,
                 isFollowing: false,
@@ -117,10 +128,10 @@ export default function UserProfilePage() {
             : prev
         )
       } else {
-        const result = await followUser(profile.userId)
-        if (!isMountedRef.current) return
+        const result = await followUser(targetId)
+        if (isStale()) return
         setProfile(prev =>
-          prev
+          prev && prev.userId === targetId
             ? {
                 ...prev,
                 isFollowing: true,
@@ -132,9 +143,10 @@ export default function UserProfilePage() {
         )
       }
     } catch (error) {
-      if (!isMountedRef.current) return
+      if (isStale()) return
       setFollowError(error instanceof Error ? error.message : '요청에 실패했습니다.')
     } finally {
+      // stale 여부와 무관하게 항상 reset — 그렇지 않으면 사용자가 다른 프로필로 이동한 새 페이지에서 버튼이 영구 disabled
       if (isMountedRef.current) setIsFollowProcessing(false)
     }
   }


### PR DESCRIPTION
- api/follow.ts 신규 - followUser POST + unfollowUser DELETE + FollowResponse/UnfollowResponse 타입

- UserProfilePage 팔로우 버튼 활성화 - profile.isFollowing 기준 토글 (팔로우/팔로잉)

- handleToggleFollow: 응답 followerCount로 즉시 갱신, isMountedRef 가드, 처리 중 disabled

- 리뷰 반영: 결정 시점 스냅샷(wasFollowing), Number.isFinite fallback, POST body 명시(null), unfollow 응답 비대칭 주석

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필 페이지에서 팔로우/언팔로우 기능을 추가했습니다.
  * 팔로우 상태에 따라 버튼 텍스트와 스타일이 동적으로 변경됩니다.
  * 팔로워 수가 API 응답에 따라 실시간으로 업데이트됩니다.
  * 요청 처리 중 버튼이 자동으로 비활성화되어 중복 요청을 방지합니다.
  * 실패 시 사용자 친화적인 오류 알림이 표시됩니다.
  * 늦게 도착한 응답이 다른 프로필에 영향을 주지 않도록 보호 로직을 적용했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->