### PR TITLE
feat: 팔로워/팔로잉 목록 페이지 신규 구현 및 GET API 연동 (#99)

### DIFF
--- a/src/api/follow.ts
+++ b/src/api/follow.ts
@@ -14,6 +14,87 @@ export interface UnfollowResponse {
   followingCount: number
 }
 
+export interface FollowMemberSummary {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+  bio: string | null
+  isFollowing: boolean
+  isFollowedBy: boolean
+}
+
+export interface FollowListResponse {
+  content: FollowMemberSummary[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+export interface GetFollowListParams {
+  userId: number
+  cursor?: number | null
+  limit?: number
+  signal?: AbortSignal
+}
+
+export async function getFollowers({
+  userId,
+  cursor,
+  limit = 20,
+  signal,
+}: GetFollowListParams): Promise<FollowListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<FollowListResponse>>(
+      `/api/v1/users/${userId}/followers`,
+      {
+        params: {
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '팔로워 목록 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '팔로워 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
+export async function getFollowing({
+  userId,
+  cursor,
+  limit = 20,
+  signal,
+}: GetFollowListParams): Promise<FollowListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<FollowListResponse>>(
+      `/api/v1/users/${userId}/following`,
+      {
+        params: {
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '팔로잉 목록 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '팔로잉 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
 // AbortSignal 미지원 유지: POST는 서버 상태를 변경하므로 클라이언트에서 중단해도 서버 반영 여부가 불확실하고
 // (실제로 DB 쓰기가 이미 커밋되었을 수 있음), 취소의 실효성이 낮다. 대신 호출측에서 이중 클릭 방지(disabled)로 중복 호출을 막는다.
 export async function followUser(userId: number): Promise<FollowResponse> {

--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import axios from 'axios'
+import { cn } from '@/lib/utils'
+import AppHeader from '@/components/layout/AppHeader'
+import {
+  followUser,
+  unfollowUser,
+  getFollowers,
+  getFollowing,
+  type FollowMemberSummary,
+} from '@/api/follow'
+import { getUserProfile } from '@/api/member'
+import { useAuthStore } from '@/store/authStore'
+
+type TabValue = 'followers' | 'following'
+
+const tabs: { value: TabValue; label: string }[] = [
+  { value: 'followers', label: '팔로워' },
+  { value: 'following', label: '팔로잉' },
+]
+
+export default function FollowListPage() {
+  const { userId } = useParams<{ userId: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const myUserId = useAuthStore(state => state.user?.id)
+
+  const isValidId = /^\d+$/.test(userId ?? '')
+  const numericUserId = isValidId ? parseInt(userId!, 10) : 0
+
+  // URL 쿼리를 단일 진실 원천으로 사용 — 브라우저 back/forward에서도 자동 동기화
+  const activeTab: TabValue = searchParams.get('tab') === 'following' ? 'following' : 'followers'
+
+  const setActiveTab = (tab: TabValue) => {
+    setSearchParams(
+      prev => {
+        if (prev.get('tab') === tab) return prev
+        const next = new URLSearchParams(prev)
+        next.set('tab', tab)
+        return next
+      },
+      { replace: true }
+    )
+  }
+
+  const [nickname, setNickname] = useState<string | null>(null)
+  const [items, setItems] = useState<FollowMemberSummary[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  // 카드별 토글 진행 상태 (userId → in-flight 여부)
+  const [togglingIds, setTogglingIds] = useState<Set<number>>(() => new Set())
+  // 카드별 토글 에러 메시지 (userId → message)
+  const [toggleErrors, setToggleErrors] = useState<Map<number, string>>(() => new Map())
+
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+  const isMountedRef = useRef(true)
+
+  const stateRef = useRef({
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    activeTab,
+    loadMoreError,
+  })
+  stateRef.current = {
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    activeTab,
+    loadMoreError,
+  }
+
+  // StrictMode 안전: setup에서 true 명시 리셋
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  // 닉네임은 별도 호출로 가져옴 (직접 URL 진입에도 동작 보장)
+  useEffect(() => {
+    if (!isValidId) return
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const profile = await getUserProfile(numericUserId, controller.signal)
+        if (controller.signal.aborted) return
+        setNickname(profile.nickname)
+      } catch {
+        // 닉네임 조회 실패는 silent — 목록 조회 자체가 메인 경로
+      }
+    })()
+    return () => controller.abort()
+  }, [isValidId, numericUserId])
+
+  // 초기 로딩 + 탭 변경 시 재요청
+  useEffect(() => {
+    if (!isValidId) {
+      setErrorMessage('잘못된 사용자 ID입니다.')
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoadingMore(false)
+    setLoadMoreError(null)
+    moreControllerRef.current?.abort()
+
+    const controller = new AbortController()
+    setItems([])
+    setNextCursor(null)
+    setHasNext(false)
+    setIsLoading(true)
+    setErrorMessage(null)
+
+    const fetcher = activeTab === 'followers' ? getFollowers : getFollowing
+    ;(async () => {
+      try {
+        const response = await fetcher({
+          userId: numericUserId,
+          cursor: null,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setItems(response.content)
+        setNextCursor(response.nextCursor)
+        setHasNext(response.hasNext)
+      } catch (error) {
+        // normalizeAxiosError가 cancel은 rethrow하므로 여기서 분기 필수
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '목록을 불러오지 못했습니다.')
+        setItems([])
+        setNextCursor(null)
+        setHasNext(false)
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+    }
+  }, [isValidId, numericUserId, activeTab])
+
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
+    const requestedTab = s.activeTab
+    const requestedCursor = s.nextCursor
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const fetcher = requestedTab === 'followers' ? getFollowers : getFollowing
+      const response = await fetcher({
+        userId: numericUserId,
+        cursor: requestedCursor,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      // 탭이 바뀌었다면 응답 버림 (stale guard)
+      if (stateRef.current.activeTab !== requestedTab) return
+      setItems(prev => [...prev, ...response.content])
+      setNextCursor(response.nextCursor)
+      setHasNext(response.hasNext)
+    } catch (error) {
+      // normalizeAxiosError가 cancel은 rethrow하므로 여기서 분기 필수
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      // 탭이 바뀌었다면 에러도 버림
+      if (stateRef.current.activeTab !== requestedTab) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [numericUserId])
+
+  // sentinel ref callback: 조건부 렌더된 sentinel 마운트/언마운트에 따라 observer 재부착이 자동
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (!entries[0].isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  const retryLoadMore = () => {
+    setLoadMoreError(null)
+    fetchMore()
+  }
+
+  const handleToggleCard = async (target: FollowMemberSummary) => {
+    if (togglingIds.has(target.userId)) return
+    const wasFollowing = target.isFollowing
+    // 탭이 토글 도중 바뀌면 응답을 list에 반영하지 않기 위한 stale guard 스냅샷
+    const requestedTab = activeTab
+    setTogglingIds(prev => {
+      const next = new Set(prev)
+      next.add(target.userId)
+      return next
+    })
+    setToggleErrors(prev => {
+      if (!prev.has(target.userId)) return prev
+      const next = new Map(prev)
+      next.delete(target.userId)
+      return next
+    })
+    try {
+      if (wasFollowing) {
+        await unfollowUser(target.userId)
+      } else {
+        await followUser(target.userId)
+      }
+      if (!isMountedRef.current) return
+      // 탭이 그 사이 바뀌었다면 list 갱신 스킵 (다른 fetcher의 결과로 채워졌을 수 있음)
+      if (stateRef.current.activeTab !== requestedTab) return
+      setItems(prev =>
+        prev.map(it => (it.userId === target.userId ? { ...it, isFollowing: !wasFollowing } : it))
+      )
+    } catch (error) {
+      if (!isMountedRef.current) return
+      const message = error instanceof Error ? error.message : '요청에 실패했습니다.'
+      setToggleErrors(prev => {
+        const next = new Map(prev)
+        next.set(target.userId, message)
+        return next
+      })
+    } finally {
+      // finally 블록의 early return은 no-unsafe-finally 위반이라 if 래핑 사용
+      if (isMountedRef.current) {
+        setTogglingIds(prev => {
+          const next = new Set(prev)
+          next.delete(target.userId)
+          return next
+        })
+      }
+    }
+  }
+
+  const headerTitle = nickname ?? '사용자'
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title={headerTitle} showBack />
+
+      {/* 탭 */}
+      <div className="flex border-b border-border" role="tablist">
+        {tabs.map(tab => (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.value}
+            onClick={() => setActiveTab(tab.value)}
+            className={cn(
+              'flex-1 py-4 text-sm font-semibold transition-colors',
+              activeTab === tab.value
+                ? 'border-b-2 border-primary text-primary'
+                : 'text-muted-foreground hover:text-primary'
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <main className="flex-1 overflow-y-auto pb-12">
+        {isLoading && items.length === 0 && (
+          <p
+            role="status"
+            aria-busy="true"
+            className="py-10 text-center text-sm text-muted-foreground"
+          >
+            불러오는 중...
+          </p>
+        )}
+
+        {!isLoading && errorMessage && (
+          <p role="alert" className="py-10 text-center text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        {!isLoading && !errorMessage && items.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              group
+            </span>
+            <p className="text-sm text-muted-foreground">
+              {activeTab === 'followers' ? '아직 팔로워가 없어요.' : '아직 팔로잉이 없어요.'}
+            </p>
+          </div>
+        )}
+
+        {items.length > 0 && (
+          <ul className="flex flex-col">
+            {items.map(item => {
+              const isMe = myUserId != null && item.userId === myUserId
+              const isToggling = togglingIds.has(item.userId)
+              return (
+                <li
+                  key={item.userId}
+                  className="flex flex-col gap-1 border-b border-border/50 px-6 py-4"
+                >
+                  <div className="flex items-center gap-3">
+                    <Link
+                      to={`/user/${item.userId}`}
+                      className="flex min-w-0 flex-1 items-center gap-3"
+                    >
+                      <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10">
+                        {item.profileImageUrl ? (
+                          <img
+                            src={item.profileImageUrl}
+                            alt={`${item.nickname} 프로필 이미지`}
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <span
+                            aria-hidden="true"
+                            className="material-symbols-outlined text-2xl text-muted-foreground/40"
+                          >
+                            person
+                          </span>
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold">{item.nickname}</p>
+                        {item.bio && (
+                          <p className="truncate text-xs text-muted-foreground">{item.bio}</p>
+                        )}
+                      </div>
+                    </Link>
+                    {!isMe && (
+                      <button
+                        type="button"
+                        onClick={() => handleToggleCard(item)}
+                        disabled={isToggling}
+                        aria-pressed={item.isFollowing}
+                        className={
+                          item.isFollowing
+                            ? 'shrink-0 rounded-full border border-primary/30 bg-card px-4 py-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:opacity-60'
+                            : 'shrink-0 rounded-full bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground shadow-sm transition-transform active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60'
+                        }
+                      >
+                        {isToggling ? '처리 중' : item.isFollowing ? '팔로잉' : '팔로우'}
+                      </button>
+                    )}
+                  </div>
+                  {toggleErrors.get(item.userId) && (
+                    <p role="alert" className="ml-15 text-xs text-destructive">
+                      {toggleErrors.get(item.userId)}
+                    </p>
+                  )}
+                </li>
+              )
+            })}
+
+            {/* 무한 스크롤 sentinel */}
+            <div ref={sentinelRef} className="h-10" />
+
+            {isLoadingMore && (
+              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+            )}
+
+            {loadMoreError && !isLoadingMore && (
+              <div className="flex flex-col items-center gap-2 py-4">
+                <p role="alert" className="text-sm text-destructive">
+                  {loadMoreError}
+                </p>
+                <button
+                  type="button"
+                  onClick={retryLoadMore}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                >
+                  다시 불러오기
+                </button>
+              </div>
+            )}
+
+            {!hasNext && !isLoadingMore && !loadMoreError && (
+              <p className="py-4 text-center text-xs text-muted-foreground/50">
+                모든 사용자를 확인했습니다
+              </p>
+            )}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -106,6 +106,10 @@ export default function FollowListPage() {
     if (!isValidId) {
       setErrorMessage('잘못된 사용자 ID입니다.')
       setIsLoading(false)
+      // 이전 탭에서 로드된 항목/페이지네이션 상태가 잔류하지 않도록 함께 리셋
+      setItems([])
+      setNextCursor(null)
+      setHasNext(false)
       return
     }
 
@@ -188,7 +192,7 @@ export default function FollowListPage() {
 
   // sentinel ref callback: 조건부 렌더된 sentinel 마운트/언마운트에 따라 observer 재부착이 자동
   const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
+    (node: HTMLLIElement | null) => {
       observerRef.current?.disconnect()
       if (!node) {
         observerRef.current = null
@@ -380,15 +384,17 @@ export default function FollowListPage() {
               )
             })}
 
-            {/* 무한 스크롤 sentinel */}
-            <div ref={sentinelRef} className="h-10" />
+            {/* 무한 스크롤 sentinel — <ul> 직계 자식은 <li>여야 유효 마크업 */}
+            <li ref={sentinelRef} aria-hidden="true" className="h-10 list-none" />
 
             {isLoadingMore && (
-              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+              <li className="list-none py-4 text-center text-xs text-muted-foreground">
+                더 불러오는 중...
+              </li>
             )}
 
             {loadMoreError && !isLoadingMore && (
-              <div className="flex flex-col items-center gap-2 py-4">
+              <li className="flex list-none flex-col items-center gap-2 py-4">
                 <p role="alert" className="text-sm text-destructive">
                   {loadMoreError}
                 </p>
@@ -399,13 +405,13 @@ export default function FollowListPage() {
                 >
                   다시 불러오기
                 </button>
-              </div>
+              </li>
             )}
 
             {!hasNext && !isLoadingMore && !loadMoreError && (
-              <p className="py-4 text-center text-xs text-muted-foreground/50">
+              <li className="list-none py-4 text-center text-xs text-muted-foreground/50">
                 모든 사용자를 확인했습니다
-              </p>
+              </li>
             )}
           </ul>
         )}

--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -87,6 +87,8 @@ export default function FollowListPage() {
 
   // 닉네임은 별도 호출로 가져옴 (직접 URL 진입에도 동작 보장)
   useEffect(() => {
+    // 라우트 변경/중단 시 이전 사용자 닉네임이 헤더에 잔류하지 않도록 즉시 fallback으로 리셋
+    setNickname(null)
     if (!isValidId) return
     const controller = new AbortController()
     ;(async () => {
@@ -243,9 +245,16 @@ export default function FollowListPage() {
       if (!isMountedRef.current) return
       // 탭이 그 사이 바뀌었다면 list 갱신 스킵 (다른 fetcher의 결과로 채워졌을 수 있음)
       if (stateRef.current.activeTab !== requestedTab) return
-      setItems(prev =>
-        prev.map(it => (it.userId === target.userId ? { ...it, isFollowing: !wasFollowing } : it))
-      )
+      // 내 팔로잉 목록에서 언팔로우한 경우, 해당 항목은 더 이상 팔로잉이 아니므로 목록에서 제거
+      const isMyFollowingTab =
+        myUserId != null && numericUserId === myUserId && requestedTab === 'following'
+      if (isMyFollowingTab && wasFollowing) {
+        setItems(prev => prev.filter(it => it.userId !== target.userId))
+      } else {
+        setItems(prev =>
+          prev.map(it => (it.userId === target.userId ? { ...it, isFollowing: !wasFollowing } : it))
+        )
+      }
     } catch (error) {
       if (!isMountedRef.current) return
       const message = error instanceof Error ? error.message : '요청에 실패했습니다.'

--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -376,7 +376,7 @@ export default function FollowListPage() {
                     )}
                   </div>
                   {toggleErrors.get(item.userId) && (
-                    <p role="alert" className="ml-15 text-xs text-destructive">
+                    <p role="alert" className="ml-[60px] text-xs text-destructive">
                       {toggleErrors.get(item.userId)}
                     </p>
                   )}

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -233,13 +233,20 @@ export default function MyProfilePage() {
             </p>
           )}
 
-          {/* TODO(M6): 팔로워/팔로잉 목록 페이지 연동 시 disabled/aria-disabled 제거 + hover 클래스 복원 + onClick 추가 */}
           <div className="mt-6 flex items-center justify-center gap-4 text-base font-medium text-primary/80">
-            <button type="button" disabled aria-disabled="true">
+            <button
+              type="button"
+              onClick={() => navigate(`/user/${profile.userId}/follows?tab=followers`)}
+              className="transition-colors hover:text-primary"
+            >
               팔로워 {profile.followerCount}
             </button>
             <span className="text-primary/30">|</span>
-            <button type="button" disabled aria-disabled="true">
+            <button
+              type="button"
+              onClick={() => navigate(`/user/${profile.userId}/follows?tab=following`)}
+              className="transition-colors hover:text-primary"
+            >
               팔로잉 {profile.followingCount}
             </button>
           </div>

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -179,13 +179,20 @@ export default function UserProfilePage() {
             </p>
           )}
 
-          {/* TODO(Follow): 팔로워/팔로잉 목록 페이지 연동 시 disabled 제거 + onClick 추가 */}
           <div className="mt-6 flex items-center justify-center gap-4 text-base font-medium text-primary/80">
-            <button type="button" disabled aria-disabled="true">
+            <button
+              type="button"
+              onClick={() => navigate(`/user/${numericUserId}/follows?tab=followers`)}
+              className="transition-colors hover:text-primary"
+            >
               팔로워 {profile.followerCount}
             </button>
             <span className="text-primary/30">|</span>
-            <button type="button" disabled aria-disabled="true">
+            <button
+              type="button"
+              onClick={() => navigate(`/user/${numericUserId}/follows?tab=following`)}
+              className="transition-colors hover:text-primary"
+            >
               팔로잉 {profile.followingCount}
             </button>
           </div>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -22,6 +22,7 @@ import EditProfilePage from '@/pages/EditProfilePage'
 import UserProfilePage from '@/pages/UserProfilePage'
 import LibraryBookDetailPage from '@/pages/LibraryBookDetailPage'
 import UserLibraryPage from '@/pages/UserLibraryPage'
+import FollowListPage from '@/pages/FollowListPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 
 export const router = createBrowserRouter([
@@ -134,6 +135,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <UserLibraryPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/user/:userId/follows',
+    element: (
+      <ProtectedRoute>
+        <FollowListPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
- api/follow.ts: getFollowers/getFollowing + FollowListResponse/FollowMemberSummary 타입 추가

- FollowListPage 신규: URL derived 탭(followers/following) + 무한 스크롤 + 카드별 팔로우 토글

- /user/:userId/follows 라우트 추가, ?tab= 쿼리로 초기/현재 탭 결정

- UserProfilePage / MyProfilePage 팔로워/팔로잉 카운트 버튼 활성화

- 리뷰 반영: unused navigate 제거(HIGH), searchParams deps 제거(M1), 카드별 toggleErrors inline 에러(M2), 토글 stale guard(M3), browser back/forward 동기화(M4), no-unsafe-finally if 래핑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팔로워/팔로잉 목록을 조회할 수 있는 새 페이지 추가
  * 프로필 페이지의 팔로워/팔로잉 버튼을 클릭 가능하도록 변경
  * 팔로워/팔로잉 목록에 무한 스크롤 페이지네이션과 불러오기 재시도 UI 추가
  * 목록 내에서 다른 사용자를 팔로우/언팔로우할 수 있는 토글 기능 추가
  * 팔로우 목록 페이지는 인증된 사용자만 접근 가능하도록 라우트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->