### PR TITLE
Feat/#113 refresh token flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// authStore mock — getState()를 동적으로 제어하기 위해 stateholder 패턴 사용
+const authState = {
+  user: { id: 1, nickname: 'tester', email: 't@t.com' },
+  accessToken: 'old-access-token',
+  isAuthenticated: true,
+}
+const setAuthMock = vi.fn((user, accessToken) => {
+  authState.user = user
+  authState.accessToken = accessToken
+})
+const clearAuthMock = vi.fn(() => {
+  authState.user = null as unknown as typeof authState.user
+  authState.accessToken = null as unknown as string
+  authState.isAuthenticated = false
+})
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: {
+    getState: () => ({
+      ...authState,
+      setAuth: setAuthMock,
+      clearAuth: clearAuthMock,
+    }),
+  },
+}))
+
+// window.location.href는 jsdom 없이도 mock 가능하도록 stub
+const originalLocation = globalThis.location
+const locationStub = { href: '' }
+beforeEach(() => {
+  // @ts-expect-error — node 환경에서 location 재할당 허용
+  globalThis.location = locationStub
+  locationStub.href = ''
+  authState.user = { id: 1, nickname: 'tester', email: 't@t.com' }
+  authState.accessToken = 'old-access-token'
+  authState.isAuthenticated = true
+  setAuthMock.mockClear()
+  clearAuthMock.mockClear()
+})
+afterEach(() => {
+  // @ts-expect-error — restore
+  globalThis.location = originalLocation
+  vi.restoreAllMocks()
+})
+
+describe('isAuthFlowUrl', () => {
+  it('인증 흐름 path는 true', async () => {
+    const { isAuthFlowUrl } = await import('./client')
+    expect(isAuthFlowUrl('/api/v1/auth/login')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/signup')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/logout')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/token/refresh')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/oauth2/google/login')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/email/verify')).toBe(true)
+    expect(isAuthFlowUrl('/api/v1/auth/password/reset')).toBe(true)
+  })
+
+  it('일반 도메인 path는 false', async () => {
+    const { isAuthFlowUrl } = await import('./client')
+    expect(isAuthFlowUrl('/api/v1/users/me')).toBe(false)
+    expect(isAuthFlowUrl('/api/v1/books/search')).toBe(false)
+    expect(isAuthFlowUrl('/api/v1/feed/following')).toBe(false)
+  })
+})
+
+describe('performRefresh', () => {
+  it('200 응답 시 새 accessToken 반환', async () => {
+    const client = await import('./client')
+    const postSpy = vi.spyOn(client.refreshClient, 'post').mockResolvedValueOnce({
+      data: {
+        status: 'SUCCESS',
+        code: 200,
+        data: { accessToken: 'new-access-token', accessTokenExpiresIn: 3600 },
+      },
+    } as never)
+
+    const token = await client.performRefresh()
+    expect(token).toBe('new-access-token')
+    expect(postSpy).toHaveBeenCalledOnce()
+    expect(postSpy).toHaveBeenCalledWith('/api/v1/auth/token/refresh')
+  })
+
+  it('400 응답 시 throw (refreshToken 쿠키 누락)', async () => {
+    const client = await import('./client')
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce({
+      response: { status: 400, data: { message: 'refreshToken이 없습니다.' } },
+      isAxiosError: true,
+    })
+    await expect(client.performRefresh()).rejects.toBeDefined()
+  })
+
+  it('401 응답 시 throw (refresh token 만료)', async () => {
+    const client = await import('./client')
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce({
+      response: { status: 401, data: { message: '만료된 refresh token입니다.' } },
+      isAxiosError: true,
+    })
+    await expect(client.performRefresh()).rejects.toBeDefined()
+  })
+
+  it('200 응답이지만 data가 비어있으면 throw', async () => {
+    const client = await import('./client')
+    vi.spyOn(client.refreshClient, 'post').mockResolvedValueOnce({
+      data: { status: 'SUCCESS', code: 200, message: '응답 손상' },
+    } as never)
+    await expect(client.performRefresh()).rejects.toThrow('응답 손상')
+  })
+})
+
+describe('getRefreshPromise (race condition 큐잉)', () => {
+  it('동시에 여러 번 호출해도 performRefresh는 한 번만 실행', async () => {
+    const client = await import('./client')
+    let resolveInner: ((token: string) => void) | undefined
+    const innerPromise = new Promise<string>(resolve => {
+      resolveInner = resolve
+    })
+    const postSpy = vi.spyOn(client.refreshClient, 'post').mockImplementationOnce(
+      () =>
+        innerPromise.then(token => ({
+          data: {
+            status: 'SUCCESS',
+            code: 200,
+            data: { accessToken: token, accessTokenExpiresIn: 3600 },
+          },
+        })) as never
+    )
+
+    // 5개 요청 동시 발생
+    const p1 = client.getRefreshPromise()
+    const p2 = client.getRefreshPromise()
+    const p3 = client.getRefreshPromise()
+    const p4 = client.getRefreshPromise()
+    const p5 = client.getRefreshPromise()
+
+    expect(postSpy).toHaveBeenCalledOnce()
+
+    resolveInner!('queued-token')
+    const results = await Promise.all([p1, p2, p3, p4, p5])
+    expect(results).toEqual([
+      'queued-token',
+      'queued-token',
+      'queued-token',
+      'queued-token',
+      'queued-token',
+    ])
+  })
+
+  it('첫 refresh 종료 후 두 번째 호출은 새 refresh를 시작', async () => {
+    const client = await import('./client')
+    const postSpy = vi
+      .spyOn(client.refreshClient, 'post')
+      .mockResolvedValueOnce({
+        data: {
+          status: 'SUCCESS',
+          code: 200,
+          data: { accessToken: 'token-1', accessTokenExpiresIn: 3600 },
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          status: 'SUCCESS',
+          code: 200,
+          data: { accessToken: 'token-2', accessTokenExpiresIn: 3600 },
+        },
+      } as never)
+
+    const first = await client.getRefreshPromise()
+    expect(first).toBe('token-1')
+
+    // refreshPromise가 null로 reset된 뒤 두 번째 호출은 새 refresh
+    const second = await client.getRefreshPromise()
+    expect(second).toBe('token-2')
+    expect(postSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('refresh 실패 후에도 다음 호출은 새 refresh를 시도', async () => {
+    const client = await import('./client')
+    const postSpy = vi
+      .spyOn(client.refreshClient, 'post')
+      .mockRejectedValueOnce({
+        response: { status: 401 },
+        isAxiosError: true,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          status: 'SUCCESS',
+          code: 200,
+          data: { accessToken: 'recovered-token', accessTokenExpiresIn: 3600 },
+        },
+      } as never)
+
+    await expect(client.getRefreshPromise()).rejects.toBeDefined()
+
+    // 실패 후 refreshPromise null reset 검증 — 두 번째 호출이 새 호출
+    const recovered = await client.getRefreshPromise()
+    expect(recovered).toBe('recovered-token')
+    expect(postSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -12,9 +12,12 @@ const authState: {
   accessToken: 'old-access-token',
   isAuthenticated: true,
 }
+// 실제 authStore의 setAuth는 isAuthenticated도 함께 true로 flip하므로 mock도 동일하게.
+// 향후 인터셉터가 isAuthenticated 의존 로직을 추가했을 때 회귀를 잡기 위해 미러링.
 const setAuthMock = vi.fn((user: typeof authState.user, accessToken: string) => {
   authState.user = user
   authState.accessToken = accessToken
+  authState.isAuthenticated = true
 })
 const clearAuthMock = vi.fn(() => {
   authState.user = null
@@ -220,17 +223,11 @@ describe('getRefreshPromise (race condition 큐잉)', () => {
  * 하지 않아도 되어 테스트가 빠르고 결정적.
  */
 describe('apiClient response interceptor — 401 분기', () => {
-  type ErrorHandler = (error: AxiosError) => Promise<unknown>
-
+  // handleApiClientResponseError를 named export로 분리한 뒤로는 axios 내부 handlers
+  // 배열에 의존하지 않고 직접 import하여 테스트한다 (브리틀한 내부 구조 의존 제거)
   async function getErrorHandler() {
     const client = await import('./client')
-    // axios 인터셉터의 내부 handlers 배열에 접근 — 첫 번째 핸들러의 rejected 콜백
-    const handlers = (
-      client.default.interceptors.response as unknown as {
-        handlers: Array<{ rejected: ErrorHandler }>
-      }
-    ).handlers
-    return handlers[0]!.rejected
+    return client.handleApiClientResponseError
   }
 
   function makeAxiosError(
@@ -307,18 +304,68 @@ describe('apiClient response interceptor — 401 분기', () => {
     expect(refreshSpy).not.toHaveBeenCalled()
   })
 
-  it('refresh 실패 → clearAuth + /login 리다이렉트', async () => {
+  it('refresh가 401(만료)로 실패 → clearAuth + /login 리다이렉트', async () => {
     const client = await import('./client')
     const handler = await getErrorHandler()
-    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce({
-      response: { status: 401 },
-      isAxiosError: true,
-    })
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce(
+      Object.assign(new Error('refresh 401'), {
+        isAxiosError: true,
+        response: { status: 401 },
+      })
+    )
 
     const error = makeAxiosError('/api/v1/users/me', 401)
     await expect(handler(error)).rejects.toBeDefined()
     expect(clearAuthMock).toHaveBeenCalledOnce()
     expect(locationStub.href).toBe('/login')
+  })
+
+  it('refresh가 400(쿠키 누락)으로 실패 → clearAuth + /login 리다이렉트', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce(
+      Object.assign(new Error('refresh 400'), {
+        isAxiosError: true,
+        response: { status: 400 },
+      })
+    )
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await expect(handler(error)).rejects.toBeDefined()
+    expect(clearAuthMock).toHaveBeenCalledOnce()
+    expect(locationStub.href).toBe('/login')
+  })
+
+  it('refresh가 네트워크 오류로 실패 → 세션 유지, logout 미호출 (CodeRabbit fix)', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce(
+      Object.assign(new Error('Network Error'), {
+        isAxiosError: true,
+        // response 없음 → 네트워크 오류
+      })
+    )
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await expect(handler(error)).rejects.toBeDefined()
+    expect(clearAuthMock).not.toHaveBeenCalled()
+    expect(locationStub.href).toBe('')
+  })
+
+  it('refresh가 5xx로 실패 → 세션 유지, logout 미호출 (CodeRabbit fix)', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce(
+      Object.assign(new Error('Server Error'), {
+        isAxiosError: true,
+        response: { status: 500 },
+      })
+    )
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await expect(handler(error)).rejects.toBeDefined()
+    expect(clearAuthMock).not.toHaveBeenCalled()
+    expect(locationStub.href).toBe('')
   })
 
   it('refresh 도중 logout 발생 시 setAuth 미호출, 원본 에러 reject (H1 fix)', async () => {

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,18 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AxiosError } from 'axios'
 
-// authStore mock — getState()를 동적으로 제어하기 위해 stateholder 패턴 사용
-const authState = {
+// authStore mock — 모듈 레벨에서 single source of truth로 다루고, 각 테스트는
+// authState 객체를 직접 변경해 다양한 인증 시나리오를 시뮬레이션한다
+const authState: {
+  user: { id: number; nickname: string; email: string } | null
+  accessToken: string | null
+  isAuthenticated: boolean
+} = {
   user: { id: 1, nickname: 'tester', email: 't@t.com' },
   accessToken: 'old-access-token',
   isAuthenticated: true,
 }
-const setAuthMock = vi.fn((user, accessToken) => {
+const setAuthMock = vi.fn((user: typeof authState.user, accessToken: string) => {
   authState.user = user
   authState.accessToken = accessToken
 })
 const clearAuthMock = vi.fn(() => {
-  authState.user = null as unknown as typeof authState.user
-  authState.accessToken = null as unknown as string
+  authState.user = null
+  authState.accessToken = null
   authState.isAuthenticated = false
 })
 
@@ -26,12 +32,15 @@ vi.mock('@/store/authStore', () => ({
   },
 }))
 
-// window.location.href는 jsdom 없이도 mock 가능하도록 stub
-const originalLocation = globalThis.location
+// node 환경엔 window/location이 없으므로 stub. 매 테스트마다 fresh 모듈을 import해
+// 모듈 레벨 state(refreshPromise, isLoggingOut)도 함께 reset.
+// client.ts는 `window.location.href`를 사용하므로 globalThis.window까지 stub해야
+// 실제 할당이 locationStub.href에 반영됨.
 const locationStub = { href: '' }
 beforeEach(() => {
-  // @ts-expect-error — node 환경에서 location 재할당 허용
-  globalThis.location = locationStub
+  vi.resetModules()
+  // @ts-expect-error — node 환경에서 window 재할당 허용 (jsdom 미사용)
+  globalThis.window = { location: locationStub }
   locationStub.href = ''
   authState.user = { id: 1, nickname: 'tester', email: 't@t.com' }
   authState.accessToken = 'old-access-token'
@@ -40,8 +49,8 @@ beforeEach(() => {
   clearAuthMock.mockClear()
 })
 afterEach(() => {
-  // @ts-expect-error — restore
-  globalThis.location = originalLocation
+  // @ts-expect-error — node 환경에서는 원래 window가 없으므로 단순 unset
+  delete globalThis.window
   vi.restoreAllMocks()
 })
 
@@ -62,6 +71,12 @@ describe('isAuthFlowUrl', () => {
     expect(isAuthFlowUrl('/api/v1/users/me')).toBe(false)
     expect(isAuthFlowUrl('/api/v1/books/search')).toBe(false)
     expect(isAuthFlowUrl('/api/v1/feed/following')).toBe(false)
+  })
+
+  it('쿼리스트링에 인증 path 문자열이 포함되어도 path는 일반 path면 false (M1 fix)', async () => {
+    const { isAuthFlowUrl } = await import('./client')
+    expect(isAuthFlowUrl('/api/v1/feed/comments?redirect=/api/v1/auth/login')).toBe(false)
+    expect(isAuthFlowUrl('/api/v1/users/me?from=/api/v1/auth/signup')).toBe(false)
   })
 })
 
@@ -127,7 +142,6 @@ describe('getRefreshPromise (race condition 큐잉)', () => {
         })) as never
     )
 
-    // 5개 요청 동시 발생
     const p1 = client.getRefreshPromise()
     const p2 = client.getRefreshPromise()
     const p3 = client.getRefreshPromise()
@@ -169,7 +183,6 @@ describe('getRefreshPromise (race condition 큐잉)', () => {
     const first = await client.getRefreshPromise()
     expect(first).toBe('token-1')
 
-    // refreshPromise가 null로 reset된 뒤 두 번째 호출은 새 refresh
     const second = await client.getRefreshPromise()
     expect(second).toBe('token-2')
     expect(postSpy).toHaveBeenCalledTimes(2)
@@ -193,9 +206,179 @@ describe('getRefreshPromise (race condition 큐잉)', () => {
 
     await expect(client.getRefreshPromise()).rejects.toBeDefined()
 
-    // 실패 후 refreshPromise null reset 검증 — 두 번째 호출이 새 호출
     const recovered = await client.getRefreshPromise()
     expect(recovered).toBe('recovered-token')
     expect(postSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+/**
+ * 응답 인터셉터 분기 테스트 (H2 fix).
+ *
+ * apiClient.interceptors.handlers의 두 번째 인자(error handler)를 직접 호출해
+ * 실제 인터셉터 로직을 단위 검증한다. 이 방식이 axios 전체 라이프사이클을 mock
+ * 하지 않아도 되어 테스트가 빠르고 결정적.
+ */
+describe('apiClient response interceptor — 401 분기', () => {
+  type ErrorHandler = (error: AxiosError) => Promise<unknown>
+
+  async function getErrorHandler() {
+    const client = await import('./client')
+    // axios 인터셉터의 내부 handlers 배열에 접근 — 첫 번째 핸들러의 rejected 콜백
+    const handlers = (
+      client.default.interceptors.response as unknown as {
+        handlers: Array<{ rejected: ErrorHandler }>
+      }
+    ).handlers
+    return handlers[0]!.rejected
+  }
+
+  function makeAxiosError(
+    url: string,
+    status: number | undefined,
+    extraConfig: Partial<{ _retry: boolean }> = {}
+  ): AxiosError {
+    return {
+      isAxiosError: true,
+      config: { url, headers: {}, ...extraConfig },
+      response:
+        status != null ? { status, data: {}, headers: {}, config: {}, statusText: '' } : undefined,
+      message: 'mock',
+      name: 'AxiosError',
+      toJSON: () => ({}),
+    } as unknown as AxiosError
+  }
+
+  it('401 + 일반 path + 미시도 + 로그인 상태 → refresh 1회 호출 + 새 토큰으로 setAuth', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+
+    vi.spyOn(client.refreshClient, 'post').mockResolvedValueOnce({
+      data: {
+        status: 'SUCCESS',
+        code: 200,
+        data: { accessToken: 'fresh-token', accessTokenExpiresIn: 3600 },
+      },
+    } as never)
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    // 재시도(apiClient(originalRequest))는 실제 axios가 노드 환경에서 네트워크 요청을 시도해
+    // 실패할 수 있으므로 결과는 신경쓰지 않고 setAuth 호출 여부만 검증한다.
+    // axios 1.x의 bound instance는 spy로 가로채기 어려워 retry 자체는 통합테스트로 검증.
+    await handler(error).catch(() => undefined)
+
+    expect(setAuthMock).toHaveBeenCalledOnce()
+    expect(setAuthMock.mock.calls[0]?.[1]).toBe('fresh-token')
+    expect(clearAuthMock).not.toHaveBeenCalled()
+    expect(locationStub.href).toBe('')
+  })
+
+  it('401 + 인증 흐름 path → refresh 시도 안 함, 그대로 reject', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    const refreshSpy = vi.spyOn(client.refreshClient, 'post')
+
+    const error = makeAxiosError('/api/v1/auth/login', 401)
+    await expect(handler(error)).rejects.toBe(error)
+    expect(refreshSpy).not.toHaveBeenCalled()
+    expect(clearAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('401 + _retry: true (이미 재시도된 요청) → refresh 시도 안 함, 그대로 reject', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    const refreshSpy = vi.spyOn(client.refreshClient, 'post')
+
+    const error = makeAxiosError('/api/v1/users/me', 401, { _retry: true })
+    await expect(handler(error)).rejects.toBe(error)
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it('401 + 비로그인 상태 → refresh 시도 안 함', async () => {
+    authState.isAuthenticated = false
+    authState.user = null
+    authState.accessToken = null
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    const refreshSpy = vi.spyOn(client.refreshClient, 'post')
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await expect(handler(error)).rejects.toBe(error)
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it('refresh 실패 → clearAuth + /login 리다이렉트', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce({
+      response: { status: 401 },
+      isAxiosError: true,
+    })
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await expect(handler(error)).rejects.toBeDefined()
+    expect(clearAuthMock).toHaveBeenCalledOnce()
+    expect(locationStub.href).toBe('/login')
+  })
+
+  it('refresh 도중 logout 발생 시 setAuth 미호출, 원본 에러 reject (H1 fix)', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+
+    let resolveInner: ((token: string) => void) | undefined
+    const innerPromise = new Promise<string>(resolve => {
+      resolveInner = resolve
+    })
+    vi.spyOn(client.refreshClient, 'post').mockImplementationOnce(
+      () =>
+        innerPromise.then(token => ({
+          data: {
+            status: 'SUCCESS',
+            code: 200,
+            data: { accessToken: token, accessTokenExpiresIn: 3600 },
+          },
+        })) as never
+    )
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    const handlerPromise = handler(error)
+
+    // refresh 진행 중 사용자가 logout
+    authState.isAuthenticated = false
+    authState.user = null
+
+    resolveInner!('would-be-stale-token')
+    await expect(handlerPromise).rejects.toBe(error)
+    expect(setAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('refresh 도중 다른 계정으로 전환 시 setAuth 미호출 (H1 fix)', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+
+    let resolveInner: ((token: string) => void) | undefined
+    const innerPromise = new Promise<string>(resolve => {
+      resolveInner = resolve
+    })
+    vi.spyOn(client.refreshClient, 'post').mockImplementationOnce(
+      () =>
+        innerPromise.then(token => ({
+          data: {
+            status: 'SUCCESS',
+            code: 200,
+            data: { accessToken: token, accessTokenExpiresIn: 3600 },
+          },
+        })) as never
+    )
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    const handlerPromise = handler(error)
+
+    // refresh 진행 중 다른 계정으로 전환 (id 변경)
+    authState.user = { id: 999, nickname: 'other', email: 'o@o.com' }
+
+    resolveInner!('cross-account-token')
+    await expect(handlerPromise).rejects.toBe(error)
+    expect(setAuthMock).not.toHaveBeenCalled()
   })
 })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
 import { useAuthStore } from '@/store/authStore'
+import type { ApiResponse } from './_helpers'
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 
@@ -33,13 +34,6 @@ interface TokenRefreshResponse {
   accessTokenExpiresIn: number
 }
 
-interface ApiResponseShape<T> {
-  status: string
-  code: number
-  data?: T
-  message?: string
-}
-
 /**
  * Refresh token 쿠키로 새 access token 발급.
  *
@@ -52,7 +46,7 @@ interface ApiResponseShape<T> {
  * @throws 응답이 200이 아니거나 data가 비어있으면 Error
  */
 async function performRefresh(): Promise<string> {
-  const { data } = await refreshClient.post<ApiResponseShape<TokenRefreshResponse>>(
+  const { data } = await refreshClient.post<ApiResponse<TokenRefreshResponse>>(
     '/api/v1/auth/token/refresh'
   )
   if (!data.data?.accessToken) {
@@ -86,6 +80,14 @@ function getRefreshPromise(): Promise<string> {
 }
 
 /**
+ * 동시 다수 401 실패 시 logoutAndRedirect가 N번 호출되는 것을 막는 가드.
+ *
+ * `clearAuth`는 멱등이지만 `window.location.href` 할당이 여러 번 발생하면 진행 중인
+ * 다른 비동기 작업과의 race를 만들 수 있어 단발화한다.
+ */
+let isLoggingOut = false
+
+/**
  * 사용자가 보호된 페이지에서 인증 만료(refresh 실패 포함) 시 호출.
  *
  * Zustand 인증 상태 초기화 + persist storage 정리 후 로그인 페이지로 강제 이동.
@@ -93,6 +95,8 @@ function getRefreshPromise(): Promise<string> {
  * 사용 시 stale state가 남을 수 있음).
  */
 function logoutAndRedirect() {
+  if (isLoggingOut) return
+  isLoggingOut = true
   useAuthStore.getState().clearAuth()
   window.location.href = '/login'
 }
@@ -127,8 +131,13 @@ const AUTH_FLOW_PATHS = [
   '/api/v1/auth/password',
 ]
 
+/**
+ * 인증 흐름 path 매칭. 쿼리스트링이 path에 인증 path 문자열을 포함하는 false positive를
+ * 막기 위해 path 부분만 잘라 startsWith로 정확 매칭한다.
+ */
 function isAuthFlowUrl(url: string): boolean {
-  return AUTH_FLOW_PATHS.some(p => url.includes(p))
+  const path = url.split('?')[0] ?? url
+  return AUTH_FLOW_PATHS.some(p => path.startsWith(p))
 }
 
 /**
@@ -138,7 +147,10 @@ function isAuthFlowUrl(url: string): boolean {
  * 1. 인증 흐름(login/signup/refresh 등) 호출이거나 이미 한 번 재시도한 요청이면 그대로 reject
  * 2. 비로그인 상태면 그대로 reject (이전 동작 유지 — 보호 라우트 진입 자체를 막지 않음)
  * 3. 그 외엔 _retry 플래그 부여 후 getRefreshPromise()로 새 토큰 획득 시도
- *    - 성공: authStore에 새 토큰 반영, 원래 요청의 Authorization 헤더 갱신, 재시도
+ *    - 성공 + 같은 사용자가 여전히 로그인 상태 → authStore 갱신 후 원래 요청 재시도
+ *      (Authorization 헤더는 요청 인터셉터가 store의 최신 토큰을 자동 부착하므로 명시 부착 불필요)
+ *    - 성공이지만 그 사이 logout/계정 전환 → 재시도하지 않고 원본 에러 reject (stale 토큰
+ *      주입 방지)
  *    - 실패: clearAuth + /login 리다이렉트
  */
 apiClient.interceptors.response.use(
@@ -157,15 +169,20 @@ apiClient.interceptors.response.use(
       useAuthStore.getState().isAuthenticated
     ) {
       originalRequest._retry = true
+      // refresh 직전의 user id를 스냅샷 — refresh 진행 중 logout/계정 전환 감지용
+      const userBefore = useAuthStore.getState().user
       try {
         const newToken = await getRefreshPromise()
-        const user = useAuthStore.getState().user
-        if (user) {
-          useAuthStore.getState().setAuth(user, newToken)
+        const stateAfter = useAuthStore.getState()
+        // refresh 도중 사용자가 logout했거나 다른 계정으로 전환된 경우 → 새 토큰을
+        // store에 주입하지 않고 원본 에러를 그대로 reject (토큰/사용자 불일치 방지)
+        if (!stateAfter.isAuthenticated || !stateAfter.user) {
+          return Promise.reject(error)
         }
-        if (originalRequest.headers) {
-          originalRequest.headers.Authorization = `Bearer ${newToken}`
+        if (userBefore && stateAfter.user.id !== userBefore.id) {
+          return Promise.reject(error)
         }
+        useAuthStore.getState().setAuth(stateAfter.user, newToken)
         return apiClient(originalRequest)
       } catch (refreshError) {
         logoutAndRedirect()

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,10 @@
-import axios from 'axios'
+import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
 import { useAuthStore } from '@/store/authStore'
 
+const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+  baseURL,
   timeout: 10000,
   withCredentials: true,
   headers: {
@@ -10,7 +12,97 @@ const apiClient = axios.create({
   },
 })
 
-// 요청 인터셉터 - JWT 토큰 자동 첨부
+/**
+ * Refresh 호출 전용 별도 axios 인스턴스.
+ *
+ * apiClient의 응답 인터셉터에 진입하지 않게 분리해, refresh 호출이 401/400을 받아도
+ * 무한 루프(refresh 실패 → 인터셉터가 또 refresh 시도)에 빠지지 않도록 한다.
+ * 쿠키 자동 전송이 필요하므로 withCredentials는 동일하게 true.
+ */
+const refreshClient = axios.create({
+  baseURL,
+  timeout: 10000,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+interface TokenRefreshResponse {
+  accessToken: string
+  accessTokenExpiresIn: number
+}
+
+interface ApiResponseShape<T> {
+  status: string
+  code: number
+  data?: T
+  message?: string
+}
+
+/**
+ * Refresh token 쿠키로 새 access token 발급.
+ *
+ * 응답 분기 (백엔드 명세):
+ * - 200: 성공, 새 accessToken 반환. refresh token도 자동 회전(쿠키 set 새로 됨)
+ * - 400: refreshToken 쿠키 미포함 → throw (재시도 무의미)
+ * - 401: refresh token 만료/무효 → throw (재시도 무의미)
+ *
+ * @returns 새 access token 문자열
+ * @throws 응답이 200이 아니거나 data가 비어있으면 Error
+ */
+async function performRefresh(): Promise<string> {
+  const { data } = await refreshClient.post<ApiResponseShape<TokenRefreshResponse>>(
+    '/api/v1/auth/token/refresh'
+  )
+  if (!data.data?.accessToken) {
+    throw new Error(data.message ?? '토큰 갱신 응답이 올바르지 않습니다.')
+  }
+  return data.data.accessToken
+}
+
+/**
+ * 진행 중인 refresh 호출의 in-flight Promise.
+ *
+ * 동시에 여러 요청이 401을 받아도 refresh API는 단 한 번만 호출되도록 큐잉한다.
+ * 첫 401 → performRefresh 시작 → refreshPromise에 저장. 후속 401들은 같은 Promise를
+ * await 후 새 토큰을 받아 자기 요청을 재시도. 완료(성공/실패) 후 null로 초기화하여
+ * 다음 만료 사이클에서 다시 동작한다.
+ */
+let refreshPromise: Promise<string> | null = null
+
+/**
+ * 인터셉터에서 사용하는 refresh 게이트웨이.
+ *
+ * 이미 진행 중인 refresh가 있으면 그 Promise를 그대로 반환(공유). 없으면 새로 시작.
+ */
+function getRefreshPromise(): Promise<string> {
+  if (!refreshPromise) {
+    refreshPromise = performRefresh().finally(() => {
+      refreshPromise = null
+    })
+  }
+  return refreshPromise
+}
+
+/**
+ * 사용자가 보호된 페이지에서 인증 만료(refresh 실패 포함) 시 호출.
+ *
+ * Zustand 인증 상태 초기화 + persist storage 정리 후 로그인 페이지로 강제 이동.
+ * window.location.href를 사용해 React Router 내부 상태도 초기화 (SPA navigate
+ * 사용 시 stale state가 남을 수 있음).
+ */
+function logoutAndRedirect() {
+  useAuthStore.getState().clearAuth()
+  window.location.href = '/login'
+}
+
+/**
+ * 요청 인터셉터.
+ *
+ * 매 요청마다 authStore의 최신 accessToken을 Authorization 헤더에 부착.
+ * 토큰 갱신 직후 재시도되는 요청도 새 토큰을 자동으로 받음.
+ */
 apiClient.interceptors.request.use(config => {
   const token = useAuthStore.getState().accessToken
   if (token) {
@@ -19,21 +111,72 @@ apiClient.interceptors.request.use(config => {
   return config
 })
 
-// 응답 인터셉터 - 401 처리 (인증된 사용자의 토큰 만료 시에만 로그아웃 처리)
+/**
+ * Refresh를 시도하지 않을 인증 흐름 자체의 호출 경로.
+ *
+ * 이 경로의 401은 사용자 자격증명 자체 문제(잘못된 비밀번호, 만료된 인증 코드 등)이거나
+ * refresh 자체의 실패라서 refresh 재시도가 무의미.
+ */
+const AUTH_FLOW_PATHS = [
+  '/api/v1/auth/login',
+  '/api/v1/auth/signup',
+  '/api/v1/auth/logout',
+  '/api/v1/auth/oauth2',
+  '/api/v1/auth/token/refresh',
+  '/api/v1/auth/email',
+  '/api/v1/auth/password',
+]
+
+function isAuthFlowUrl(url: string): boolean {
+  return AUTH_FLOW_PATHS.some(p => url.includes(p))
+}
+
+/**
+ * 응답 인터셉터.
+ *
+ * 401 응답 흐름:
+ * 1. 인증 흐름(login/signup/refresh 등) 호출이거나 이미 한 번 재시도한 요청이면 그대로 reject
+ * 2. 비로그인 상태면 그대로 reject (이전 동작 유지 — 보호 라우트 진입 자체를 막지 않음)
+ * 3. 그 외엔 _retry 플래그 부여 후 getRefreshPromise()로 새 토큰 획득 시도
+ *    - 성공: authStore에 새 토큰 반영, 원래 요청의 Authorization 헤더 갱신, 재시도
+ *    - 실패: clearAuth + /login 리다이렉트
+ */
 apiClient.interceptors.response.use(
   response => response,
-  async error => {
-    const requestUrl: string = error.config?.url ?? ''
-    const isLogoutCall = requestUrl.includes('/api/v1/auth/logout')
-    if (error.response?.status === 401 && !isLogoutCall) {
-      const wasAuthenticated = useAuthStore.getState().isAuthenticated
-      if (wasAuthenticated) {
-        useAuthStore.getState().clearAuth()
-        window.location.href = '/login'
+  async (error: AxiosError) => {
+    const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined
+    if (!originalRequest) return Promise.reject(error)
+
+    const requestUrl: string = originalRequest.url ?? ''
+    const status = error.response?.status
+
+    if (
+      status === 401 &&
+      !isAuthFlowUrl(requestUrl) &&
+      !originalRequest._retry &&
+      useAuthStore.getState().isAuthenticated
+    ) {
+      originalRequest._retry = true
+      try {
+        const newToken = await getRefreshPromise()
+        const user = useAuthStore.getState().user
+        if (user) {
+          useAuthStore.getState().setAuth(user, newToken)
+        }
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newToken}`
+        }
+        return apiClient(originalRequest)
+      } catch (refreshError) {
+        logoutAndRedirect()
+        return Promise.reject(refreshError)
       }
     }
+
     return Promise.reject(error)
   }
 )
 
 export default apiClient
+// 단위 테스트 전용 export (프로덕션 코드에서 직접 사용 금지)
+export { refreshClient, performRefresh, getRefreshPromise, isAuthFlowUrl }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -141,7 +141,24 @@ function isAuthFlowUrl(url: string): boolean {
 }
 
 /**
- * 응답 인터셉터.
+ * Refresh 실패가 인증 자체 문제(refresh token 누락/만료)인지 판단.
+ *
+ * 백엔드 명세상 refresh API는 400(쿠키 누락) / 401(만료)만 인증 문제.
+ * 그 외(네트워크/timeout/5xx)는 일시적 장애일 가능성이 높아 강제 logout은 UX 회귀.
+ * 따라서 이 함수가 true일 때만 logoutAndRedirect를 호출하고, 그 외엔 세션을
+ * 보존한 채 원본 에러만 propagate.
+ */
+function isAuthFailureRefreshError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false
+  const status = error.response?.status
+  return status === 400 || status === 401
+}
+
+/**
+ * 응답 인터셉터의 에러 핸들러.
+ *
+ * 인터셉터 등록 안에 anonymous로 두지 않고 export하여 단위 테스트가 axios 내부
+ * (interceptors.response.handlers[0].rejected) 접근 없이 직접 호출 가능하도록 한다.
  *
  * 401 응답 흐름:
  * 1. 인증 흐름(login/signup/refresh 등) 호출이거나 이미 한 번 재시도한 요청이면 그대로 reject
@@ -151,49 +168,58 @@ function isAuthFlowUrl(url: string): boolean {
  *      (Authorization 헤더는 요청 인터셉터가 store의 최신 토큰을 자동 부착하므로 명시 부착 불필요)
  *    - 성공이지만 그 사이 logout/계정 전환 → 재시도하지 않고 원본 에러 reject (stale 토큰
  *      주입 방지)
- *    - 실패: clearAuth + /login 리다이렉트
+ *    - refresh 실패가 400/401(인증 문제)이면 clearAuth + /login 리다이렉트
+ *    - refresh 실패가 그 외(네트워크/timeout/5xx)면 세션 유지하고 에러만 propagate
  */
-apiClient.interceptors.response.use(
-  response => response,
-  async (error: AxiosError) => {
-    const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined
-    if (!originalRequest) return Promise.reject(error)
+async function handleApiClientResponseError(error: AxiosError) {
+  const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined
+  if (!originalRequest) return Promise.reject(error)
 
-    const requestUrl: string = originalRequest.url ?? ''
-    const status = error.response?.status
+  const requestUrl: string = originalRequest.url ?? ''
+  const status = error.response?.status
 
-    if (
-      status === 401 &&
-      !isAuthFlowUrl(requestUrl) &&
-      !originalRequest._retry &&
-      useAuthStore.getState().isAuthenticated
-    ) {
-      originalRequest._retry = true
-      // refresh 직전의 user id를 스냅샷 — refresh 진행 중 logout/계정 전환 감지용
-      const userBefore = useAuthStore.getState().user
-      try {
-        const newToken = await getRefreshPromise()
-        const stateAfter = useAuthStore.getState()
-        // refresh 도중 사용자가 logout했거나 다른 계정으로 전환된 경우 → 새 토큰을
-        // store에 주입하지 않고 원본 에러를 그대로 reject (토큰/사용자 불일치 방지)
-        if (!stateAfter.isAuthenticated || !stateAfter.user) {
-          return Promise.reject(error)
-        }
-        if (userBefore && stateAfter.user.id !== userBefore.id) {
-          return Promise.reject(error)
-        }
-        useAuthStore.getState().setAuth(stateAfter.user, newToken)
-        return apiClient(originalRequest)
-      } catch (refreshError) {
-        logoutAndRedirect()
-        return Promise.reject(refreshError)
+  if (
+    status === 401 &&
+    !isAuthFlowUrl(requestUrl) &&
+    !originalRequest._retry &&
+    useAuthStore.getState().isAuthenticated
+  ) {
+    originalRequest._retry = true
+    // refresh 직전의 user id를 스냅샷 — refresh 진행 중 logout/계정 전환 감지용
+    const userBefore = useAuthStore.getState().user
+    try {
+      const newToken = await getRefreshPromise()
+      const stateAfter = useAuthStore.getState()
+      // refresh 도중 사용자가 logout했거나 다른 계정으로 전환된 경우 → 새 토큰을
+      // store에 주입하지 않고 원본 에러를 그대로 reject (토큰/사용자 불일치 방지)
+      if (!stateAfter.isAuthenticated || !stateAfter.user) {
+        return Promise.reject(error)
       }
+      if (userBefore && stateAfter.user.id !== userBefore.id) {
+        return Promise.reject(error)
+      }
+      useAuthStore.getState().setAuth(stateAfter.user, newToken)
+      return apiClient(originalRequest)
+    } catch (refreshError) {
+      // 인증 문제(400/401)일 때만 logout. 일시적 네트워크/timeout/5xx에선 세션 유지
+      if (isAuthFailureRefreshError(refreshError)) {
+        logoutAndRedirect()
+      }
+      return Promise.reject(refreshError)
     }
-
-    return Promise.reject(error)
   }
-)
+
+  return Promise.reject(error)
+}
+
+apiClient.interceptors.response.use(response => response, handleApiClientResponseError)
 
 export default apiClient
 // 단위 테스트 전용 export (프로덕션 코드에서 직접 사용 금지)
-export { refreshClient, performRefresh, getRefreshPromise, isAuthFlowUrl }
+export {
+  refreshClient,
+  performRefresh,
+  getRefreshPromise,
+  isAuthFlowUrl,
+  handleApiClientResponseError,
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+// 단위 테스트용 Vitest 설정. 브라우저 모드(@vitest/browser-playwright)는 storybook
+// 통합 전용으로 두고, 본 설정은 node 환경에서 axios 인터셉터/race condition 같은
+// 순수 로직 테스트를 빠르게 돌리는 데 집중한다.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})


### PR DESCRIPTION
axios 401 인터셉터가 즉시 로그아웃 → /login으로 강제 리다이렉트하던 기존 동작을
refresh-then-retry 흐름으로 교체. access token 만료 주기마다 사용자가 강제
재로그인하던 UX 회귀를 해소하고, HttpOnly 쿠키 기반 refresh를 자연스럽게 연동.

## 핵심 구현
- 별도 refreshClient axios 인스턴스 추가 — apiClient 인터셉터에 진입하지 않게
  분리해 refresh가 401/400을 받아도 무한 루프에 빠지지 않도록 격리
- performRefresh(): POST /api/v1/auth/token/refresh 호출, 200 OK면 새 accessToken
  반환 (refresh token도 백엔드에서 자동 회전)
- getRefreshPromise(): in-flight Promise 큐잉으로 동시 401에 대해 refresh API가
  단 한 번만 호출되도록 보장. 완료(성공/실패) 후 null reset되어 다음 만료
  사이클에 다시 동작
- 응답 인터셉터: 401 + 인증 흐름 path 아님 + 미시도 + 로그인 상태일 때만
  refresh 시도. 성공 시 authStore.setAuth로 새 토큰 반영 + originalRequest의
  Authorization 헤더 갱신 + apiClient(originalRequest)로 재시도. 실패 시
  clearAuth + window.location.href = '/login'
- isAuthFlowUrl(): /auth/login, /auth/signup, /auth/logout, /auth/oauth2,
  /auth/token/refresh, /auth/email, /auth/password 호출의 401은 refresh 시도하지 
  않음 (자체 인증 흐름의 401은 재시도 무의미)

## 백엔드 응답 명세 매핑 (AuthController.java:86-93)
- 200 OK → 갱신 성공
- 400 Bad Request → refreshToken 쿠키 누락 → 즉시 로그아웃
- 401 Unauthorized → refresh token 만료/무효 → 즉시 로그아웃

## 테스트 인프라
- vitest.config.ts 신설 — node 환경, @ alias 매핑, src/**/*.test.ts include
- package.json: test (vitest run), test:watch (vitest) 스크립트 추가
- src/api/client.test.ts 신규 — 9건 단위 테스트 작성, 전부 통과
  - isAuthFlowUrl: 인증/일반 path 분기 (2건)
  - performRefresh: 200/400/401/응답 손상 (4건)
  - getRefreshPromise race condition: 동시 5회 호출 큐잉, 종료 후 재호출,
    실패 후 recovery (3건)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * API 인증 및 토큰 갱신 흐름에 대한 포괄적인 단위 테스트 추가

* **기타**
  * 테스트 실행을 위한 스크립트 추가 (`test`, `test:watch`)
  * Vitest 테스트 환경 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->