### PR TITLE
fix: MyLibraryPage UX 개선 — 서재 내 검색 / 필터 칩 가시성 / 완료 시간 정합성 (#120)

### DIFF
--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -165,13 +165,17 @@ export default function LibraryBookDetailPage() {
     // unknown enum 응답 시 사용자가 방금 선택한 status로 fallback (BookDetailPage와 동일 정책)
     const nextStatus =
       backendToFrontStatus[result.status] != null ? result.status : frontToBackendStatus[status]
+    // [code-review MED fix] #120 — 백엔드가 finished에서 다른 상태로 전환 시 finishedAt을
+    // 비우지 않는 정합성 이슈를 클라이언트 state에서도 정규화. 표시단(showFinished) 분기와
+    // 짝을 맞춰 client state 자체를 깨끗이 유지한다.
+    const normalizedFinishedAt = nextStatus === 'FINISHED' ? result.finishedAt : null
     setDetail(prev =>
       prev
         ? {
             ...prev,
             status: nextStatus,
             startedAt: result.startedAt,
-            finishedAt: result.finishedAt,
+            finishedAt: normalizedFinishedAt,
           }
         : prev
     )
@@ -191,10 +195,12 @@ export default function LibraryBookDetailPage() {
   // 백엔드 enum이 미지원 값이어도 페이지가 크래시하지 않도록 방어
   const frontStatus: ReadingStatus | undefined = backendToFrontStatus[detail.status]
   const status = frontStatus ? statusLabel[frontStatus] : null
-  // 날짜 표시 가시성은 데이터 존재 여부만으로 결정 — frontStatus 매핑이 실패해도(unknown enum) 데이터가 있으면 보여준다.
-  // (frontStatus는 라벨/액션 분기에만 사용)
+  // 시작 날짜는 데이터 존재 여부만으로 표시 (frontStatus 매핑 실패해도 데이터가 있으면 보여준다).
+  // 완료 날짜는 의미상 status가 finished일 때만 보여준다 — 백엔드가 finished에서 다른 상태로
+  // 전환 시 finishedAt을 비우지 않는 데이터 정합성 이슈가 있어 (#120 임시 회피), 표시단에서
+  // 분기. 근본 정리는 LibraryBookService.updateStatus() 백엔드 후속 이슈로 처리.
   const showStarted = detail.startedAt != null
-  const showFinished = detail.finishedAt != null
+  const showFinished = frontStatus === 'finished' && detail.finishedAt != null
   const showPeriod = showStarted || showFinished
   const reading = frontStatus === 'reading'
   // "N일째 읽는 중" 라벨은 의미상 READING 상태에서만 보여야 하므로 status 분기 유지

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -431,27 +431,31 @@ export default function MyLibraryPage() {
               <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
             )}
 
-            {loadMoreError && !isLoadingMore && (
-              <div className="flex flex-col items-center gap-2 py-4">
-                <p role="alert" className="text-sm text-destructive">
-                  {loadMoreError}
-                </p>
-                <button
-                  type="button"
-                  onClick={retryLoadMore}
-                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
-                >
-                  다시 불러오기
-                </button>
-              </div>
-            )}
-
             {!hasNext && !isLoadingMore && !loadMoreError && (
               <p className="py-4 text-center text-xs text-muted-foreground/50">
                 모든 도서를 확인했습니다
               </p>
             )}
           </>
+        )}
+
+        {/* [CodeRabbit fix] loadMoreError + 재시도는 그리드(visibleItems > 0)와 검색 빈 결과
+            분기 양쪽에서 모두 보여야 한다. 검색 빈 결과 상태에서 "다음 페이지 불러오기"가 실패해도
+            사용자가 원인을 알 수 있도록 conditional 밖으로 hoist. items가 0건일 땐 errorMessage
+            분기로 가므로 items.length > 0 가드만 추가. */}
+        {items.length > 0 && loadMoreError && !isLoadingMore && (
+          <div className="flex flex-col items-center gap-2 py-4">
+            <p role="alert" className="text-sm text-destructive">
+              {loadMoreError}
+            </p>
+            <button
+              type="button"
+              onClick={retryLoadMore}
+              className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+            >
+              다시 불러오기
+            </button>
+          </div>
         )}
       </main>
 

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import axios from 'axios'
 import { cn } from '@/lib/utils'
