### PR TITLE
chore: 프로젝트명 변경 BookLog → Shelfeed (#103)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
       rel="stylesheet"
     />
-    <title>BookLog</title>
+    <title>Shelfeed</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -9,7 +9,7 @@ interface AppHeaderProps {
 }
 
 export default function AppHeader({
-  title = 'BookLog',
+  title = 'Shelfeed',
   showBack = false,
   rightAction,
   className,

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -87,7 +87,7 @@ export default function BookDetailPage() {
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
-        <AppHeader title="BookLog" showBack />
+        <AppHeader title="Shelfeed" showBack />
         <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
           <p role="status" className="text-sm text-muted-foreground">
             불러오는 중...
@@ -101,7 +101,7 @@ export default function BookDetailPage() {
   if (errorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
-        <AppHeader title="BookLog" showBack />
+        <AppHeader title="Shelfeed" showBack />
         <main className="flex flex-1 flex-col items-center justify-center gap-4 pb-24">
           <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
             search_off
@@ -149,7 +149,7 @@ export default function BookDetailPage() {
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <AppHeader
-        title="BookLog"
+        title="Shelfeed"
         showBack
         rightAction={
           <button

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -5,7 +5,7 @@ import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import { searchBooks, type BookSummary } from '@/api/book'
 
-const RECENT_KEYWORDS_KEY = 'booklog-recent-keywords'
+const RECENT_KEYWORDS_KEY = 'shelfeed-recent-keywords'
 const MAX_RECENT_KEYWORDS = 10
 
 function loadRecentKeywords(): string[] {
@@ -198,7 +198,7 @@ export default function BookSearchPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <AppHeader title="BookLog" showBack />
+      <AppHeader title="Shelfeed" showBack />
 
       {/* Search Bar */}
       <div className="border-b border-border px-4 py-3" role="search">

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -121,7 +121,7 @@ export default function EmailVerificationPage() {
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <header className="flex items-center justify-center border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md">
-        <h1 className="text-xl font-bold tracking-tight text-primary">BookLog</h1>
+        <h1 className="text-xl font-bold tracking-tight text-primary">Shelfeed</h1>
       </header>
 
       <main className="flex flex-1 flex-col items-center px-6 pt-16">

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -178,7 +178,7 @@ export default function HomeFeedPage() {
       {/* Header */}
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="flex items-center justify-between px-4 py-3">
-          <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+          <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
           <Link
             to="/notifications"
             className="rounded-full p-2 transition-colors hover:bg-primary/5"

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -81,7 +81,7 @@ export default function LoginPage() {
       {/* Header */}
       <header className="flex w-full items-center justify-center py-16">
         <div className="flex flex-col items-center gap-2">
-          <h1 className="text-4xl font-bold tracking-tight text-primary">BookLog</h1>
+          <h1 className="text-4xl font-bold tracking-tight text-primary">Shelfeed</h1>
           <div className="h-px w-8 bg-primary/30" />
         </div>
       </header>

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -119,7 +119,7 @@ export default function MyProfilePage() {
           <div className="grid grid-cols-3 items-center px-4 py-3">
             <div />
             <div className="flex justify-center">
-              <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+              <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
             </div>
             <div />
           </div>
@@ -141,7 +141,7 @@ export default function MyProfilePage() {
           <div className="grid grid-cols-3 items-center px-4 py-3">
             <div />
             <div className="flex justify-center">
-              <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+              <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
             </div>
             <div />
           </div>
@@ -180,7 +180,7 @@ export default function MyProfilePage() {
           </div>
 
           <div className="flex justify-center">
-            <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+            <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
           </div>
 
           <div className="flex justify-end">

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -70,7 +70,7 @@ export default function OnboardingPage() {
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       {/* Header */}
       <header className="flex items-center justify-between p-6">
-        <h1 className="text-2xl font-bold tracking-tight text-primary">BookLog</h1>
+        <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
         <button onClick={completeOnboarding} className="text-sm font-medium text-primary/60">
           건너뛰기
         </button>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -273,7 +273,7 @@ export default function SettingsPage() {
           <div className="text-center text-primary/20">
             <div className="mb-2 flex items-center justify-center gap-2">
               <span className="material-symbols-outlined text-[18px]">menu_book</span>
-              <span className="text-2xl italic">BookLog</span>
+              <span className="text-2xl italic">Shelfeed</span>
             </div>
             <p className="text-sm uppercase tracking-wider">Version 2.4.0</p>
           </div>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -157,7 +157,7 @@ export default function SignupPage() {
           <span className="material-symbols-outlined text-[24px]">arrow_back</span>
         </button>
         <h2 className="flex-1 pr-12 text-center text-lg font-bold leading-tight tracking-tight">
-          {step === 1 ? '회원가입' : 'BookLog'}
+          {step === 1 ? '회원가입' : 'Shelfeed'}
         </h2>
       </div>
 
@@ -178,7 +178,7 @@ export default function SignupPage() {
           {/* Step 1: 계정 정보 */}
           <div className="px-4 pb-3 pt-6">
             <h1 className="text-[32px] font-bold leading-tight tracking-tight">
-              BookLog에 오신 것을 환영합니다
+              Shelfeed에 오신 것을 환영합니다
             </h1>
             <p className="pt-2 text-base text-muted-foreground">
               먼저 로그인에 사용할 계정 정보를 입력해주세요.


### PR DESCRIPTION
- 사용자 노출 텍스트 일괄 교체: 브라우저 탭 타이틀, AppHeader 기본값, 로그인/회원가입/이메일 인증/온보딩/홈/프로필/설정/도서 상세/도서 검색 페이지의 헤더·로고·환영 문구
- BookSearchPage의 localStorage 키 booklog-recent-keywords → shelfeed-recent-keywords (MVP 단계라 마이그레이션 코드는 추가하지 않음)
- 백엔드/API 변경 없음. 로고 자산·favicon·README 등 자산 교체는 후속 이슈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 애플리케이션 브랜딩을 'BookLog'에서 'Shelfeed'로 업데이트했습니다. 페이지 제목, 헤더, 로컬스토리지 키를 포함한 전체 인터페이스의 표시 이름이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->