### PR TITLE
feat: 리뷰 수정 및 삭제 기능 추가, 라우터 설정 업데이트

### DIFF
--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -10,6 +10,8 @@ export interface CreateReviewRequest {
   isSpoiler?: boolean
 }
 
+export type UpdateReviewRequest = Omit<CreateReviewRequest, 'bookId'>
+
 export interface CreateReviewResponse {
   reviewId: number
 }
@@ -75,5 +77,21 @@ export async function getReviewDetail(
     return data.data
   } catch (error) {
     throw normalizeAxiosError(error, '감상 상세를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function updateReview(reviewId: number, request: UpdateReviewRequest): Promise<void> {
+  try {
+    await apiClient.put<ApiResponse<unknown>>(`/api/v1/reviews/${reviewId}`, request)
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function deleteReview(reviewId: number): Promise<void> {
+  try {
+    await apiClient.delete<ApiResponse<unknown>>(`/api/v1/reviews/${reviewId}`)
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
-import { getReviewDetail, type ReviewDetail } from '@/api/review'
+import { deleteReview, getReviewDetail, type ReviewDetail } from '@/api/review'
 import { backendToFrontStatus } from '@/api/library'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useAuthStore } from '@/store/authStore'
 import type { ReadingStatus } from '@/types'
 
 const readingStatusLabel: Record<ReadingStatus, string> = {
@@ -17,10 +26,14 @@ const readingStatusLabel: Record<ReadingStatus, string> = {
 export default function ReviewDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const currentUserId = useAuthStore(state => state.user?.id)
   const reviewId = Number(id)
   const [review, setReview] = useState<ReviewDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     if (!Number.isFinite(reviewId)) {
@@ -117,6 +130,20 @@ export default function ReviewDetailPage() {
       ? '도서 소개'
       : '감상 중에서'
   const coverImageUrl = review.book.coverImageUrl
+  const isMyReview = currentUserId != null && review.user.userId === currentUserId
+
+  const handleDeleteReview = async () => {
+    setIsDeleting(true)
+    setDeleteErrorMessage(null)
+    try {
+      await deleteReview(review.reviewId)
+      navigate(`/book/${review.book.bookId}`, { replace: true })
+    } catch (error) {
+      setDeleteErrorMessage(error instanceof Error ? error.message : '감상을 삭제하지 못했습니다.')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -164,6 +191,30 @@ export default function ReviewDetailPage() {
             </div>
           </div>
         </section>
+
+        {isMyReview && (
+          <section className="flex gap-2 px-5 pb-3">
+            <button
+              type="button"
+              onClick={() => navigate(`/review/${review.reviewId}/edit`)}
+              className="flex h-11 flex-1 items-center justify-center gap-2 rounded-xl border border-primary/20 bg-card text-sm font-bold text-primary transition-colors hover:bg-primary/5"
+            >
+              <span className="material-symbols-outlined text-[18px]">edit</span>
+              수정
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setDeleteErrorMessage(null)
+                setIsDeleteDialogOpen(true)
+              }}
+              className="flex h-11 flex-1 items-center justify-center gap-2 rounded-xl border border-destructive/20 bg-destructive/5 text-sm font-bold text-destructive transition-colors hover:bg-destructive/10"
+            >
+              <span className="material-symbols-outlined text-[18px]">delete</span>
+              삭제
+            </button>
+          </section>
+        )}
 
         {/* Review Content */}
         <section className="px-5 py-3">
@@ -276,6 +327,56 @@ export default function ReviewDetailPage() {
           </div>
         </section>
       </main>
+
+      <Dialog
+        open={isDeleteDialogOpen}
+        onOpenChange={open => {
+          if (isDeleting && !open) return
+          setIsDeleteDialogOpen(open)
+        }}
+      >
+        <DialogContent
+          onInteractOutside={e => {
+            if (isDeleting) e.preventDefault()
+          }}
+          onEscapeKeyDown={e => {
+            if (isDeleting) e.preventDefault()
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>감상을 삭제하시겠습니까?</DialogTitle>
+            <DialogDescription>
+              삭제한 감상은 되돌릴 수 없습니다. 이 책에 대한 감상 기록이 사라집니다.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteErrorMessage && (
+            <p
+              role="alert"
+              className="rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {deleteErrorMessage}
+            </p>
+          )}
+          <DialogFooter className="gap-2">
+            <button
+              type="button"
+              onClick={() => setIsDeleteDialogOpen(false)}
+              disabled={isDeleting}
+              className="rounded-lg border border-primary/20 bg-card px-5 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-primary/5 disabled:opacity-60"
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteReview}
+              disabled={isDeleting}
+              className="rounded-lg bg-destructive px-5 py-3 text-sm font-semibold text-destructive-foreground transition-all hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isDeleting ? '삭제 중...' : '삭제하기'}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <BottomNav />
     </div>

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -2,15 +2,20 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { getBook, type BookDetail } from '@/api/book'
-import { createReview } from '@/api/review'
+import { createReview, getReviewDetail, updateReview } from '@/api/review'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
+import { useAuthStore } from '@/store/authStore'
+
+type ReviewFormBook = Pick<BookDetail, 'bookId' | 'title' | 'author' | 'coverImageUrl'>
 
 export default function WriteReviewPage() {
-  const { bookId } = useParams()
+  const { bookId, reviewId } = useParams()
   const navigate = useNavigate()
+  const currentUserId = useAuthStore(state => state.user?.id)
+  const isEditMode = reviewId != null
 
-  const [book, setBook] = useState<BookDetail | null>(null)
+  const [book, setBook] = useState<ReviewFormBook | null>(null)
   const [rating, setRating] = useState(5)
   const [reviewText, setReviewText] = useState('')
   const [quoteText, setQuoteText] = useState('')
@@ -30,6 +35,52 @@ export default function WriteReviewPage() {
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
+    if (isEditMode) {
+      const isValid = /^\d+$/.test(reviewId ?? '')
+      if (!isValid) {
+        setLoadErrorMessage('감상 정보가 올바르지 않습니다.')
+        setBook(null)
+        setIsLoading(false)
+        return
+      }
+
+      const numericReviewId = parseInt(reviewId!, 10)
+      const controller = new AbortController()
+      setIsLoading(true)
+      setLoadErrorMessage(null)
+      ;(async () => {
+        try {
+          const result = await getReviewDetail(numericReviewId, controller.signal)
+          if (currentUserId != null && result.user.userId !== currentUserId) {
+            setLoadErrorMessage('본인이 작성한 감상만 수정할 수 있습니다.')
+            setBook(null)
+            return
+          }
+          setBook({
+            bookId: result.book.bookId,
+            title: result.book.title,
+            author: result.book.author,
+            coverImageUrl: result.book.coverImageUrl,
+          })
+          setRating(result.rating)
+          setReviewText(result.content)
+          setQuoteText(result.quote ?? '')
+          setIsQuoteEditorOpen(Boolean(result.quote))
+          setIsSpoiler(result.isSpoiler)
+        } catch (error) {
+          if (axios.isCancel(error)) return
+          setLoadErrorMessage(
+            error instanceof Error ? error.message : '감상을 불러오지 못했습니다.'
+          )
+          setBook(null)
+        } finally {
+          if (!controller.signal.aborted) setIsLoading(false)
+        }
+      })()
+
+      return () => controller.abort()
+    }
+
     const isValid = /^\d+$/.test(bookId ?? '')
     if (!isValid) {
       setLoadErrorMessage(
@@ -48,6 +99,11 @@ export default function WriteReviewPage() {
       try {
         const result = await getBook(numericBookId, controller.signal)
         setBook(result)
+        setRating(5)
+        setReviewText('')
+        setQuoteText('')
+        setIsQuoteEditorOpen(false)
+        setIsSpoiler(false)
       } catch (error) {
         // [MED-1 fix] try 블록 내 controller.signal.aborted 가드는 사실상 도달 불가
         // (요청이 abort되면 axios가 throw로 빠짐) + _helpers.ts의 normalizeAxiosError가
@@ -62,14 +118,15 @@ export default function WriteReviewPage() {
     })()
 
     return () => controller.abort()
-  }, [bookId])
+  }, [bookId, currentUserId, isEditMode, reviewId])
 
   const handleSubmit = async () => {
-    const isValid = /^\d+$/.test(bookId ?? '')
+    const isValidBookId = /^\d+$/.test(bookId ?? '')
+    const isValidReviewId = /^\d+$/.test(reviewId ?? '')
     const trimmedContent = reviewText.trim()
     const trimmedQuote = quoteText.trim()
 
-    if (!isValid || !book) {
+    if ((!isEditMode && !isValidBookId) || (isEditMode && !isValidReviewId) || !book) {
       setSubmitErrorMessage('도서 정보가 올바르지 않습니다.')
       return
     }
@@ -82,17 +139,36 @@ export default function WriteReviewPage() {
     setIsSubmitting(true)
     setSubmitErrorMessage(null)
     try {
-      const result = await createReview({
-        bookId: parseInt(bookId!, 10),
+      const basePayload = {
         content: trimmedContent,
         rating,
-        ...(trimmedQuote ? { quote: trimmedQuote } : {}),
         // [HIGH-1 fix] 사용자가 토글로 명시적으로 표시한 값을 그대로 전송 (이전엔 false 고정)
         isSpoiler,
+      }
+
+      if (isEditMode) {
+        await updateReview(parseInt(reviewId!, 10), {
+          ...basePayload,
+          quote: trimmedQuote,
+        })
+        navigate(`/review/${reviewId}`, { replace: true })
+        return
+      }
+
+      const result = await createReview({
+        bookId: parseInt(bookId!, 10),
+        ...basePayload,
+        ...(trimmedQuote ? { quote: trimmedQuote } : {}),
       })
       navigate(`/review/${result.reviewId}`, { replace: true })
     } catch (error) {
-      setSubmitErrorMessage(error instanceof Error ? error.message : '감상을 작성하지 못했습니다.')
+      setSubmitErrorMessage(
+        error instanceof Error
+          ? error.message
+          : isEditMode
+            ? '감상을 수정하지 못했습니다.'
+            : '감상을 작성하지 못했습니다.'
+      )
     } finally {
       setIsSubmitting(false)
     }
@@ -101,7 +177,7 @@ export default function WriteReviewPage() {
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
-        <AppHeader title="감상 작성" showBack />
+        <AppHeader title={isEditMode ? '감상 수정' : '감상 작성'} showBack />
         <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
           <p role="status" className="text-sm text-muted-foreground">
             불러오는 중...
@@ -115,7 +191,7 @@ export default function WriteReviewPage() {
   if (loadErrorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
-        <AppHeader title="감상 작성" showBack />
+        <AppHeader title={isEditMode ? '감상 수정' : '감상 작성'} showBack />
         <main className="flex flex-1 flex-col items-center justify-center gap-4 px-8 pb-24">
           <span className="material-symbols-outlined text-6xl text-muted-foreground/30">
             search_off
@@ -139,7 +215,7 @@ export default function WriteReviewPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <AppHeader title="감상 작성" showBack />
+      <AppHeader title={isEditMode ? '감상 수정' : '감상 작성'} showBack />
 
       <main className="flex-1 overflow-y-auto pb-24">
         {/* Book Info */}
@@ -273,7 +349,13 @@ export default function WriteReviewPage() {
               disabled={isSubmitting}
               className="h-14 flex-[1.7] rounded-full bg-primary text-base font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSubmitting ? '게시 중...' : '게시하기'}
+              {isSubmitting
+                ? isEditMode
+                  ? '수정 중...'
+                  : '게시 중...'
+                : isEditMode
+                  ? '수정하기'
+                  : '게시하기'}
             </button>
           </div>
         </section>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -115,6 +115,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: '/review/:reviewId/edit',
+    element: (
+      <ProtectedRoute>
+        <WriteReviewPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: '/profile',
     element: (
       <ProtectedRoute>


### PR DESCRIPTION
## 작업 내용

감상 수정/삭제 API를 연동했습니다.

- `PUT /api/v1/reviews/{reviewId}` 감상 수정 API 추가
- `DELETE /api/v1/reviews/{reviewId}` 감상 삭제 API 추가
- 감상 상세 페이지에서 본인 감상일 때만 수정/삭제 버튼 노출
- 기존 `WriteReviewPage`를 감상 수정 화면으로 재사용
- `/review/:reviewId/edit` 라우트 추가
- 수정 화면 진입 시 기존 감상 상세 데이터를 불러와 폼 초기값 세팅
- 삭제 전 확인 다이얼로그 추가
- 삭제 성공 시 해당 도서 상세 페이지로 이동

## 주요 변경 파일

- `src/api/review.ts`
- `src/pages/WriteReviewPage.tsx`
- `src/pages/ReviewDetailPage.tsx`
- `src/router/index.tsx`

## 확인 사항

- [x] `npm run build` 통과
- [x] `npm run lint` 통과
- [x] 본인 감상일 때만 수정/삭제 버튼 노출
- [x] 수정 성공 후 감상 상세 페이지로 이동
- [x] 삭제 성공 후 도서 상세 페이지로 이동

## 참고 사항

- `WriteReviewPage`는 작성/수정 공용 페이지로 사용합니다.
- 수정 모드에서는 기존 감상 정보를 `getReviewDetail`로 불러와 폼에 채웁니다.
- 인용구를 삭제하는 수정도 반영되도록 수정 요청 시 `quote: ''`를 전송합니다.
- `npm run lint` 실행 시 기존 `src/components/ui/button.tsx`의 Fast Refresh warning 1건이 남아 있으나, 이번 작업과는 무관합니다.

Closes #117 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 작성한 감상을 수정할 수 있습니다.
  * 작성한 감상을 삭제할 수 있습니다. (삭제 전 확인 대화가 표시됩니다)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->