@@ -32,9 +32,34 @@ export default function MyLibraryPage() {
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  /**
+   * 서재 내 검색 입력창 표시 여부와 검색어.
+   *
+   * 헤더 돋보기 클릭 시 입력창이 헤더 아래 토글된다. 검색어가 있으면 현재 로드된
+   * `items`를 클라이언트 측에서 `book.title`/`book.author` 부분 일치(대소문자 무시)로
+   * 필터링한다.
+   *
+   * @remarks 한계 — 서버 페이징을 다 가져오기 전에는 검색이 현재까지 로드된 항목
+   * 내에서만 동작한다. 정식 검색은 백엔드에 query 파라미터를 추가하는 별도 이슈에서
+   * 처리한다.
+   */
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const observerRef = useRef<IntersectionObserver | null>(null)
   const moreControllerRef = useRef<AbortController | null>(null)
+  /**
+   * 활성 필터 칩 노드들. 활성 칩이 시야 밖이면 가운데로 자동 스크롤하여
+   * "잘려서 안 보임" 문제를 해결한다.
+   *
+   * [code-review MED fix] 키를 `FilterValue`로 좁혀 enum 추가/제거 시 컴파일러가 추적.
+   */
+  const filterChipRefs = useRef<Partial<Record<FilterValue, HTMLButtonElement | null>>>({})
+  /**
+   * 검색 입력 DOM ref. autoFocus 대신 명시적 focus()로 a11y 룰(no-autofocus)과의
+   * 충돌을 피하면서 동일 UX를 보장.
+   */
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
 
   // observer 콜백에서 최신 state를 읽기 위한 ref (deps 폭주 방지)
   const stateRef = useRef({
@@ -157,47 +182,125 @@ export default function MyLibraryPage() {
 
   useEffect(() => () => observerRef.current?.disconnect(), [])
 
+  // 필터 변경 시 활성 칩이 시야 밖이면 가운데로 자동 스크롤. "중단"이 잘려서 안 보이는
+  // 문제와 모바일 좁은 화면에서 활성 칩이 시야 밖에 있을 때 모두 커버.
+  useEffect(() => {
+    const node = filterChipRefs.current[activeFilter]
+    node?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' })
+  }, [activeFilter])
+
+  // 검색 입력창이 열릴 때마다 명시적으로 focus. autoFocus 대신 useRef + .focus() 패턴
+  // 사용 — eslint jsx-a11y/no-autofocus 룰과의 충돌 방지 및 SSR 환경에서도 동작 보장.
+  useEffect(() => {
+    if (isSearchOpen) searchInputRef.current?.focus()
+  }, [isSearchOpen])
+
   const retryLoadMore = () => {
     setLoadMoreError(null)
     fetchMore()
   }
 
+  /**
+   * 검색어 적용 결과. 빈 문자열이면 원본 그대로, 아니면 title/author 부분 일치 필터링.
+   *
+   * 입력 정규화: 양끝 공백 제거 후 소문자 비교. 클라이언트 측이라 추가 API 호출 없음.
+   */
+  const visibleItems = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return items
+    return items.filter(item => {
+      const title = item.book.title?.toLowerCase() ?? ''
+      const author = item.book.author?.toLowerCase() ?? ''
+      return title.includes(q) || author.includes(q)
+    })
+  }, [items, searchQuery])
+
+  const isSearching = searchQuery.trim().length > 0
+
+  /**
+   * 검색 입력창 토글 핸들러. 닫을 때는 검색어를 함께 초기화하여 사용자가 같은
+   * 검색어로 화면이 필터된 상태로 다시 들어오는 혼란을 막는다.
+   */
+  const toggleSearch = () => {
+    if (isSearchOpen) {
+      setIsSearchOpen(false)
+      setSearchQuery('')
+    } else {
+      setIsSearchOpen(true)
+    }
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       {/* Header */}
-      <header className="sticky top-0 z-20 flex items-center justify-between border-b border-border bg-background/80 px-4 py-4 backdrop-blur-md">
-        <h1 className="text-2xl font-bold">내 서재</h1>
-        <Link to="/search" className="rounded-full p-2 transition-colors hover:bg-primary/10">
-          <span className="material-symbols-outlined text-primary">search</span>
-        </Link>
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
+        <div className="flex items-center justify-between px-4 py-4">
+          <h1 className="text-2xl font-bold">내 서재</h1>
+          <button
+            type="button"
+            onClick={toggleSearch}
+            aria-label={isSearchOpen ? '서재 검색 닫기' : '서재 내 검색'}
+            aria-expanded={isSearchOpen}
+            className="rounded-full p-2 transition-colors hover:bg-primary/10"
+          >
+            <span className="material-symbols-outlined text-primary">
+              {isSearchOpen ? 'close' : 'search'}
+            </span>
+          </button>
+        </div>
+        {isSearchOpen && (
+          <div className="px-4 pb-3">
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              placeholder="서재에서 제목·저자 검색"
+              aria-label="서재 내 검색어"
+              className="w-full rounded-full border border-border bg-background px-4 py-2 text-sm outline-none focus:border-primary"
+            />
+          </div>
+        )}
       </header>
 
-      {/* Filter Chips */}
-      <div className="no-scrollbar flex gap-2 overflow-x-auto p-4" role="tablist">
-        {filters.map(filter => (
-          <button
-            key={filter.value}
-            type="button"
-            role="tab"
-            aria-selected={activeFilter === filter.value}
-            onClick={() => setActiveFilter(filter.value)}
-            className={cn(
-              'shrink-0 rounded-full px-5 py-2 text-sm font-medium transition-colors',
-              activeFilter === filter.value
-                ? 'bg-primary text-primary-foreground'
-                : 'bg-primary/10 text-primary hover:bg-primary/20'
-            )}
-          >
-            {filter.label}
-          </button>
-        ))}
+      {/* Filter Chips — 우측 페이드로 가로 스크롤 가능함을 시각적으로 암시 + 활성 칩 자동 가운데 정렬 */}
+      <div className="relative">
+        <div className="no-scrollbar flex gap-2 overflow-x-auto p-4" role="tablist">
+          {filters.map(filter => (
+            <button
+              key={filter.value}
+              ref={node => {
+                filterChipRefs.current[filter.value] = node
+              }}
+              type="button"
+              role="tab"
+              aria-selected={activeFilter === filter.value}
+              onClick={() => setActiveFilter(filter.value)}
+              className={cn(
+                'shrink-0 rounded-full px-5 py-2 text-sm font-medium transition-colors',
+                activeFilter === filter.value
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-primary/10 text-primary hover:bg-primary/20'
+              )}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent"
+        />
       </div>
 
-      {/* Book Count */}
+      {/* Book Count — 검색 중엔 검색 결과 수 표시, 일반 시엔 전체 권수.
+          [code-review HIGH fix] 검색 결과도 hasNext일 때 "+"를 붙여 추가 페이지 매치 가능성을 명시. */}
       <div className="px-4 py-2">
         {!isLoading && !errorMessage && (
           <p className="text-sm font-medium">
-            총 {items.length}권{hasNext ? '+' : ''}
+            {isSearching
+              ? `검색 결과 ${visibleItems.length}권${hasNext ? '+' : ''}`
+              : `총 ${items.length}권${hasNext ? '+' : ''}`}
           </p>
         )}
       </div>
@@ -233,10 +336,40 @@ export default function MyLibraryPage() {
           </div>
         )}
 
-        {items.length > 0 && (
+        {/* 검색 중인데 결과 0건일 때의 빈 상태 — items는 있지만 visibleItems만 비었을 때.
+            sentinel은 visibleItems 분기 안에 있어 자동 페이징이 멈추므로,
+            아직 로드 안 된 페이지가 남았다면(hasNext) 명시적 "더 불러오기" 버튼 제공. */}
+        {!isLoading && !errorMessage && items.length > 0 && visibleItems.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              search_off
+            </span>
+            <p className="text-sm text-muted-foreground">
+              &lsquo;{searchQuery}&rsquo;에 해당하는 도서가 없습니다
+            </p>
+            {hasNext && (
+              <>
+                <p className="text-xs text-muted-foreground/70">
+                  추가로 로드되지 않은 도서가 있을 수 있습니다.
+                </p>
+                <button
+                  type="button"
+                  onClick={fetchMore}
+                  disabled={isLoadingMore}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20 disabled:opacity-60"
+                >
+                  {/* [code-review MED fix] 1회 클릭 = 1페이지 단위임을 사용자에게 명시 */}
+                  {isLoadingMore ? '불러오는 중...' : '다음 페이지 불러오기'}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {visibleItems.length > 0 && (
           <>
             <div className="grid grid-cols-3 gap-4">
-              {items.map(item => {
+              {visibleItems.map(item => {
                 // 백엔드가 알 수 없는 enum 값을 반환해도 그리드 전체가 크래시하지 않도록 방어
                 const frontStatus: ReadingStatus | undefined = backendToFrontStatus[item.status]
                 const badge = frontStatus ? statusBadge[frontStatus] : null


### PR DESCRIPTION
## MyLibraryPage
- 헤더 돋보기를 도서 검색(/search) Link에서 서재 내 검색 토글 button으로 변경. 클릭 시 헤더 아래 검색 입력창 토글, 닫을 때 검색어도 초기화.
- useMemo로 visibleItems 메모이제이션 — book.title/author 부분 일치(대소문자 무시).
- 검색 빈 결과 + hasNext 시 "다음 페이지 불러오기" 버튼 노출 (sentinel은 visibleItems > 0 분기 안에 있어 자동 페이징이 멈추는 상황 보완).
- 필터 칩 우측 페이드 그라데이션으로 가로 스크롤 가능함을 시각적 암시.
- activeFilter 변경 시 filterChipRefs로 활성 칩을 가운데로 자동 스크롤 → "중단"이 잘려서 안 보이는 문제 해결.

## LibraryBookDetailPage
- showFinished 조건에 frontStatus === 'finished' 추가 — 백엔드가 finished → 다른 상태 전환 시 finishedAt을 비우지 않는 정합성 이슈 임시 회피 (근본 정리는 LibraryBookService.updateStatus() 백엔드 후속 이슈로 분리).

## 코드 리뷰 반영
- [HIGH] 검색 카운트도 hasNext일 때 "+" 표기 추가 — 추가 페이지에 매치가 있을 가능성을 사용자에게 명시
- [MED] "더 불러오기" → "다음 페이지 불러오기"로 카피 변경 (1회=1페이지 단위임을 명시)
- [MED] 검색 입력 autoFocus → useRef + useEffect.focus() 마이그레이션 (eslint jsx-a11y/no-autofocus 룰 충돌 회피)
- [MED] filterChipRefs 키 타입을 Partial<Record<FilterValue, ...>>로 좁힘 → enum 추가/제거 시 컴파일러 추적
- [MED] handleStatusChange 응답 정규화 — nextStatus가 FINISHED가 아니면 client state의 finishedAt도 null로 강제. 표시단(showFinished) 분기와 짝을 맞춰 client state 자체를 깨끗이 유지

## 알려진 한계
- 서재 내 검색은 클라이언트 측 필터링이라 현재까지 로드된 항목 내에서만 동작. 정식 검색은 백엔드에 query 파라미터 추가 후 별도 이슈에서 처리 예정.
- finishedAt 정합성 임시 회피는 표시단 수정이라 백엔드 데이터는 여전히 dirty. 근본 정리는 백엔드 후속 이슈에서 진행.

검증:
- npx tsc --noEmit → 0건
- npx eslint → 0건
- npx vitest run → 20/20 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **검색 기능 추가**
  * 제목과 저자로 도서를 검색할 수 있는 검색창 추가
  * 실시간 필터링으로 빠른 검색 결과 제공
  * 검색 결과가 없을 때 안내 메시지 표시

## 버그 수정

* **완독 날짜 표시 개선**
  * 완독 상태가 아닐 때 완독 날짜가 표시되지 않도록 수정
  * 상태 업데이트 시 정확한 완독 정보 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->