### PR TITLE
feat: 알림 조회/읽음 API 연동 (#115)

### DIFF
--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -9,6 +9,22 @@ export interface ApiResponse<T> {
 }
 
 /**
+ * 백엔드 `ApiResponse<T>` 응답에서 `data` 필드를 안전하게 꺼낸다.
+ *
+ * `data`가 누락되어 있으면 백엔드 `message`(있으면)를, 없으면 `fallback`을 사용해
+ * 일반 `Error`를 던진다. 호출부의 `if (!data.data) throw ...; return data.data`
+ * 보일러플레이트를 일원화한다.
+ *
+ * @remarks 후속 cleanup 이슈에서 다른 api/*.ts 모듈도 본 헬퍼로 점진 마이그레이션 예정.
+ */
+export function parseApiResponse<T>(response: ApiResponse<T>, fallback: string): T {
+  if (response.data === undefined || response.data === null) {
+    throw new Error(response.message ?? fallback)
+  }
+  return response.data
+}
+
+/**
  * Axios 에러를 한국어 메시지의 일반 Error로 정규화한다.
  * 취소 에러(CanceledError / AbortError)는 원본 그대로 rethrow하여
  * 호출자가 `axios.isCancel`로 분기할 수 있게 한다.

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -1,0 +1,122 @@
+import apiClient from './client'
+import { type ApiResponse, normalizeAxiosError } from './_helpers'
+
+/**
+ * 백엔드 `NotificationType` enum과 1:1 매칭되는 문자열 리터럴 유니온.
+ *
+ * - `REVIEW_LIKE`: 내 감상에 좋아요 (target: reviewId)
+ * - `COMMENT`: 내 감상에 댓글 (target: reviewId + commentId)
+ * - `COMMENT_LIKE`: 내 댓글에 좋아요 (target: reviewId + commentId)
+ * - `FOLLOW`: 나를 팔로우 (target: actor.userId)
+ * - `SYSTEM`: 시스템 메시지 (actor 없음, 이동 없음)
+ */
+export type NotificationType = 'REVIEW_LIKE' | 'COMMENT' | 'COMMENT_LIKE' | 'FOLLOW' | 'SYSTEM'
+
+export interface NotificationActor {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+}
+
+export interface NotificationItem {
+  notificationId: number
+  type: NotificationType
+  message: string | null
+  isRead: boolean
+  actor: NotificationActor | null
+  reviewId: number | null
+  commentId: number | null
+  followId: number | null
+  createdAt: string
+}
+
+export interface NotificationListResponse {
+  content: NotificationItem[]
+  nextCursor: string | null
+  hasNext: boolean
+  size: number
+}
+
+export interface UnreadCountResponse {
+  unreadCount: number
+}
+
+/**
+ * 내 알림 목록을 커서 기반으로 조회한다.
+ *
+ * 백엔드는 `notificationId DESC` 정렬에 cursor 미만 항목을 반환하므로 첫 페이지는
+ * cursor 미지정, 다음 페이지는 직전 응답의 `nextCursor`를 그대로 전달하면 된다.
+ *
+ * @param cursor 직전 응답의 `nextCursor`. 첫 페이지면 null/undefined
+ * @param limit 페이지 크기 (기본 20)
+ * @param signal 요청 취소용 AbortSignal
+ */
+export async function getNotifications(
+  cursor?: string | null,
+  limit = 20,
+  signal?: AbortSignal
+): Promise<NotificationListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<NotificationListResponse>>(
+      '/api/v1/notifications',
+      {
+        params: {
+          limit,
+          // [code-review NIT fix] 빈 문자열 cursor도 명시적으로 누락하도록 != null 사용
+          ...(cursor != null && cursor !== '' ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '알림 목록 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '알림을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 단일 알림을 읽음 처리한다.
+ *
+ * 본인 소유가 아닌 알림이면 백엔드에서 403(FORBIDDEN), 존재하지 않으면 404를
+ * 반환한다. 멱등이지만 호출자가 낙관적 업데이트 후 실패 시 롤백할 수 있도록
+ * 에러는 그대로 전파한다.
+ */
+export async function markNotificationAsRead(
+  notificationId: number,
+  signal?: AbortSignal
+): Promise<void> {
+  try {
+    await apiClient.patch<ApiResponse<void>>(
+      `/api/v1/notifications/${notificationId}/read`,
+      undefined,
+      { signal }
+    )
+  } catch (error) {
+    throw normalizeAxiosError(error, '알림 읽음 처리에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 미읽음 알림 개수를 조회한다.
+ *
+ * @remarks HomeFeedPage 종 아이콘 뱃지에서 사용 예정 (후속 이슈).
+ */
+export async function getUnreadNotificationCount(
+  signal?: AbortSignal
+): Promise<UnreadCountResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<UnreadCountResponse>>(
+      '/api/v1/notifications/unread-count',
+      { signal }
+    )
+    if (!data.data) {
+      throw new Error(data.message ?? '미읽음 개수 응답이 올바르지 않습니다.')
+    }
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '미읽음 알림 수를 불러오지 못했습니다.')
+  }
+}

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import { type ApiResponse, normalizeAxiosError } from './_helpers'
+import { type ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
 
 /**
  * 백엔드 `NotificationType` enum과 1:1 매칭되는 문자열 리터럴 유니온.
@@ -68,10 +68,7 @@ export async function getNotifications(
         signal,
       }
     )
-    if (!data.data) {
-      throw new Error(data.message ?? '알림 목록 응답이 올바르지 않습니다.')
-    }
-    return data.data
+    return parseApiResponse(data, '알림 목록 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(error, '알림을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
@@ -112,10 +109,7 @@ export async function getUnreadNotificationCount(
       '/api/v1/notifications/unread-count',
       { signal }
     )
-    if (!data.data) {
-      throw new Error(data.message ?? '미읽음 개수 응답이 올바르지 않습니다.')
-    }
-    return data.data
+    return parseApiResponse(data, '미읽음 개수 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(error, '미읽음 알림 수를 불러오지 못했습니다.')
   }

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -369,6 +369,17 @@ export default function NotificationsPage() {
                   highlighted
                 />
               ))
+            ) : hasNext || isLoadingMore ? (
+              // [CodeRabbit fix] 클라이언트 측 필터(unread)라 첫 페이지가 모두 읽음이고 다음
+              // 페이지에 미읽음이 있는 경우, 빈 상태를 보여주면서 동시에 sentinel이 백그라운드
+              // 페이지를 가져오는 동작이 사용자에겐 "없다고 했다가 갑자기 생겨남"으로 혼란스럽다.
+              // hasNext가 true이거나 추가 로딩 중이면 "확인 중" placeholder만 보여주고, 모든
+              // 페이지를 다 본 뒤에야 진짜 빈 상태를 노출한다.
+              <div className="flex flex-col items-center justify-center gap-3 py-20">
+                <p role="status" aria-busy="true" className="text-sm text-muted-foreground">
+                  읽지 않은 알림 확인 중...
+                </p>
+              </div>
             ) : (
               <div className="flex flex-col items-center justify-center gap-3 py-20">
                 <span className="material-symbols-outlined text-5xl text-muted-foreground/30">

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,31 +1,261 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { cn } from '@/lib/utils'
-import { mockNotifications } from '@/mocks/data'
-import type { NotificationType } from '@/types'
+import axios from 'axios'
+import { cn, formatRelativeTime } from '@/lib/utils'
+import {
+  getNotifications,
+  markNotificationAsRead,
+  type NotificationItem,
+  type NotificationType,
+} from '@/api/notification'
 import BottomNav from '@/components/layout/BottomNav'
 
+type TabValue = 'all' | 'unread'
+
+/**
+ * 백엔드 `NotificationType`별 우상단 아이콘/배경색 매핑.
+ *
+ * `REVIEW_LIKE`/`COMMENT_LIKE`는 시각적으로 동일하게 좋아요(빨강 하트)로 표시한다.
+ * `SYSTEM`은 actor가 없으므로 회색 톤으로 처리.
+ */
 const typeIcon: Record<NotificationType, { icon: string; bg: string }> = {
-  like: { icon: 'favorite', bg: 'bg-red-500' },
-  comment: { icon: 'chat_bubble', bg: 'bg-blue-500' },
-  follow: { icon: 'person_add', bg: 'bg-emerald-500' },
-  new_review: { icon: 'menu_book', bg: 'bg-amber-600' },
+  REVIEW_LIKE: { icon: 'favorite', bg: 'bg-red-500' },
+  COMMENT: { icon: 'chat_bubble', bg: 'bg-blue-500' },
+  COMMENT_LIKE: { icon: 'favorite', bg: 'bg-red-500' },
+  FOLLOW: { icon: 'person_add', bg: 'bg-emerald-500' },
+  SYSTEM: { icon: 'campaign', bg: 'bg-muted-foreground' },
 }
 
-export default function NotificationsPage() {
-  const [activeTab, setActiveTab] = useState<'all' | 'unread'>('all')
-  const [notifications, setNotifications] = useState(mockNotifications)
+/**
+ * `actor`가 있는 알림(좋아요/댓글/팔로우)의 메시지 본문을 만든다.
+ *
+ * 백엔드는 `message`를 null로 내려주는 경우가 있어(현재 트리거 미구현) 타입별 기본
+ * 문구를 프론트에서 합성한다. 백엔드 트리거 머지 후 message가 채워지면 그 값을
+ * 우선 사용한다.
+ */
+function buildNotificationMessage(n: NotificationItem): string {
+  if (n.message) return n.message
+  switch (n.type) {
+    case 'REVIEW_LIKE':
+      return '님이 회원님의 감상에 좋아요를 눌렀습니다.'
+    case 'COMMENT':
+      return '님이 회원님의 감상에 댓글을 남겼습니다.'
+    case 'COMMENT_LIKE':
+      return '님이 회원님의 댓글에 좋아요를 눌렀습니다.'
+    case 'FOLLOW':
+      return '님이 회원님을 팔로우하기 시작했습니다.'
+    case 'SYSTEM':
+      return '새로운 시스템 알림이 있습니다.'
+  }
+}
 
-  const displayed = activeTab === 'all' ? notifications : notifications.filter(n => !n.isRead)
+/**
+ * 알림 클릭 시 이동할 경로를 결정한다.
+ *
+ * - 좋아요/댓글 계열 → 해당 감상 상세
+ * - 팔로우 → 행위자 프로필
+ * - 시스템 → 이동 없음 (null)
+ */
+function resolveDestination(n: NotificationItem): string | null {
+  switch (n.type) {
+    case 'REVIEW_LIKE':
+    case 'COMMENT':
+    case 'COMMENT_LIKE':
+      return n.reviewId != null ? `/review/${n.reviewId}` : null
+    case 'FOLLOW':
+      return n.actor ? `/user/${n.actor.userId}` : null
+    case 'SYSTEM':
+      return null
+  }
+}
+
+/**
+ * 알림 페이지.
+ *
+ * - 첫 마운트 시 `getNotifications`로 첫 페이지 로드.
+ * - `IntersectionObserver` 기반 무한 스크롤 + `nextCursor`로 후속 페이지 로딩 (HomeFeedPage 패턴 재사용).
+ * - 항목 클릭 시 낙관적으로 `isRead=true` 처리 후 `markNotificationAsRead` 호출. 실패하면 롤백.
+ * - 탭(전체/읽지 않음)은 클라이언트 측 필터링. 미읽음 탭은 이미 읽은 항목을 가린다.
+ *
+ * @remarks 폴링/SSE는 본 이슈 범위 밖. 사용자 진입 시 새로고침 정책으로 충분하다.
+ */
+export default function NotificationsPage() {
+  const navigate = useNavigate()
+  const [activeTab, setActiveTab] = useState<TabValue>('all')
+
+  const [notifications, setNotifications] = useState<NotificationItem[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+  /**
+   * 읽음 처리 PATCH 진행 중인 알림 ID 집합과 그 abort controller.
+   *
+   * [code-review MED fix] 같은 알림 연타 시 두 PATCH가 병렬로 가면 첫 실패의
+   * 롤백 setState가 두 번째 성공을 덮어쓰는 race를 막기 위해 ID 단위로 in-flight
+   * 가드. 또한 페이지 언마운트 시 모든 PATCH를 abort하여 unmount-after-setState
+   * 경고를 방지한다.
+   */
+  const inFlightReadsRef = useRef<Set<number>>(new Set())
+  const readControllersRef = useRef<Set<AbortController>>(new Set())
+
+  const stateRef = useRef({ hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError })
+  stateRef.current = { hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError }
+
+  // 첫 페이지 로드. 마운트 시 1회. 페이지 이탈 시 in-flight 요청 취소.
+  useEffect(() => {
+    const controller = new AbortController()
+    // ref 값이 cleanup 시점에 바뀔 수 있다는 ESLint 경고 회피 — 마운트 시점에
+    // 캡처. Set 인스턴스 자체는 컴포넌트 생명주기 동안 동일 객체로 유지된다.
+    const readControllers = readControllersRef.current
+    const inFlightReads = inFlightReadsRef.current
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const response = await getNotifications(null, 20, controller.signal)
+        if (controller.signal.aborted) return
+        setNotifications(response.content)
+        setNextCursor(response.nextCursor)
+        setHasNext(response.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '알림을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+      // [code-review MED fix] 진행 중인 읽음 처리 PATCH도 함께 abort하여
+      // unmount 후 롤백 setState가 발생하지 않도록 한다.
+      readControllers.forEach(c => c.abort())
+      readControllers.clear()
+      inFlightReads.clear()
+    }
+  }, [])
+
+  /**
+   * 다음 페이지를 cursor로 추가 로딩한다.
+   *
+   * stateRef로 최신 상태를 안전하게 읽고, 진행 중인 이전 요청은 새 controller로 abort한다.
+   * `loadMoreError` 발생 시 observer가 자동 재시도하지 않고 사용자가 명시적으로 retry.
+   */
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext || !s.nextCursor) return
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await getNotifications(s.nextCursor, 20, controller.signal)
+      if (controller.signal.aborted) return
+      setNotifications(prev => [...prev, ...response.content])
+      setNextCursor(response.nextCursor)
+      setHasNext(response.hasNext)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [])
+
+  /**
+   * sentinel ref 콜백. 조건부로 렌더되는 sentinel의 마운트/언마운트에 따라 observer 재부착.
+   */
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (!entries[0]?.isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  const retryLoadMore = () => {
+    setLoadMoreError(null)
+    fetchMore()
+  }
+
+  /**
+   * 항목 클릭 핸들러. 낙관적으로 `isRead=true` 적용 후 백엔드 호출, 실패 시 롤백.
+   *
+   * [code-review MED fix]
+   * - 같은 알림 ID에 PATCH가 이미 진행 중이면 새 호출을 스킵하여 race 방지.
+   * - 롤백은 함수형 setState로 prev에서 해당 row를 다시 평가 — 다른 성공 호출이
+   *   이미 true로 만든 결과를 덮어쓰지 않는다 (현재는 ID 가드로 동시 호출 자체가
+   *   막히지만 안전망 차원에서 함수형 갱신 유지).
+   * - 언마운트 시 전체 abort되도록 controller를 ref Set에 등록.
+   * - signal을 markNotificationAsRead에 전달하여 abort 시 axios가 즉시 cancel.
+   *
+   * 이미 읽은 항목은 API 호출 없이 라우팅만 진행 (백엔드 멱등이지만 트래픽 절약).
+   */
+  const handleItemClick = async (n: NotificationItem) => {
+    const destination = resolveDestination(n)
+
+    if (n.isRead) {
+      if (destination) navigate(destination)
+      return
+    }
+
+    if (inFlightReadsRef.current.has(n.notificationId)) {
+      if (destination) navigate(destination)
+      return
+    }
+
+    inFlightReadsRef.current.add(n.notificationId)
+    const controller = new AbortController()
+    readControllersRef.current.add(controller)
+
+    setNotifications(prev =>
+      prev.map(item =>
+        item.notificationId === n.notificationId ? { ...item, isRead: true } : item
+      )
+    )
+    try {
+      await markNotificationAsRead(n.notificationId, controller.signal)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      // 토스트 시스템이 없어 조용히 복원. 함수형 setState로 prev에서 다시 평가.
+      setNotifications(prev =>
+        prev.map(item =>
+          item.notificationId === n.notificationId ? { ...item, isRead: false } : item
+        )
+      )
+    } finally {
+      inFlightReadsRef.current.delete(n.notificationId)
+      readControllersRef.current.delete(controller)
+    }
+    if (destination) navigate(destination)
+  }
 
   const unread = notifications.filter(n => !n.isRead)
   const read = notifications.filter(n => n.isRead)
-
-  const markAsRead = (id: number) => {
-    setNotifications(prev => prev.map(n => (n.id === id ? { ...n, isRead: true } : n)))
-  }
-
-  const navigate = useNavigate()
+  const displayed = activeTab === 'all' ? notifications : unread
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -40,9 +270,11 @@ export default function NotificationsPage() {
           <h1 className="text-xl font-bold tracking-tight text-primary">알림</h1>
           <div className="w-10" />
         </div>
-        {/* Tabs */}
-        <div className="flex gap-6 px-4">
+        <div className="flex gap-6 px-4" role="tablist">
           <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'all'}
             onClick={() => setActiveTab('all')}
             className={cn(
               'border-b-2 pb-2 text-sm font-bold transition-colors',
@@ -54,6 +286,9 @@ export default function NotificationsPage() {
             전체
           </button>
           <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'unread'}
             onClick={() => setActiveTab('unread')}
             className={cn(
               'border-b-2 pb-2 text-sm font-medium transition-colors',
@@ -68,41 +303,69 @@ export default function NotificationsPage() {
       </header>
 
       <main className="flex-1 overflow-y-auto pb-24">
-        {activeTab === 'all' ? (
+        {isLoading && notifications.length === 0 && (
+          <p
+            role="status"
+            aria-busy="true"
+            className="py-10 text-center text-sm text-muted-foreground"
+          >
+            불러오는 중...
+          </p>
+        )}
+
+        {!isLoading && errorMessage && (
+          <p role="alert" className="py-10 text-center text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        {!isLoading && !errorMessage && notifications.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              notifications_off
+            </span>
+            <p className="text-sm text-muted-foreground">알림이 없습니다</p>
+          </div>
+        )}
+
+        {notifications.length > 0 && activeTab === 'all' && (
           <>
-            {/* Unread Section */}
             {unread.length > 0 && (
               <div className="bg-primary/5 px-4 py-3">
                 <p className="mb-2 text-[10px] font-bold uppercase tracking-widest">New</p>
                 {unread.map(noti => (
-                  <NotificationItem
-                    key={noti.id}
+                  <NotificationRow
+                    key={noti.notificationId}
                     notification={noti}
-                    onRead={markAsRead}
+                    onClick={handleItemClick}
                     highlighted
                   />
                 ))}
               </div>
             )}
-
-            {/* Read Section */}
             {read.length > 0 && (
               <div className="px-4 py-3">
                 <p className="mb-4 text-[10px] font-bold uppercase tracking-widest">Earlier</p>
                 {read.map(noti => (
-                  <NotificationItem key={noti.id} notification={noti} onRead={markAsRead} />
+                  <NotificationRow
+                    key={noti.notificationId}
+                    notification={noti}
+                    onClick={handleItemClick}
+                  />
                 ))}
               </div>
             )}
           </>
-        ) : (
+        )}
+
+        {notifications.length > 0 && activeTab === 'unread' && (
           <div className="px-4 py-3">
             {displayed.length > 0 ? (
               displayed.map(noti => (
-                <NotificationItem
-                  key={noti.id}
+                <NotificationRow
+                  key={noti.notificationId}
                   notification={noti}
-                  onRead={markAsRead}
+                  onClick={handleItemClick}
                   highlighted
                 />
               ))
@@ -116,6 +379,37 @@ export default function NotificationsPage() {
             )}
           </div>
         )}
+
+        {notifications.length > 0 && (
+          <>
+            {hasNext && <div ref={sentinelRef} className="h-10" aria-hidden="true" />}
+
+            {isLoadingMore && (
+              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+            )}
+
+            {loadMoreError && !isLoadingMore && (
+              <div className="flex flex-col items-center gap-2 py-4">
+                <p role="alert" className="text-sm text-destructive">
+                  {loadMoreError}
+                </p>
+                <button
+                  type="button"
+                  onClick={retryLoadMore}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                >
+                  다시 불러오기
+                </button>
+              </div>
+            )}
+
+            {!hasNext && !isLoadingMore && !loadMoreError && (
+              <p className="py-4 text-center text-xs text-muted-foreground/50">
+                모든 알림을 확인했습니다
+              </p>
+            )}
+          </>
+        )}
       </main>
 
       <BottomNav />
@@ -123,20 +417,32 @@ export default function NotificationsPage() {
   )
 }
 
-function NotificationItem({
+/**
+ * 알림 한 줄. 좌측 actor 아바타 + 우측 메시지/시간을 렌더링한다.
+ *
+ * - 좋아요/댓글/팔로우는 actor 정보 표시. 시스템 알림은 actor가 null이라 익명 아이콘.
+ * - 클릭 시 부모 핸들러 호출(읽음 처리 + 라우팅).
+ */
+function NotificationRow({
   notification,
-  onRead,
+  onClick,
   highlighted = false,
 }: {
-  notification: (typeof mockNotifications)[number]
-  onRead: (id: number) => void
+  notification: NotificationItem
+  onClick: (n: NotificationItem) => void
   highlighted?: boolean
 }) {
   const icon = typeIcon[notification.type]
+  const actorName = notification.actor?.nickname ?? '시스템'
+  const message = buildNotificationMessage(notification)
+  // [code-review LOW fix] SYSTEM 알림은 message 자체가 완결된 문장이라 actor 이름이
+  // 앞에 붙으면 어색하다("시스템새로운 시스템 알림이 있습니다."). 시스템은 prefix 미노출.
+  const showActorPrefix = notification.type !== 'SYSTEM'
 
   return (
     <button
-      onClick={() => onRead(notification.id)}
+      type="button"
+      onClick={() => onClick(notification)}
       className={cn(
         'mb-3 flex w-full items-center gap-4 rounded-xl p-4 text-left transition-colors',
         highlighted ? 'bg-primary/10 shadow-sm' : 'hover:bg-primary/5'
@@ -144,10 +450,10 @@ function NotificationItem({
     >
       <div className="relative shrink-0">
         <div className="size-12 overflow-hidden rounded-full border-2 border-card">
-          {notification.senderProfileImageUrl ? (
+          {notification.actor?.profileImageUrl ? (
             <img
-              src={notification.senderProfileImageUrl}
-              alt={notification.senderNickname}
+              src={notification.actor.profileImageUrl}
+              alt={actorName}
               className="size-full object-cover"
             />
           ) : (
@@ -165,7 +471,8 @@ function NotificationItem({
           <span
             className={cn(
               'material-symbols-outlined text-[12px]',
-              notification.type === 'like' && 'fill-icon'
+              (notification.type === 'REVIEW_LIKE' || notification.type === 'COMMENT_LIKE') &&
+                'fill-icon'
             )}
           >
             {icon.icon}
@@ -175,13 +482,12 @@ function NotificationItem({
 
       <div className="flex-1">
         <p className="text-sm leading-snug">
-          <span className="font-bold">{notification.senderNickname}</span>
-          {notification.message}
-          {notification.bookTitle && (
-            <span className="italic"> &apos;{notification.bookTitle}&apos;</span>
-          )}
+          {showActorPrefix && <span className="font-bold">{actorName}</span>}
+          {message}
         </p>
-        <p className="mt-1 text-xs text-muted-foreground">{notification.createdAt}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {formatRelativeTime(notification.createdAt)}
+        </p>
       </div>
 
       {!notification.isRead && <div className="size-2 shrink-0 rounded-full bg-primary" />}


### PR DESCRIPTION
- src/api/notification.ts 신규: 알림 목록(커서 페이징) / 단건 읽음 처리 / 미읽음 개수 조회 API 래퍼. 백엔드 NotificationType enum과 1:1 타입 매칭.
- NotificationsPage: mock 제거, 실 API 연동
  - IntersectionObserver 기반 무한 스크롤 + nextCursor 페이징
  - 로딩/에러/빈 상태 UI (BookDetailPage·HomeFeedPage 패턴 재사용)
  - 항목 클릭 시 낙관적 읽음 처리 + 실패 시 함수형 롤백
  - 타입별 라우팅: 좋아요/댓글 → /review/{id}, 팔로우 → /user/{actorId}, 시스템 → 이동 없음
    - 백엔드 message가 null일 경우 타입별 기본 문구 합성 (트리거 미구현 대비)
  - formatRelativeTime 재사용으로 createdAt 상대 시간 표시
  - 페이지 이탈 시 in-flight 요청(목록/추가/PATCH) AbortController로 일괄 취소

코드 리뷰 반영:
- [MED] 읽음 PATCH race: per-id in-flight Set으로 중복 호출 차단, 함수형 setState로 롤백 시 prev에서 다시 평가하여 다른 성공 결과 덮어쓰기 방지
- [MED] markNotificationAsRead에 AbortSignal 미전달 문제 수정, axios.isCancel 분기로 abort된 호출은 롤백 스킵
- [LOW] SYSTEM 알림에 "시스템" prefix가 본문 앞에 어색하게 노출되던 문제: showActorPrefix 분기로 SYSTEM은 prefix 미노출
- [NIT] cursor 빈 문자열 안전성: cursor != null && cursor !== '' 로 명시화

검증:
- npx vitest run → 20/20 통과 (client 테스트 회귀 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 시스템을 백엔드 기반으로 전환하여 실시간 알림 조회 지원
  * 무한 스크롤을 통한 알림 목록 페이지 개선
  * 알림 읽음 상태 최적화 업데이트 추가
  * 액터 프로필 사진, 상대 시간 표시 등 UI 개선
  * 시스템 알림 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->