### PR TITLE
feat: 감상작성, 감상상세조회 api 연동

### DIFF
--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,5 +1,6 @@
 import apiClient from './client'
 import { ApiResponse, normalizeAxiosError } from './_helpers'
+import type { BackendReadingStatus } from './book'
 
 export interface CreateReviewRequest {
   bookId: number
@@ -11,6 +12,34 @@ export interface CreateReviewRequest {
 
 export interface CreateReviewResponse {
   reviewId: number
+}
+
+export interface ReviewDetail {
+  reviewId: number
+  user: {
+    userId: number
+    nickname: string
+    profileImageUrl: string | null
+  }
+  book: {
+    bookId: number
+    isbn13?: string
+    title: string
+    author: string
+    publisher?: string | null
+    coverImageUrl: string | null
+    description?: string | null
+  }
+  rating: number
+  content: string
+  quote: string | null
+  isSpoiler: boolean
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  tags?: string[]
+  readingStatus?: BackendReadingStatus | null
+  createdAt: string
 }
 
 export async function createReview(request: CreateReviewRequest): Promise<CreateReviewResponse> {
@@ -27,5 +56,24 @@ export async function createReview(request: CreateReviewRequest): Promise<Create
     return data.data
   } catch (error) {
     throw normalizeAxiosError(error, '감상을 작성하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function getReviewDetail(
+  reviewId: number,
+  signal?: AbortSignal
+): Promise<ReviewDetail> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<ReviewDetail>>(`/api/v1/reviews/${reviewId}`, {
+      signal,
+    })
+
+    if (!data.data) {
+      throw new Error(data.message ?? '감상 상세 응답이 올바르지 않습니다.')
+    }
+
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상 상세를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,0 +1,31 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError } from './_helpers'
+
+export interface CreateReviewRequest {
+  bookId: number
+  content: string
+  rating: number
+  quote?: string
+  isSpoiler?: boolean
+}
+
+export interface CreateReviewResponse {
+  reviewId: number
+}
+
+export async function createReview(request: CreateReviewRequest): Promise<CreateReviewResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<CreateReviewResponse>>(
+      '/api/v1/reviews',
+      request
+    )
+
+    if (!data.data) {
+      throw new Error(data.message ?? '감상 작성 응답이 올바르지 않습니다.')
+    }
+
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상을 작성하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -14,18 +14,11 @@ const readingStatusLabel: Record<ReadingStatus, string> = {
   want_to_read: '읽고 싶어요',
 }
 
-const commentTemplates = [
-  '문장 해석이 인상적이네요. 저도 다시 읽어보고 싶어요.',
-  '공감되는 감상이에요. 다음에도 이런 리뷰 기대할게요.',
-  '스포일러 경고 덕분에 안심하고 읽었습니다. 감사합니다!',
-]
-
 export default function ReviewDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
   const reviewId = Number(id)
   const [review, setReview] = useState<ReviewDetail | null>(null)
-  const [liked, setLiked] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
@@ -42,11 +35,13 @@ export default function ReviewDetailPage() {
     ;(async () => {
       try {
         const result = await getReviewDetail(reviewId, controller.signal)
-        if (controller.signal.aborted) return
         setReview(result)
-        setLiked(result.isLiked)
       } catch (error) {
-        if (axios.isCancel(error) || controller.signal.aborted) return
+        // [MED-1 fix] try 블록 내 controller.signal.aborted 가드는 사실상 도달 불가
+        // (요청이 abort되면 axios가 throw로 빠짐) + _helpers.ts의 normalizeAxiosError가
+        // 이미 cancel을 rethrow하므로 catch에서 axios.isCancel만 보면 책임이 끝난다.
+        // 다른 도메인(book/library 등)과 패턴 통일 + CLAUDE.md "방어 코드 최소화"에 맞춰 단일화.
+        if (axios.isCancel(error)) return
         setErrorMessage(error instanceof Error ? error.message : '감상을 불러오지 못했습니다.')
       } finally {
         if (!controller.signal.aborted) setIsLoading(false)
@@ -104,21 +99,23 @@ export default function ReviewDetailPage() {
     ? backendToFrontStatus[review.readingStatus]
     : undefined
   const reviewStatus = frontReadingStatus ? readingStatusLabel[frontReadingStatus] : '기록'
-  const likeCount = Math.max(0, review.likeCount + (liked === review.isLiked ? 0 : liked ? 1 : -1))
-  const comments = Array.from({ length: Math.min(review.commentCount ?? 0, 3) }, (_, index) => ({
-    id: index + 1,
-    author: `독자 ${index + 1}`,
-    time: `${index + 1}시간 전`,
-    content: commentTemplates[index % commentTemplates.length],
-  }))
   const tags: string[] =
     review.tags && review.tags.length > 0
       ? review.tags
       : [review.book.author, review.book.publisher, reviewStatus].filter((tag): tag is string =>
           Boolean(tag)
         )
-  const quote = review.quote ?? review.book.description ?? review.content
-  const quoteSource = review.quote || !review.book.description ? '감상 중에서' : '도서 소개'
+  // [MED-2 fix] 이전엔 quote 결정은 ?? (null/undefined만 fallthrough), source 결정은 || (빈 문자열도 falsy)
+  // 라 백엔드가 quote: ""를 보내면 quote 자리에 빈 문자열이 렌더되면서 라벨은 '감상 중에서'로
+  // 잘못 표기되는 미스매치가 있었다. 두 분기 모두 || 기준으로 통일하고 hasOwnQuote 플래그로
+  // 라벨을 정확히 결정하도록 수정.
+  const hasOwnQuote = Boolean(review.quote)
+  const quote = review.quote || review.book.description || review.content
+  const quoteSource = hasOwnQuote
+    ? '감상 중에서'
+    : review.book.description
+      ? '도서 소개'
+      : '감상 중에서'
   const coverImageUrl = review.book.coverImageUrl
 
   return (
@@ -206,77 +203,74 @@ export default function ReviewDetailPage() {
           </div>
         </section>
 
-        {/* Reactions */}
+        {/* Reactions
+            [HIGH-2 fix] 이전엔 좋아요 버튼이 로컬 state(liked)만 토글되어 새로고침 시 액션이
+            사라지고, likeCount 계산식도 초기값 대비 한 번의 토글에만 정확했다. POST/DELETE
+            좋아요 API가 본 PR 범위 밖이므로 일단 disabled로 처리해 서버에서 받은 isLiked /
+            likeCount를 표시만 한다. 좋아요 API 연동은 후속 이슈에서 처리.
+            [MED-3 fix] 이전엔 review.commentCount ?? 0 형태로 가드했지만 타입은 number(non-null)
+            이라 가드 불필요. CLAUDE.md "방어 코드 최소화" + 타입 신뢰성을 위해 ?? 0 제거. */}
         <section className="mt-4 border-t border-border px-5 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-5 text-sm font-semibold text-muted-foreground">
               <button
-                onClick={() => setLiked(prev => !prev)}
-                className="flex items-center gap-1.5 transition-colors hover:text-primary"
+                type="button"
+                disabled
+                aria-label="좋아요 (준비 중)"
+                className="flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <span
                   className="material-symbols-outlined text-[20px]"
-                  style={{ fontVariationSettings: `'FILL' ${liked ? 1 : 0}` }}
+                  style={{ fontVariationSettings: `'FILL' ${review.isLiked ? 1 : 0}` }}
                 >
                   favorite
                 </span>
-                <span>{likeCount}</span>
+                <span>{review.likeCount}</span>
               </button>
 
               <div className="flex items-center gap-1.5">
                 <span className="material-symbols-outlined text-[20px]">chat_bubble</span>
-                <span>{review.commentCount ?? 0}</span>
+                <span>{review.commentCount}</span>
               </div>
             </div>
 
-            <button className="text-muted-foreground transition-colors hover:text-primary">
+            <button
+              type="button"
+              disabled
+              aria-label="공유 (준비 중)"
+              className="text-muted-foreground/40 disabled:cursor-not-allowed"
+            >
               <span className="material-symbols-outlined text-[22px]">share</span>
             </button>
           </div>
         </section>
 
-        {/* Comments */}
+        {/* Comments
+            [MED-4 fix] 이전엔 commentTemplates ("독자 1: 문장 해석이 인상적이네요…")로 가짜 댓글을
+            진짜처럼 렌더해 사용자가 실제 댓글로 오해할 수 있었다. 댓글 API가 본 PR 범위 밖이므로
+            placeholder("댓글 기능은 곧 제공될 예정입니다.")로 교체하여 명시적 "준비 중" 상태를
+            표시. 댓글 API 연동은 후속 이슈에서 처리. */}
         <section className="px-5 pb-6 pt-2">
-          <h3 className="mb-4 text-lg font-bold">댓글 {review.commentCount ?? 0}개</h3>
-
-          {comments.length > 0 ? (
-            <div className="border-t border-border">
-              {comments.map(comment => (
-                <div key={comment.id} className="border-b border-border py-4">
-                  <div className="mb-2 flex items-start justify-between gap-3">
-                    <div className="flex items-center gap-3">
-                      <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
-                        {comment.author[0]}
-                      </div>
-                      <div>
-                        <p className="text-sm font-bold">{comment.author}</p>
-                        <p className="text-xs text-muted-foreground">{comment.time}</p>
-                      </div>
-                    </div>
-                  </div>
-
-                  <p className="pl-[52px] text-sm leading-6 text-foreground/85">
-                    {comment.content}
-                  </p>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="rounded-xl bg-card px-4 py-5 text-center text-sm text-muted-foreground">
-              아직 댓글이 없습니다.
-            </div>
-          )}
+          <h3 className="mb-4 text-lg font-bold">댓글 {review.commentCount}개</h3>
+          <div className="rounded-xl bg-card px-4 py-5 text-center text-sm text-muted-foreground">
+            댓글 기능은 곧 제공될 예정입니다.
+          </div>
         </section>
 
-        {/* Comment Input */}
+        {/* Comment Input — [MED-4 fix] 위와 동일 사유로 입력창/게시 버튼 모두 disabled 처리 */}
         <section className="border-t border-border px-5 py-4">
-          <div className="flex items-center gap-3 rounded-full border border-primary/10 bg-card px-4 py-3">
+          <div className="flex items-center gap-3 rounded-full border border-primary/10 bg-card px-4 py-3 opacity-60">
             <input
               type="text"
-              placeholder="따뜻한 댓글을 남겨주세요"
-              className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/50"
+              disabled
+              placeholder="댓글 기능 준비 중"
+              className="min-w-0 flex-1 cursor-not-allowed bg-transparent text-sm outline-none placeholder:text-muted-foreground/50"
             />
-            <button className="text-sm font-bold text-primary transition-colors hover:text-primary/80">
+            <button
+              type="button"
+              disabled
+              className="cursor-not-allowed text-sm font-bold text-primary/40"
+            >
               게시
             </button>
           </div>

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import axios from 'axios'
+import { getReviewDetail, type ReviewDetail } from '@/api/review'
+import { backendToFrontStatus } from '@/api/library'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
-import { mockBookDetailReviews, mockReviews } from '@/mocks/data'
 import type { ReadingStatus } from '@/types'
 
 const readingStatusLabel: Record<ReadingStatus, string> = {
@@ -21,12 +23,56 @@ const commentTemplates = [
 export default function ReviewDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const [liked, setLiked] = useState(false)
-  const allReviews = useMemo(() => [...mockReviews, ...mockBookDetailReviews], [])
   const reviewId = Number(id)
-  const review = allReviews.find(item => item.id === reviewId)
+  const [review, setReview] = useState<ReviewDetail | null>(null)
+  const [liked, setLiked] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  if (!review) {
+  useEffect(() => {
+    if (!Number.isFinite(reviewId)) {
+      setErrorMessage('감상 정보가 올바르지 않습니다.')
+      setIsLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const result = await getReviewDetail(reviewId, controller.signal)
+        if (controller.signal.aborted) return
+        setReview(result)
+        setLiked(result.isLiked)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '감상을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [reviewId])
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="감상 상세" showBack />
+
+        <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        </main>
+
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (errorMessage || !review) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="감상 상세" showBack />
@@ -36,6 +82,11 @@ export default function ReviewDetailPage() {
             search_off
           </span>
           <p className="text-lg font-bold text-muted-foreground">감상을 찾을 수 없습니다</p>
+          {errorMessage && (
+            <p role="alert" className="max-w-[280px] text-center text-sm text-muted-foreground">
+              {errorMessage}
+            </p>
+          )}
           <button
             onClick={() => navigate(-1)}
             className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
@@ -49,17 +100,26 @@ export default function ReviewDetailPage() {
     )
   }
 
-  const reviewStatus = review.readingStatus ? readingStatusLabel[review.readingStatus] : '기록'
-  const likeCount = review.likeCount + (liked ? 1 : 0)
+  const frontReadingStatus = review.readingStatus
+    ? backendToFrontStatus[review.readingStatus]
+    : undefined
+  const reviewStatus = frontReadingStatus ? readingStatusLabel[frontReadingStatus] : '기록'
+  const likeCount = Math.max(0, review.likeCount + (liked === review.isLiked ? 0 : liked ? 1 : -1))
   const comments = Array.from({ length: Math.min(review.commentCount ?? 0, 3) }, (_, index) => ({
     id: index + 1,
     author: `독자 ${index + 1}`,
     time: `${index + 1}시간 전`,
     content: commentTemplates[index % commentTemplates.length],
   }))
-  const tags = [review.book.author, review.book.publisher, reviewStatus]
-  const quote = review.book.description ?? review.content
-  const quoteSource = review.book.description ? '도서 소개' : '감상 중에서'
+  const tags: string[] =
+    review.tags && review.tags.length > 0
+      ? review.tags
+      : [review.book.author, review.book.publisher, reviewStatus].filter((tag): tag is string =>
+          Boolean(tag)
+        )
+  const quote = review.quote ?? review.book.description ?? review.content
+  const quoteSource = review.quote || !review.book.description ? '감상 중에서' : '도서 소개'
+  const coverImageUrl = review.book.coverImageUrl
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -71,11 +131,17 @@ export default function ReviewDetailPage() {
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
             <div className="bg-muted/30 px-6 py-8">
               <div className="mx-auto aspect-[2/3] w-[62%] max-w-[260px] overflow-hidden rounded-md shadow-xl">
-                <img
-                  src={review.book.coverImageUrl}
-                  alt={review.book.title}
-                  className="size-full object-cover"
-                />
+                {coverImageUrl ? (
+                  <img
+                    src={coverImageUrl}
+                    alt={review.book.title}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="flex size-full items-center justify-center bg-primary/10 text-primary/35">
+                    <span className="material-symbols-outlined text-5xl">menu_book</span>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -92,7 +158,7 @@ export default function ReviewDetailPage() {
                   >
                     star
                   </span>
-                  <span>{(review.rating ?? review.book.rating ?? 0).toFixed(1)}</span>
+                  <span>{review.rating.toFixed(1)}</span>
                 </div>
               </div>
 

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -1,40 +1,104 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import axios from 'axios'
+import { getBook, type BookDetail } from '@/api/book'
+import { createReview } from '@/api/review'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
-import { mockBooks } from '@/mocks/data'
 
 export default function WriteReviewPage() {
   const { bookId } = useParams()
   const navigate = useNavigate()
-  const book = bookId ? mockBooks.find(item => item.isbn === bookId) : undefined
 
+  const [book, setBook] = useState<BookDetail | null>(null)
   const [rating, setRating] = useState(5)
   const [reviewText, setReviewText] = useState('')
   const [quoteText, setQuoteText] = useState('')
   const [isQuoteEditorOpen, setIsQuoteEditorOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  if (!bookId) {
+  useEffect(() => {
+    const isValid = /^\d+$/.test(bookId ?? '')
+    if (!isValid) {
+      setErrorMessage(
+        bookId ? '잘못된 도서 ID입니다.' : '도서를 먼저 선택하면 감상을 작성할 수 있어요.'
+      )
+      setBook(null)
+      setIsLoading(false)
+      return
+    }
+
+    const numericBookId = parseInt(bookId!, 10)
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const result = await getBook(numericBookId, controller.signal)
+        if (controller.signal.aborted) return
+        setBook(result)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '도서를 불러오지 못했습니다.')
+        setBook(null)
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [bookId])
+
+  const handleSubmit = async () => {
+    const isValid = /^\d+$/.test(bookId ?? '')
+    const trimmedContent = reviewText.trim()
+    const trimmedQuote = quoteText.trim()
+
+    if (!isValid || !book) {
+      setErrorMessage('도서 정보가 올바르지 않습니다.')
+      return
+    }
+
+    if (!trimmedContent) {
+      setErrorMessage('감상 내용을 입력해주세요.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrorMessage(null)
+    try {
+      const result = await createReview({
+        bookId: parseInt(bookId!, 10),
+        content: trimmedContent,
+        rating,
+        ...(trimmedQuote ? { quote: trimmedQuote } : {}),
+        isSpoiler: false,
+      })
+      navigate(`/review/${result.reviewId}`, { replace: true })
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '감상을 작성하지 못했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="감상 작성" showBack />
-        <main className="flex flex-1 flex-col items-center justify-center gap-4 px-8 pb-24">
-          <p className="text-center text-sm text-muted-foreground">
-            도서를 먼저 선택하면 해당 책 기준으로 감상을 작성할 수 있어요.
+        <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
           </p>
-          <button
-            onClick={() => navigate(-1)}
-            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
-          >
-            돌아가기
-          </button>
         </main>
         <BottomNav />
       </div>
     )
   }
 
-  if (!book) {
+  if (errorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="감상 작성" showBack />
@@ -43,7 +107,11 @@ export default function WriteReviewPage() {
             search_off
           </span>
           <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
+          <p role="alert" className="max-w-[280px] text-center text-sm text-muted-foreground">
+            {errorMessage ?? '도서 정보를 불러올 수 없습니다.'}
+          </p>
           <button
+            type="button"
             onClick={() => navigate(-1)}
             className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
           >
@@ -65,7 +133,19 @@ export default function WriteReviewPage() {
           <div className="flex items-center gap-4">
             <div className="flex h-24 w-16 shrink-0 items-center justify-center rounded-2xl bg-card shadow-sm">
               <div className="h-20 w-12 overflow-hidden rounded-md border border-primary/10 bg-primary/5">
-                <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
+                {book.coverImageUrl ? (
+                  <img
+                    src={book.coverImageUrl}
+                    alt={book.title}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="flex size-full items-center justify-center">
+                    <span className="material-symbols-outlined text-3xl text-muted-foreground/30">
+                      menu_book
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -148,18 +228,27 @@ export default function WriteReviewPage() {
 
         {/* Action Buttons */}
         <section className="px-8 pb-6 pt-2">
+          {errorMessage && (
+            <p role="alert" className="mb-3 text-sm font-semibold text-destructive">
+              {errorMessage}
+            </p>
+          )}
+
           <div className="flex gap-3">
             <button
               type="button"
+              disabled={isSubmitting}
               className="h-14 flex-1 rounded-full border-2 border-primary bg-background text-base font-bold text-primary transition-colors hover:bg-primary/5"
             >
               임시저장
             </button>
             <button
               type="button"
-              className="h-14 flex-[1.7] rounded-full bg-primary text-base font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="h-14 flex-[1.7] rounded-full bg-primary text-base font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
             >
-              게시하기
+              {isSubmitting ? '게시 중...' : '게시하기'}
             </button>
           </div>
         </section>

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -15,14 +15,24 @@ export default function WriteReviewPage() {
   const [reviewText, setReviewText] = useState('')
   const [quoteText, setQuoteText] = useState('')
   const [isQuoteEditorOpen, setIsQuoteEditorOpen] = useState(false)
+  // [HIGH-1 fix] 이전엔 isSpoiler를 항상 false로 전송 → 사용자가 스포일러 글을 써도
+  // 피드의 ReviewCard에서 hasSpoiler 블러 처리가 동작하지 않아 다른 사용자에게 결말이 새는
+  // 도메인 정책 위반이 발생했다. 사용자가 명시적으로 토글로 표시하도록 state로 받음.
+  const [isSpoiler, setIsSpoiler] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  // [CodeRabbit fix] 단일 errorMessage가 "도서 로드 실패"와 "감상 제출 실패"를 함께 다뤄
+  // 제출 실패 시 하단의 풀페이지 분기(errorMessage || !book)에 걸려 "도서를 찾을 수 없습니다"
+  // 화면으로 점프하면서 사용자가 작성한 글이 사라진 것처럼 보였다.
+  // 두 흐름의 에러를 분리해 로드 실패는 풀페이지로, 제출 실패는 인라인 alert로 노출하고
+  // 작성한 글이 보존되도록 수정.
+  const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(null)
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     const isValid = /^\d+$/.test(bookId ?? '')
     if (!isValid) {
-      setErrorMessage(
+      setLoadErrorMessage(
         bookId ? '잘못된 도서 ID입니다.' : '도서를 먼저 선택하면 감상을 작성할 수 있어요.'
       )
       setBook(null)
@@ -33,15 +43,18 @@ export default function WriteReviewPage() {
     const numericBookId = parseInt(bookId!, 10)
     const controller = new AbortController()
     setIsLoading(true)
-    setErrorMessage(null)
+    setLoadErrorMessage(null)
     ;(async () => {
       try {
         const result = await getBook(numericBookId, controller.signal)
-        if (controller.signal.aborted) return
         setBook(result)
       } catch (error) {
-        if (axios.isCancel(error) || controller.signal.aborted) return
-        setErrorMessage(error instanceof Error ? error.message : '도서를 불러오지 못했습니다.')
+        // [MED-1 fix] try 블록 내 controller.signal.aborted 가드는 사실상 도달 불가
+        // (요청이 abort되면 axios가 throw로 빠짐) + _helpers.ts의 normalizeAxiosError가
+        // 이미 cancel을 rethrow하므로 catch에서 axios.isCancel만 보면 책임이 끝난다.
+        // 다른 도메인(book/library 등)과 패턴 통일 + CLAUDE.md "방어 코드 최소화"에 맞춰 단일화.
+        if (axios.isCancel(error)) return
+        setLoadErrorMessage(error instanceof Error ? error.message : '도서를 불러오지 못했습니다.')
         setBook(null)
       } finally {
         if (!controller.signal.aborted) setIsLoading(false)
@@ -57,28 +70,29 @@ export default function WriteReviewPage() {
     const trimmedQuote = quoteText.trim()
 
     if (!isValid || !book) {
-      setErrorMessage('도서 정보가 올바르지 않습니다.')
+      setSubmitErrorMessage('도서 정보가 올바르지 않습니다.')
       return
     }
 
     if (!trimmedContent) {
-      setErrorMessage('감상 내용을 입력해주세요.')
+      setSubmitErrorMessage('감상 내용을 입력해주세요.')
       return
     }
 
     setIsSubmitting(true)
-    setErrorMessage(null)
+    setSubmitErrorMessage(null)
     try {
       const result = await createReview({
         bookId: parseInt(bookId!, 10),
         content: trimmedContent,
         rating,
         ...(trimmedQuote ? { quote: trimmedQuote } : {}),
-        isSpoiler: false,
+        // [HIGH-1 fix] 사용자가 토글로 명시적으로 표시한 값을 그대로 전송 (이전엔 false 고정)
+        isSpoiler,
       })
       navigate(`/review/${result.reviewId}`, { replace: true })
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '감상을 작성하지 못했습니다.')
+      setSubmitErrorMessage(error instanceof Error ? error.message : '감상을 작성하지 못했습니다.')
     } finally {
       setIsSubmitting(false)
     }
@@ -98,7 +112,7 @@ export default function WriteReviewPage() {
     )
   }
 
-  if (errorMessage || !book) {
+  if (loadErrorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="감상 작성" showBack />
@@ -108,7 +122,7 @@ export default function WriteReviewPage() {
           </span>
           <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
           <p role="alert" className="max-w-[280px] text-center text-sm text-muted-foreground">
-            {errorMessage ?? '도서 정보를 불러올 수 없습니다.'}
+            {loadErrorMessage ?? '도서 정보를 불러올 수 없습니다.'}
           </p>
           <button
             type="button"
@@ -214,8 +228,10 @@ export default function WriteReviewPage() {
           </section>
         )}
 
-        {/* Quote Add Button */}
-        <section className="px-8 py-3">
+        {/* Quote Add Button + Spoiler Toggle
+            [HIGH-1 fix] 스포일러 토글 UI 추가. 이 값이 ReviewCard의 hasSpoiler 블러 분기와
+            연결되므로 작성자가 결말 노출 여부를 직접 선택할 수 있어야 한다. */}
+        <section className="flex items-center justify-between gap-4 px-8 py-3">
           <button
             type="button"
             onClick={() => setIsQuoteEditorOpen(true)}
@@ -224,13 +240,22 @@ export default function WriteReviewPage() {
             <span className="material-symbols-outlined text-[20px]">format_quote</span>
             인용구 추가
           </button>
+          <label className="flex cursor-pointer items-center gap-2 text-sm font-semibold text-muted-foreground select-none">
+            <input
+              type="checkbox"
+              checked={isSpoiler}
+              onChange={e => setIsSpoiler(e.target.checked)}
+              className="size-4 cursor-pointer accent-primary"
+            />
+            스포일러 포함
+          </label>
         </section>
 
         {/* Action Buttons */}
         <section className="px-8 pb-6 pt-2">
-          {errorMessage && (
+          {submitErrorMessage && (
             <p role="alert" className="mb-3 text-sm font-semibold text-destructive">
-              {errorMessage}
+              {submitErrorMessage}
             </p>
           )}
 


### PR DESCRIPTION
## 작업 내용

- 감상 작성 API를 연동했습니다.
  - `POST /api/v1/reviews`
  - 감상 내용, 별점, 인용구를 작성 요청에 포함
  - 작성 중 중복 제출 방지
  - 작성 성공 시 생성된 감상 상세 페이지로 이동

- 감상 상세 조회 API를 연동했습니다.
  - `GET /api/v1/reviews/{reviewId}`
  - 기존 mock 데이터 기반 상세 조회 제거
  - 로딩/에러 상태 처리 추가
  - 표지 이미지가 없을 경우 대체 UI 표시

- 감상 작성 페이지의 도서 조회 흐름을 수정했습니다.
  - 기존 `mockBooks` 기반 ISBN 조회 제거
  - URL의 숫자 `bookId` 검증
  - `GET /api/v1/books/{bookId}`로 작성 대상 도서 정보 조회

## 변경 파일

- `src/api/review.ts`
- `src/pages/WriteReviewPage.tsx`
- `src/pages/ReviewDetailPage.tsx`

## 테스트

- [x] `npm run build`

## 참고 사항

- 댓글 작성/좋아요 기능은 아직 API 연동 범위에 포함하지 않았습니다.
- 감상 작성 페이지는 서재/도서 상세에서 전달하는 숫자 `bookId` 기준으로 동작합니다.

수정한 파일이 적어 동작에 큰문제는 없겠지만, api 연동 코드에 문제가 있는지 검토 한번만 부탁드립니다. 감사합니다.

Closes #109 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 서버 기반 리뷰 API 연동(리뷰 생성·상세 조회) 추가
  * 리뷰 작성 페이지: 서버로 제출, 스포일러 토글, 제출 중 버튼 비활성화 및 진행 표시
  * 리뷰 상세 페이지: 서버에서 리뷰 로드, 커버 대체 이미지 표시, 서버 기준 좋아요/카운트 반영

* **개선**
  * 로딩·오류 처리 경로 분리 및 사용자용 에러 메시지 표시
  * 메타데이터(태그·인용문·별점) 우선 처리 개선
  * 댓글/반응 UI를 임시 비활성화하고 안내 메시지 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->