### PR TITLE
Feat/#105 email verify exit

### DIFF
--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -3,11 +3,19 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { verifyEmail, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
 
+// 진입 경로별로 EmailVerificationPage가 다른 탈출 UI를 노출하기 위한 식별자.
+// sender(SignupPage/SettingsPage)와 receiver(이 파일)가 동일한 union을 공유해 오타 시 컴파일 단계에서 차단.
+export type EmailVerifyEntryFrom = 'signup' | 'settings'
+export interface EmailVerifyLocationState {
+  email?: string
+  from?: EmailVerifyEntryFrom
+}
+
 export default function EmailVerificationPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const userEmail = useAuthStore(state => state.user?.email)
-  const navState = location.state as { email?: string; from?: 'signup' | 'settings' } | null
+  const navState = location.state as EmailVerifyLocationState | null
   const email = navState?.email ?? userEmail
   // 회원가입 직후 진입한 경우만 "건너뛰기" 패턴, 그 외(설정에서 진입 등)는 뒤로가기 아이콘
   const fromSignup = navState?.from === 'signup'
@@ -123,6 +131,7 @@ export default function EmailVerificationPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
+      {/* AppHeader 대신 자체 헤더: AppHeader의 우측 rightAction 슬롯이 w-10으로 고정되어 "건너뛰기" 텍스트가 잘리므로 grid 3분할 직접 구성 */}
       <header className="grid grid-cols-3 items-center border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md">
         <div className="flex justify-start">
           {!fromSignup && (
@@ -142,6 +151,8 @@ export default function EmailVerificationPage() {
             <button
               type="button"
               onClick={() => navigate('/', { replace: true })}
+              aria-label="이메일 인증 건너뛰고 홈으로 이동"
+              // SignupPage가 verify-email로 replace 이동 + 여기서 home으로 replace 이동 → 회원가입/인증 페이지가 history에 남지 않아 뒤로가기로 재진입 불가 (의도)
               className="rounded-full px-3 py-1.5 text-sm font-medium text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
             >
               건너뛰기

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -7,7 +7,10 @@ export default function EmailVerificationPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const userEmail = useAuthStore(state => state.user?.email)
-  const email = (location.state as { email?: string } | null)?.email ?? userEmail
+  const navState = location.state as { email?: string; from?: 'signup' | 'settings' } | null
+  const email = navState?.email ?? userEmail
+  // 회원가입 직후 진입한 경우만 "건너뛰기" 패턴, 그 외(설정에서 진입 등)는 뒤로가기 아이콘
+  const fromSignup = navState?.from === 'signup'
 
   const [code, setCode] = useState(['', '', '', '', '', ''])
   const [isVerifying, setIsVerifying] = useState(false)
@@ -120,8 +123,31 @@ export default function EmailVerificationPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <header className="flex items-center justify-center border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md">
-        <h1 className="text-xl font-bold tracking-tight text-primary">Shelfeed</h1>
+      <header className="grid grid-cols-3 items-center border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md">
+        <div className="flex justify-start">
+          {!fromSignup && (
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              aria-label="이전 페이지로 돌아가기"
+              className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
+            >
+              <span className="material-symbols-outlined">arrow_back</span>
+            </button>
+          )}
+        </div>
+        <h1 className="text-center text-xl font-bold tracking-tight text-primary">Shelfeed</h1>
+        <div className="flex justify-end">
+          {fromSignup && (
+            <button
+              type="button"
+              onClick={() => navigate('/', { replace: true })}
+              className="rounded-full px-3 py-1.5 text-sm font-medium text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
+            >
+              건너뛰기
+            </button>
+          )}
+        </div>
       </header>
 
       <main className="flex flex-1 flex-col items-center px-6 pt-16">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -115,7 +115,7 @@ export default function SettingsPage() {
     setVerificationError(null)
     try {
       await resendEmailCode(user.email)
-      navigate('/verify-email', { state: { email: user.email } })
+      navigate('/verify-email', { state: { email: user.email, from: 'settings' } })
     } catch (error) {
       setVerificationError(
         error instanceof Error ? error.message : '인증 코드 발송에 실패했습니다.'

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import { logout, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
+import type { EmailVerifyLocationState } from '@/pages/EmailVerificationPage'
 
 function Toggle({
   checked,
@@ -115,7 +116,8 @@ export default function SettingsPage() {
     setVerificationError(null)
     try {
       await resendEmailCode(user.email)
-      navigate('/verify-email', { state: { email: user.email, from: 'settings' } })
+      const verifyState: EmailVerifyLocationState = { email: user.email, from: 'settings' }
+      navigate('/verify-email', { state: verifyState })
     } catch (error) {
       setVerificationError(
         error instanceof Error ? error.message : '인증 코드 발송에 실패했습니다.'

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, Link } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { signup, checkEmail, checkNickname } from '@/api/auth'
 import { PASSWORD_REGEX } from '@/constants/validation'
+import type { EmailVerifyLocationState } from '@/pages/EmailVerificationPage'
 
 const step1Schema = z
   .object({
@@ -133,7 +134,8 @@ export default function SignupPage() {
         },
         result.accessToken
       )
-      navigate('/verify-email', { replace: true, state: { email, from: 'signup' } })
+      const verifyState: EmailVerifyLocationState = { email, from: 'signup' }
+      navigate('/verify-email', { replace: true, state: verifyState })
     } catch (error) {
       setStep2ErrorMessage(error instanceof Error ? error.message : '회원가입에 실패했습니다.')
     } finally {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -133,7 +133,7 @@ export default function SignupPage() {
         },
         result.accessToken
       )
-      navigate('/verify-email', { replace: true, state: { email } })
+      navigate('/verify-email', { replace: true, state: { email, from: 'signup' } })
     } catch (error) {
       setStep2ErrorMessage(error instanceof Error ? error.message : '회원가입에 실패했습니다.')
     } finally {


### PR DESCRIPTION
- 진입 경로 식별을 위해 navigate state에 from 필드 추가
  (회원가입: 'signup', 설정: 'settings')
- EmailVerificationPage 헤더를 3분할 그리드(좌/중/우)로 재구성
- 회원가입 직후 진입(from='signup') → 우측 "건너뛰기" 버튼 노출,
  클릭 시 navigate('/', { replace: true })
- 설정 등 그 외 경로 진입 → 좌측 뒤로가기 화살표 아이콘 노출,
  클릭 시 navigate(-1)
- 인증 성공 흐름과 이메일 정보 없을 때 폴백 화면은 기존 동작 유지


- EmailVerifyEntryFrom / EmailVerifyLocationState 타입을
  EmailVerificationPage에서 export, SignupPage/SettingsPage가
  import하여 sender 측에도 타입 강제 (오타 시 컴파일 단계 차단)
- "건너뛰기" 버튼에 aria-label 추가 (스크린 리더 명시성 보강)
- 더블 replace: true 흐름의 의도(가입/인증 history 누적 차단)
  주석 명시
- AppHeader 미사용 사유(우측 슬롯 폭 제약) 주석 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 이메일 인증 페이지 헤더 UI 개선: 가입 과정에서 접근 시 "건너뛰기" 버튼, 설정에서 접근 시 뒤로가기 버튼 표시
  * 헤더 레이아웃을 3열 그리드로 개선하여 조건부 액션 버튼 지원
  * 가입 및 설정 페이지에서 이메일 인증으로의 이동 시 진입 경로 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->