### PR TITLE
feat: 팔로잉 피드 조회 API 연동 및 무한스크롤 (#101)

### DIFF
--- a/src/api/feed.ts
+++ b/src/api/feed.ts
@@ -1,0 +1,71 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
+
+export interface FeedReviewUser {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+}
+
+export interface FeedReviewBook {
+  bookId: number
+  title: string
+  author: string
+  coverImageUrl: string | null
+}
+
+export interface FeedReview {
+  reviewId: number
+  user: FeedReviewUser
+  book: FeedReviewBook
+  rating: number
+  content: string
+  quote: string | null
+  isSpoiler: boolean
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  tags: string[]
+  // 서버 LocalDateTime ISO 문자열 (offset 없음). 클라이언트는 로컬 KST로 해석.
+  createdAt: string
+}
+
+export interface FeedItem {
+  feedId: number
+  review: FeedReview
+}
+
+export interface FeedListResponse {
+  content: FeedItem[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+export interface GetFollowingFeedParams {
+  cursor?: number | null
+  limit?: number
+  signal?: AbortSignal
+}
+
+export async function getFollowingFeed({
+  cursor,
+  limit = 20,
+  signal,
+}: GetFollowingFeedParams): Promise<FeedListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<FeedListResponse>>('/api/v1/feed/following', {
+      params: {
+        limit,
+        ...(cursor != null ? { cursor } : {}),
+      },
+      signal,
+    })
+    if (!data.data) {
+      throw new Error(data.message ?? '피드 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '피드를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { cn } from '@/lib/utils'
+import { cn, formatRelativeTime } from '@/lib/utils'
 import type { Memo } from '@/types'
 import StarRating from './StarRating'
 
 interface ReviewCardProps {
   review: Memo
   className?: string
+  // TODO(Review 도메인 완료 시 제거): Review 상세 페이지가 동료 담당으로 작업 중이라
+  // 임시로 카드 클릭에 의한 /review/:id 이동을 막는다.
+  disableLink?: boolean
 }
 
 const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }> = {
@@ -16,7 +19,7 @@ const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }
   stopped: { text: '중단', variant: 'outline' },
 }
 
-export default function ReviewCard({ review, className }: ReviewCardProps) {
+export default function ReviewCard({ review, className, disableLink = false }: ReviewCardProps) {
   const [spoilerRevealed, setSpoilerRevealed] = useState(false)
   const [liked, setLiked] = useState(review.isLiked)
   const [likeCount, setLikeCount] = useState(review.likeCount)
@@ -27,116 +30,132 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
     setLikeCount(prev => (liked ? prev - 1 : prev + 1))
   }
 
-  return (
-    <Link
-      to={`/review/${review.id}`}
-      className={cn(
-        'block overflow-hidden rounded-xl border border-primary/5 bg-card shadow-sm',
-        className
-      )}
-    >
-      <div className="p-4">
-        {/* User Header */}
-        <div className="mb-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="size-10 overflow-hidden rounded-full border border-primary/10 bg-primary/10">
-              {review.author.profileImageUrl && (
-                <img
-                  src={review.author.profileImageUrl}
-                  alt={review.author.nickname}
-                  className="size-full object-cover"
-                />
-              )}
-            </div>
-            <div>
-              <p className="text-sm font-bold">{review.author.nickname}</p>
-              <p className="text-xs text-muted-foreground">{review.createdAt}</p>
-            </div>
-          </div>
-          {status && (
-            <span
-              className={cn(
-                'rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider',
-                status.variant === 'solid'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-primary/10 text-primary'
-              )}
-            >
-              {status.text}
-            </span>
-          )}
-        </div>
+  const cardClassName = cn(
+    'block overflow-hidden rounded-xl border border-primary/5 bg-card shadow-sm',
+    className
+  )
 
-        {/* Book Info */}
-        <div className="mb-4 flex gap-4">
-          <div className="h-28 w-20 shrink-0 overflow-hidden rounded-md bg-primary/5 shadow-md">
+  const inner = (
+    <div className="p-4">
+      {/* User Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="size-10 overflow-hidden rounded-full border border-primary/10 bg-primary/10">
+            {review.author.profileImageUrl && (
+              <img
+                src={review.author.profileImageUrl}
+                alt={review.author.nickname}
+                className="size-full object-cover"
+              />
+            )}
+          </div>
+          <div>
+            <p className="text-sm font-bold">{review.author.nickname}</p>
+            <p className="text-xs text-muted-foreground">{formatRelativeTime(review.createdAt)}</p>
+          </div>
+        </div>
+        {status && (
+          <span
+            className={cn(
+              'rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider',
+              status.variant === 'solid'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-primary/10 text-primary'
+            )}
+          >
+            {status.text}
+          </span>
+        )}
+      </div>
+
+      {/* Book Info */}
+      <div className="mb-4 flex gap-4">
+        <div className="h-28 w-20 shrink-0 overflow-hidden rounded-md bg-primary/5 shadow-md">
+          {review.book.coverImageUrl ? (
             <img
               src={review.book.coverImageUrl}
               alt={review.book.title}
               className="size-full object-cover"
             />
-          </div>
-          <div className="flex flex-col justify-center">
-            <h3 className="text-lg font-bold leading-tight text-primary">{review.book.title}</h3>
-            <p className="mb-2 text-sm">{review.book.author}</p>
-            {review.rating && <StarRating rating={review.rating} size="md" />}
-          </div>
+          ) : (
+            // 빈 src는 브라우저가 현재 페이지를 재요청하므로 placeholder로 분기
+            <div
+              aria-hidden="true"
+              className="flex size-full items-center justify-center text-xs text-muted-foreground/60"
+            >
+              <span className="material-symbols-outlined text-2xl">menu_book</span>
+            </div>
+          )}
         </div>
-
-        {/* Review Text */}
-        {review.hasSpoiler && !spoilerRevealed ? (
-          <button
-            onClick={e => {
-              e.preventDefault()
-              setSpoilerRevealed(true)
-            }}
-            className="group relative mb-4 w-full cursor-pointer"
-          >
-            <div className="pointer-events-none select-none opacity-40 blur-md">
-              <p className="text-sm leading-relaxed">{review.content}</p>
-            </div>
-            <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg border border-primary/10 bg-primary/5 transition-colors group-hover:bg-primary/10">
-              <span className="material-symbols-outlined mb-1 text-primary">visibility_off</span>
-              <p className="text-[13px] font-bold text-primary">스포일러 포함 — 탭하여 보기</p>
-            </div>
-          </button>
-        ) : (
-          <div className="mb-4">
-            <p className="text-sm leading-relaxed">
-              {review.content}
-              {!review.hasSpoiler && (
-                <span className="ml-1 cursor-pointer font-medium text-primary">더보기</span>
-              )}
-            </p>
-          </div>
-        )}
-
-        {/* Actions */}
-        <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
-          <button
-            onClick={e => {
-              e.preventDefault()
-              toggleLike()
-            }}
-            className={cn(
-              'flex items-center gap-1.5 transition-colors hover:text-primary',
-              liked && 'text-primary'
-            )}
-          >
-            <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
-              favorite
-            </span>
-            <span className="text-xs font-bold">{likeCount}</span>
-          </button>
-          <button
-            onClick={e => e.preventDefault()}
-            className="flex items-center gap-1.5 transition-colors hover:text-primary"
-          >
-            <span className="material-symbols-outlined text-xl">chat_bubble</span>
-            <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
-          </button>
+        <div className="flex flex-col justify-center">
+          <h3 className="text-lg font-bold leading-tight text-primary">{review.book.title}</h3>
+          <p className="mb-2 text-sm">{review.book.author}</p>
+          {review.rating && <StarRating rating={review.rating} size="md" />}
         </div>
       </div>
+
+      {/* Review Text */}
+      {review.hasSpoiler && !spoilerRevealed ? (
+        <button
+          onClick={e => {
+            e.preventDefault()
+            setSpoilerRevealed(true)
+          }}
+          className="group relative mb-4 w-full cursor-pointer"
+        >
+          <div className="pointer-events-none select-none opacity-40 blur-md">
+            <p className="text-sm leading-relaxed">{review.content}</p>
+          </div>
+          <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg border border-primary/10 bg-primary/5 transition-colors group-hover:bg-primary/10">
+            <span className="material-symbols-outlined mb-1 text-primary">visibility_off</span>
+            <p className="text-[13px] font-bold text-primary">스포일러 포함 — 탭하여 보기</p>
+          </div>
+        </button>
+      ) : (
+        <div className="mb-4">
+          <p className="text-sm leading-relaxed">
+            {review.content}
+            {!review.hasSpoiler && (
+              <span className="ml-1 cursor-pointer font-medium text-primary">더보기</span>
+            )}
+          </p>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
+        <button
+          onClick={e => {
+            e.preventDefault()
+            toggleLike()
+          }}
+          className={cn(
+            'flex items-center gap-1.5 transition-colors hover:text-primary',
+            liked && 'text-primary'
+          )}
+        >
+          <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
+            favorite
+          </span>
+          <span className="text-xs font-bold">{likeCount}</span>
+        </button>
+        <button
+          onClick={e => e.preventDefault()}
+          className="flex items-center gap-1.5 transition-colors hover:text-primary"
+        >
+          <span className="material-symbols-outlined text-xl">chat_bubble</span>
+          <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
+        </button>
+      </div>
+    </div>
+  )
+
+  if (disableLink) {
+    return <div className={cardClassName}>{inner}</div>
+  }
+  return (
+    <Link to={`/review/${review.id}`} className={cardClassName}>
+      {inner}
     </Link>
   )
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,28 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * ISO 문자열 또는 Date를 한국어 상대 시간으로 변환한다.
+ * 7일 이상은 절대 날짜(YYYY.MM.DD)로 표기.
+ * invalid 입력은 빈 문자열 반환.
+ *
+ * 백엔드 LocalDateTime은 offset 없는 ISO("2026-04-26T17:10:45")로 직렬화되어
+ * 브라우저에서 로컬 타임존으로 해석된다. 서버/클라가 모두 KST이면 일치.
+ */
+export function formatRelativeTime(input: string | Date): string {
+  const date = typeof input === 'string' ? new Date(input) : input
+  if (Number.isNaN(date.getTime())) return ''
+
+  // 서버/클라 시계 어긋남으로 미래 시각이 들어와도 "방금 전"으로 흡수 (Math.max로 의도 명시)
+  const diffSec = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+  if (diffSec < 60) return '방금 전'
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}분 전`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}시간 전`
+  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}일 전`
+
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}.${m}.${d}`
+}

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -1,12 +1,177 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import axios from 'axios'
 import { cn } from '@/lib/utils'
-import { mockReviews } from '@/mocks/data'
+import { getFollowingFeed, type FeedItem } from '@/api/feed'
+import type { Memo } from '@/types'
 import BottomNav from '@/components/layout/BottomNav'
 import ReviewCard from '@/components/common/ReviewCard'
 
+type TabValue = 'following' | 'recommend'
+
+// 백엔드 FeedItem을 ReviewCard가 받는 Memo 형태로 매핑.
+// Memo의 일부 필드(book.isbn/publisher, author.followerCount/followingCount)는 ReviewCard가 사용하지 않으므로
+// 빈 값/0으로 채운다 — 후속 리팩터로 ReviewCard prop을 더 단순한 형태로 분리하면 제거 가능.
+function toMemo(item: FeedItem): Memo {
+  return {
+    id: item.review.reviewId,
+    content: item.review.content,
+    book: {
+      isbn: '',
+      title: item.review.book.title,
+      author: item.review.book.author,
+      publisher: '',
+      coverImageUrl: item.review.book.coverImageUrl ?? '',
+    },
+    author: {
+      id: item.review.user.userId,
+      nickname: item.review.user.nickname,
+      profileImageUrl: item.review.user.profileImageUrl ?? undefined,
+      followerCount: 0,
+      followingCount: 0,
+    },
+    likeCount: item.review.likeCount,
+    isLiked: item.review.isLiked,
+    createdAt: item.review.createdAt,
+    rating: item.review.rating,
+    hasSpoiler: item.review.isSpoiler,
+    commentCount: item.review.commentCount,
+  }
+}
+
 export default function HomeFeedPage() {
-  const [activeTab, setActiveTab] = useState<'following' | 'recommend'>('following')
+  const [activeTab, setActiveTab] = useState<TabValue>('following')
+
+  const [items, setItems] = useState<Memo[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+
+  const stateRef = useRef({
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    activeTab,
+    loadMoreError,
+  })
+  stateRef.current = {
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    activeTab,
+    loadMoreError,
+  }
+
+  // 초기 로딩 + 탭 변경 시 재요청. 'recommend' 탭은 백엔드 미구현이므로 placeholder만 표시 (fetch 스킵).
+  useEffect(() => {
+    setIsLoadingMore(false)
+    setLoadMoreError(null)
+    moreControllerRef.current?.abort()
+    setItems([])
+    setNextCursor(null)
+    setHasNext(false)
+    setErrorMessage(null)
+
+    if (activeTab !== 'following') {
+      setIsLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    ;(async () => {
+      try {
+        const response = await getFollowingFeed({
+          cursor: null,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setItems(response.content.map(toMemo))
+        setNextCursor(response.nextCursor)
+        setHasNext(response.hasNext)
+      } catch (error) {
+        // normalizeAxiosError가 cancel은 rethrow하므로 여기서 분기 필수
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '피드를 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+    }
+  }, [activeTab])
+
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.activeTab !== 'following') return
+    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
+    const requestedCursor = s.nextCursor
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await getFollowingFeed({
+        cursor: requestedCursor,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      // 도중에 탭이 바뀌었으면 응답 버림
+      if (stateRef.current.activeTab !== 'following') return
+      setItems(prev => [...prev, ...response.content.map(toMemo)])
+      setNextCursor(response.nextCursor)
+      setHasNext(response.hasNext)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      if (stateRef.current.activeTab !== 'following') return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [])
+
+  // sentinel ref callback: 조건부 렌더된 sentinel 마운트/언마운트에 따라 observer 재부착이 자동
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          // noUncheckedIndexedAccess 대비 + disconnect 후 잔여 콜백 방어
+          if (!entries[0]?.isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  const retryLoadMore = () => {
+    setLoadMoreError(null)
+    fetchMore()
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -22,8 +187,11 @@ export default function HomeFeedPage() {
           </Link>
         </div>
         {/* Tabs */}
-        <div className="flex gap-8 px-4">
+        <div className="flex gap-8 px-4" role="tablist">
           <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'following'}
             onClick={() => setActiveTab('following')}
             className="relative flex flex-col items-center py-3"
           >
@@ -40,6 +208,9 @@ export default function HomeFeedPage() {
             )}
           </button>
           <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'recommend'}
             onClick={() => setActiveTab('recommend')}
             className="relative flex flex-col items-center py-3"
           >
@@ -61,12 +232,77 @@ export default function HomeFeedPage() {
       {/* Feed */}
       <main className="flex-1 overflow-y-auto pb-24">
         {activeTab === 'following' ? (
-          mockReviews.map(review => (
-            <div key={review.id} className="p-4 pt-4 first:pt-4 [&:not(:first-child)]:pt-0">
-              <ReviewCard review={review} />
-            </div>
-          ))
+          <>
+            {isLoading && items.length === 0 && (
+              <p
+                role="status"
+                aria-busy="true"
+                className="py-10 text-center text-sm text-muted-foreground"
+              >
+                불러오는 중...
+              </p>
+            )}
+
+            {!isLoading && errorMessage && (
+              <p role="alert" className="py-10 text-center text-sm text-destructive">
+                {errorMessage}
+              </p>
+            )}
+
+            {!isLoading && !errorMessage && items.length === 0 && (
+              <div className="flex flex-col items-center justify-center gap-3 py-20">
+                <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+                  group
+                </span>
+                <p className="text-sm text-muted-foreground">
+                  팔로우한 사용자의 감상이 아직 없어요.
+                </p>
+              </div>
+            )}
+
+            {items.map(memo => (
+              <div key={memo.id} className="p-4 pt-4 first:pt-4 [&:not(:first-child)]:pt-0">
+                {/* TODO(Review 도메인 완료 시 제거): 동료 담당으로 작업 중이라 카드 클릭 → /review/:id 이동을 임시 비활성 */}
+                <ReviewCard review={memo} disableLink />
+              </div>
+            ))}
+
+            {items.length > 0 && (
+              <>
+                {/* hasNext가 false면 sentinel 자체를 안 띄워 불필요한 observer 부착 방지 */}
+                {hasNext && <div ref={sentinelRef} className="h-10" aria-hidden="true" />}
+
+                {isLoadingMore && (
+                  <p className="py-4 text-center text-xs text-muted-foreground">
+                    더 불러오는 중...
+                  </p>
+                )}
+
+                {loadMoreError && !isLoadingMore && (
+                  <div className="flex flex-col items-center gap-2 py-4">
+                    <p role="alert" className="text-sm text-destructive">
+                      {loadMoreError}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={retryLoadMore}
+                      className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                    >
+                      다시 불러오기
+                    </button>
+                  </div>
+                )}
+
+                {!hasNext && !isLoadingMore && !loadMoreError && (
+                  <p className="py-4 text-center text-xs text-muted-foreground/50">
+                    모든 감상을 확인했습니다
+                  </p>
+                )}
+              </>
+            )}
+          </>
         ) : (
+          // TODO(추천 피드 백엔드 구현 시 작업): 현재는 placeholder 유지
           <div className="flex flex-col items-center justify-center gap-3 py-20">
             <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
               auto_awesome

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,17 +1,3 @@
-// 공통 API 응답 타입
-export interface ApiResponse<T> {
-  data: T
-  message: string
-  status: number
-}
-
-// 페이지네이션
-export interface PageResponse<T> {
-  content: T[]
-  hasNext: boolean
-  nextCursor?: string
-}
-
 // 유저
 export interface User {
   id: number


### PR DESCRIPTION
- api/feed.ts 신규: getFollowingFeed + FeedItem/FeedReview/FeedListResponse 타입, AbortSignal/normalizeAxiosError 패턴 재사용
- HomeFeedPage: mock 제거 → 실제 API 연동 + 커서 기반 무한스크롤 (FollowListPage 패턴), 로딩/에러/빈 상태 UI, 추천 탭은 placeholder + TODO 유지
- ReviewCard: disableLink prop 추가 (Review 도메인 동료 담당으로 임시 차단, TODO 명시), formatRelativeTime 적용, coverImageUrl 빈 src placeholder 분기
- lib/utils.ts: formatRelativeTime 추가 ("방금 전"/"n분 전"/"n시간 전"/"n일 전"/"YYYY.MM.DD"), 외부 라이브러리 없이 자체 구현, Math.max(0, ...)로 시계 어긋남 방어
- types/index.ts: 미사용 ApiResponse/PageResponse 삭제 (_helpers.ts와 중복으로 잘못된 import 위험 제거)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 팔로우 중인 사용자의 피드를 동적으로 로드하는 기능 추가
  * 무한 스크롤을 통한 피드 페이지네이션 지원
  * 리뷰 작성 시간을 상대 시간으로 표시 (예: "방금 전", "2시간 전")

* **Bug Fixes**
  * 책 커버 이미지가 없을 때 플레이스홀더 표시

* **Refactor**
  * 내부 타입 선언 정리 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->