### PR TITLE
feat: 사용자 프로필 페이지에 감상 목록 API 연동 및 감상 불러오기 기능 추가

### DIFF
--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -42,6 +42,36 @@ export interface ReviewDetail {
   createdAt: string
 }
 
+export interface ReviewListItem {
+  reviewId: number
+  book: {
+    bookId: number
+    title: string
+    author: string
+    coverImageUrl: string | null
+  }
+  rating: number
+  content: string
+  quote: string | null
+  isSpoiler: boolean
+  likeCount: number
+  commentCount: number
+  createdAt: string
+}
+
+export interface ReviewListResponse {
+  content: ReviewListItem[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+export interface GetReviewListParams {
+  cursor?: number | null
+  limit?: number
+  signal?: AbortSignal
+}
+
 export async function createReview(request: CreateReviewRequest): Promise<CreateReviewResponse> {
   try {
     const { data } = await apiClient.post<ApiResponse<CreateReviewResponse>>(
@@ -56,6 +86,61 @@ export async function createReview(request: CreateReviewRequest): Promise<Create
     return data.data
   } catch (error) {
     throw normalizeAxiosError(error, '감상을 작성하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export async function getMyReviews({
+  cursor,
+  limit = 10,
+  signal,
+}: GetReviewListParams = {}): Promise<ReviewListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<ReviewListResponse>>('/api/v1/me/reviews', {
+      params: {
+        limit,
+        ...(cursor != null ? { cursor } : {}),
+      },
+      signal,
+    })
+
+    if (!data.data) {
+      throw new Error(data.message ?? '내 감상 목록 응답이 올바르지 않습니다.')
+    }
+
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(
+      error,
+      '내 감상 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+    )
+  }
+}
+
+export async function getUserReviews({
+  userId,
+  cursor,
+  limit = 10,
+  signal,
+}: GetReviewListParams & { userId: number }): Promise<ReviewListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<ReviewListResponse>>(
+      `/api/v1/${userId}/reviews`,
+      {
+        params: {
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+
+    if (!data.data) {
+      throw new Error(data.message ?? '감상 목록 응답이 올바르지 않습니다.')
+    }
+
+    return data.data
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
 

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import { ApiResponse, normalizeAxiosError } from './_helpers'
+import { type ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
 import type { BackendReadingStatus } from './book'
 
 export interface CreateReviewRequest {
@@ -42,6 +42,26 @@ export interface ReviewDetail {
   createdAt: string
 }
 
+/**
+ * 백엔드 `ReviewVisibility` enum과 1:1 매칭. 공개/비공개 감상을 구분.
+ * `findUserReviews` 쿼리는 PUBLIC만 반환하므로 타 유저 응답에는 사실상 PUBLIC만 옴.
+ * 반면 `findMyReviews`는 가시성 필터가 없어 본인 감상엔 두 값 모두 등장 가능 → 호출부에서 표시 정책 결정.
+ */
+export type ReviewVisibility = 'PUBLIC' | 'PRIVATE'
+
+/**
+ * 백엔드 `ReviewStatus` enum과 1:1 매칭. 임시저장/발행 상태 구분.
+ * `findUserReviews`는 PUBLISHED만, `findMyReviews`는 `status` 쿼리 파라미터로 선택적 필터링.
+ */
+export type ReviewBackendStatus = 'DRAFT' | 'PUBLISHED'
+
+/**
+ * 감상 목록 응답의 단일 아이템 — 백엔드 `ReviewSummaryResponse`와 1:1 매칭.
+ *
+ * 동료 PR 초안에서 `reviewVisibility`/`reviewStatus`/`isLiked`/`tags` 필드가 누락되어 있어
+ * 클라이언트가 가시성/상태/좋아요 상태를 알 수 없는 문제(특히 본인 감상에서 PRIVATE/DRAFT가
+ * 섞여 들어옴)를 해결하기 위해 누락분을 모두 노출.
+ */
 export interface ReviewListItem {
   reviewId: number
   book: {
@@ -54,60 +74,89 @@ export interface ReviewListItem {
   content: string
   quote: string | null
   isSpoiler: boolean
+  reviewVisibility: ReviewVisibility
+  reviewStatus: ReviewBackendStatus
   likeCount: number
   commentCount: number
+  isLiked: boolean
+  tags: string[]
   createdAt: string
 }
 
-export interface ReviewListResponse {
-  content: ReviewListItem[]
-  nextCursor: number | null
-  hasNext: boolean
-  size: number
+export interface GetMyReviewsParams {
+  cursor?: number | null
+  limit?: number
+  status?: ReviewBackendStatus
+  signal?: AbortSignal
 }
 
-export interface GetReviewListParams {
+export interface GetUserReviewsParams {
+  userId: number
   cursor?: number | null
   limit?: number
   signal?: AbortSignal
 }
 
+/**
+ * 감상 목록 페이지 크기. 백엔드 default(20)과 동일하게 맞춰 한 가지 단위로 hasNext를 추론한다.
+ *
+ * 옵션 A로 인해 응답이 페이지 wrapper가 아니므로(컨벤션 미통일 — 후속 백엔드 이슈),
+ * 호출부에서 `items.length === REVIEW_PAGE_SIZE`로 hasNext를 추론한다. 마지막 페이지에서
+ * 정확히 `REVIEW_PAGE_SIZE`개가 매칭되면 false-positive로 한 번 더 호출되지만, 빈 배열로
+ * 자연 종료된다.
+ */
+export const REVIEW_PAGE_SIZE = 20
+
+/**
+ * 새 감상을 작성한다.
+ *
+ * AbortSignal 미지원: POST는 서버 상태를 변경하므로 클라이언트가 중단해도 서버 반영 여부가
+ * 불확실(이미 commit됐을 수 있음). 호출부에서 이중 클릭 방지(disabled)로 중복 호출 차단.
+ */
 export async function createReview(request: CreateReviewRequest): Promise<CreateReviewResponse> {
   try {
     const { data } = await apiClient.post<ApiResponse<CreateReviewResponse>>(
       '/api/v1/reviews',
       request
     )
-
-    if (!data.data) {
-      throw new Error(data.message ?? '감상 작성 응답이 올바르지 않습니다.')
-    }
-
-    return data.data
+    return parseApiResponse(data, '감상 작성 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(error, '감상을 작성하지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
 
+/**
+ * 내 감상 목록을 커서 기반으로 조회한다 (`GET /api/v1/reviews/me`).
+ *
+ * 백엔드 응답: `ApiResponse<List<ReviewSummaryResponse>>` (페이지 wrapper 아님 — 옵션 A).
+ * `findMyReviews` 쿼리는 가시성(`reviewVisibility`) 필터가 없으므로 PUBLIC/PRIVATE이 함께 옴.
+ * `reviewStatus` 필터는 호출부의 `status` 파라미터로 선택 — 발행분만 받으려면 `'PUBLISHED'`
+ * 명시 권장 (DRAFT 임시저장 노출 방지).
+ *
+ * @remarks 후속 백엔드 이슈로 페이지 wrapper 통일 + `findMyReviews`에 PUBLIC 필터 추가
+ * 검토 예정 (`docs/리뷰_API_백엔드_wrapper_통일_논의.md`).
+ *
+ * @param params.cursor 직전 응답 마지막 아이템의 `reviewId`. 첫 페이지면 null/undefined
+ * @param params.limit 페이지 크기 (기본 `REVIEW_PAGE_SIZE`)
+ * @param params.status `'PUBLISHED'`로 임시저장 제외 등 선택적 필터
+ * @param params.signal 요청 취소용 AbortSignal
+ */
 export async function getMyReviews({
   cursor,
-  limit = 10,
+  limit = REVIEW_PAGE_SIZE,
+  status,
   signal,
-}: GetReviewListParams = {}): Promise<ReviewListResponse> {
+}: GetMyReviewsParams = {}): Promise<ReviewListItem[]> {
   try {
-    const { data } = await apiClient.get<ApiResponse<ReviewListResponse>>('/api/v1/me/reviews', {
+    const { data } = await apiClient.get<ApiResponse<ReviewListItem[]>>('/api/v1/reviews/me', {
       params: {
         limit,
         ...(cursor != null ? { cursor } : {}),
+        ...(status ? { status } : {}),
       },
       signal,
     })
-
-    if (!data.data) {
-      throw new Error(data.message ?? '내 감상 목록 응답이 올바르지 않습니다.')
-    }
-
-    return data.data
+    return parseApiResponse(data, '내 감상 목록 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(
       error,
@@ -116,15 +165,27 @@ export async function getMyReviews({
   }
 }
 
+/**
+ * 타 유저의 감상 목록을 커서 기반으로 조회한다 (`GET /api/v1/members/{userId}/reviews`).
+ *
+ * 백엔드 `findUserReviews` 쿼리는 `reviewVisibility='PUBLIC' AND reviewStatus='PUBLISHED'`
+ * 필터를 적용하므로 응답에 비공개/임시저장은 포함되지 않는다. 응답은 페이지 wrapper가 아닌
+ * 단순 배열(옵션 A) — 호출부에서 `items.length === REVIEW_PAGE_SIZE`로 hasNext 추론.
+ *
+ * @param params.userId 타 유저의 memberUserId
+ * @param params.cursor 직전 응답 마지막 아이템의 `reviewId`
+ * @param params.limit 페이지 크기 (기본 `REVIEW_PAGE_SIZE`)
+ * @param params.signal 요청 취소용 AbortSignal
+ */
 export async function getUserReviews({
   userId,
   cursor,
-  limit = 10,
+  limit = REVIEW_PAGE_SIZE,
   signal,
-}: GetReviewListParams & { userId: number }): Promise<ReviewListResponse> {
+}: GetUserReviewsParams): Promise<ReviewListItem[]> {
   try {
-    const { data } = await apiClient.get<ApiResponse<ReviewListResponse>>(
-      `/api/v1/${userId}/reviews`,
+    const { data } = await apiClient.get<ApiResponse<ReviewListItem[]>>(
+      `/api/v1/members/${userId}/reviews`,
       {
         params: {
           limit,
@@ -133,17 +194,18 @@ export async function getUserReviews({
         signal,
       }
     )
-
-    if (!data.data) {
-      throw new Error(data.message ?? '감상 목록 응답이 올바르지 않습니다.')
-    }
-
-    return data.data
+    return parseApiResponse(data, '감상 목록 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(error, '감상 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
 
+/**
+ * 감상 상세를 조회한다 (`GET /api/v1/reviews/{reviewId}`).
+ *
+ * 비회원도 접근 허용(백엔드 컨트롤러 명세). 본 호출은 axios 기본 인증 헤더가 있으면
+ * 자동으로 붙고, 인증 인터셉터가 401만 처리하므로 비회원 분기 별도 처리 불필요.
+ */
 export async function getReviewDetail(
   reviewId: number,
   signal?: AbortSignal
@@ -152,12 +214,7 @@ export async function getReviewDetail(
     const { data } = await apiClient.get<ApiResponse<ReviewDetail>>(`/api/v1/reviews/${reviewId}`, {
       signal,
     })
-
-    if (!data.data) {
-      throw new Error(data.message ?? '감상 상세 응답이 올바르지 않습니다.')
-    }
-
-    return data.data
+    return parseApiResponse(data, '감상 상세 응답이 올바르지 않습니다.')
   } catch (error) {
     throw normalizeAxiosError(error, '감상 상세를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import BottomNav from '@/components/layout/BottomNav'
 import { getMyProfile, type MyProfile } from '@/api/member'
-import { getMyReviews, type ReviewListItem } from '@/api/review'
+import { getMyReviews, REVIEW_PAGE_SIZE, type ReviewListItem } from '@/api/review'
 import { formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
 
@@ -36,6 +36,23 @@ const categoryStats = [
   { label: '인문 15%', color: '#EEE3D2' },
 ]
 
+/**
+ * 본인 프로필 페이지.
+ *
+ * 두 개의 독립 fetch effect로 구성:
+ * 1. `getMyProfile` — 상단 프로필(닉네임/bio/팔로워·팔로잉/감상수)을 채우고 `authStore.setAuth`로
+ *    persist 상태를 최신화. `useAuthStore.getState()`로 읽는 이유는 본 컴포넌트가 store를
+ *    selector로 구독하지 않게 하여 `setAuth` 호출이 리렌더 → effect 무한 루프를 일으키지 않도록 함.
+ * 2. `getMyReviews({ status: 'PUBLISHED' })` — 공개 감상 타임라인. 백엔드 `findMyReviews`
+ *    쿼리는 가시성(`reviewVisibility`) 필터가 없어 PUBLIC/PRIVATE이 모두 오므로,
+ *    DRAFT 임시저장은 `status='PUBLISHED'`로 백엔드에서 제외 + PUBLIC 필터는 클라이언트
+ *    표시단(useMemo `visibleReviews`)에서 적용. 후속 백엔드 이슈로 쿼리에 PUBLIC 필터 추가 검토.
+ *
+ * Wisdom Tower / 월별·카테고리 통계는 Library/통계 전용 API 미구현으로 mock 유지(TODO 표시).
+ *
+ * @remarks 페이징은 옵션 A — 응답이 배열이라 `items.length === REVIEW_PAGE_SIZE`로 hasNext
+ * 추론. 마지막 페이지에서 정확히 PAGE_SIZE만 매칭되면 한 번 false-positive 후 빈 배열로 자연 종료.
+ */
 export default function MyProfilePage() {
   const navigate = useNavigate()
   const [profile, setProfile] = useState<MyProfile | null>(null)
@@ -48,7 +65,23 @@ export default function MyProfilePage() {
   const [isReviewsLoadingMore, setIsReviewsLoadingMore] = useState(false)
   const [reviewsErrorMessage, setReviewsErrorMessage] = useState<string | null>(null)
 
+  /**
+   * "더 보기" 클릭 시 만들어지는 abort controller. 사용자가 페이지를 이탈하거나 빠르게
+   * 재클릭하면 진행 중인 요청을 취소하여 unmount 후 setState 경고와 stale 응답 덮어쓰기를 방지.
+   */
+  const loadMoreControllerRef = useRef<AbortController | null>(null)
+
   const maxStatValue = Math.max(...monthlyStats.map(item => item.value))
+
+  /**
+   * 백엔드 `findMyReviews`는 `reviewVisibility` 필터를 적용하지 않아 본인의 PRIVATE 감상도
+   * 응답에 포함된다. "공개 감상 타임라인" 섹션의 의미상 클라이언트 표시단에서 PUBLIC만 노출.
+   * 후속 백엔드 이슈로 쿼리 필터 추가 후 본 메모이제이션 제거 가능.
+   */
+  const visibleReviews = useMemo(
+    () => reviews.filter(r => r.reviewVisibility === 'PUBLIC'),
+    [reviews]
+  )
 
   useEffect(() => {
     const controller = new AbortController()
@@ -95,11 +128,18 @@ export default function MyProfilePage() {
     setReviewsErrorMessage(null)
     ;(async () => {
       try {
-        const response = await getMyReviews({ cursor: null, signal: controller.signal })
+        // status='PUBLISHED'로 임시저장(DRAFT) 제외. 가시성(PUBLIC) 필터는 백엔드 미적용이라
+        // 클라이언트 visibleReviews 메모이제이션에서 처리.
+        const response = await getMyReviews({
+          cursor: null,
+          status: 'PUBLISHED',
+          signal: controller.signal,
+        })
         if (controller.signal.aborted) return
-        setReviews(response.content)
-        setReviewNextCursor(response.nextCursor)
-        setHasMoreReviews(response.hasNext)
+        setReviews(response)
+        // 옵션 A: 마지막 아이템의 reviewId를 다음 cursor로, items.length === PAGE_SIZE이면 hasNext.
+        setReviewNextCursor(response.length > 0 ? response[response.length - 1].reviewId : null)
+        setHasMoreReviews(response.length === REVIEW_PAGE_SIZE)
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setReviewsErrorMessage(
@@ -110,25 +150,48 @@ export default function MyProfilePage() {
       }
     })()
 
-    return () => controller.abort()
+    return () => {
+      controller.abort()
+      // 더 보기로 진행 중이던 요청도 함께 취소 — 페이지 이탈 시 unmount 후 setState 방지.
+      loadMoreControllerRef.current?.abort()
+    }
   }, [])
 
+  /**
+   * "더 보기" 핸들러. 진행 중인 이전 요청은 abort 후 새 요청으로 교체하고, 응답에는 cancel
+   * 가드를 적용해 stale 응답이 새 응답을 덮어쓰지 않도록 한다. 빈 응답이 도착하면
+   * `hasMoreReviews=false`로 종료(옵션 A의 false-positive 자연 종료 정책).
+   */
   const handleLoadMoreReviews = async () => {
     if (isReviewsLoadingMore || !hasMoreReviews) return
+
+    loadMoreControllerRef.current?.abort()
+    const controller = new AbortController()
+    loadMoreControllerRef.current = controller
 
     setIsReviewsLoadingMore(true)
     setReviewsErrorMessage(null)
     try {
-      const response = await getMyReviews({ cursor: reviewNextCursor })
-      setReviews(prev => [...prev, ...response.content])
-      setReviewNextCursor(response.nextCursor)
-      setHasMoreReviews(response.hasNext)
+      const response = await getMyReviews({
+        cursor: reviewNextCursor,
+        status: 'PUBLISHED',
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      if (response.length === 0) {
+        setHasMoreReviews(false)
+        return
+      }
+      setReviews(prev => [...prev, ...response])
+      setReviewNextCursor(response[response.length - 1].reviewId)
+      setHasMoreReviews(response.length === REVIEW_PAGE_SIZE)
     } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
       setReviewsErrorMessage(
         error instanceof Error ? error.message : '감상 목록을 더 불러오지 못했습니다.'
       )
     } finally {
-      setIsReviewsLoadingMore(false)
+      if (!controller.signal.aborted) setIsReviewsLoadingMore(false)
     }
   }
 
@@ -383,13 +446,13 @@ export default function MyProfilePage() {
             <p role="status" className="py-8 text-center text-sm text-muted-foreground">
               감상을 불러오는 중...
             </p>
-          ) : reviews.length === 0 && !reviewsErrorMessage ? (
+          ) : visibleReviews.length === 0 && !reviewsErrorMessage ? (
             <div className="rounded-[24px] bg-card px-5 py-8 text-center text-sm text-muted-foreground">
               아직 공개 감상이 없습니다.
             </div>
           ) : (
             <div className="space-y-4">
-              {reviews.map(review => (
+              {visibleReviews.map(review => (
                 <article
                   key={review.reviewId}
                   onClick={() => navigate(`/review/${review.reviewId}`)}

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import BottomNav from '@/components/layout/BottomNav'
 import { getMyProfile, type MyProfile } from '@/api/member'
+import { getMyReviews, type ReviewListItem } from '@/api/review'
+import { formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
 
 // TODO(M1 후속): Library 통계 API 연동 시 교체 (Wisdom Tower, 연간 독서 스택)
@@ -34,42 +36,17 @@ const categoryStats = [
   { label: '인문 15%', color: '#EEE3D2' },
 ]
 
-// TODO(M1 후속): Review 목록 API 연동 시 교체 (공개 감상 타임라인)
-const publicTimeline = [
-  {
-    id: 1,
-    title: '위대한 개츠비',
-    date: '2024년 6월 15일',
-    summary: '데이지를 향한 개츠비의 맹목적인 열망은 시대를 관통하는 슬픈 낭만이다...',
-    cover:
-      'https://images.unsplash.com/photo-1544947950-fa07a98d237f?auto=format&fit=crop&w=300&q=80',
-    coverBg: '#5E8B7E',
-  },
-  {
-    id: 2,
-    title: '호밀밭의 파수꾼',
-    date: '2024년 5월 28일',
-    summary: '홀든 코필드의 방황이 낯설지 않게 느껴지는 밤. 어른이 된다는 것은 무엇일까.',
-    cover:
-      'https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=300&q=80',
-    coverBg: '#D8B08C',
-  },
-  {
-    id: 3,
-    title: '데미안',
-    date: '2024년 5월 10일',
-    summary: '새는 알을 깨고 나오기 위해 투쟁한다. 내 안의 아브락사스를 찾아서.',
-    cover:
-      'https://images.unsplash.com/photo-1526243741027-444d633d7365?auto=format&fit=crop&w=300&q=80',
-    coverBg: '#8A8075',
-  },
-]
-
 export default function MyProfilePage() {
   const navigate = useNavigate()
   const [profile, setProfile] = useState<MyProfile | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [reviews, setReviews] = useState<ReviewListItem[]>([])
+  const [reviewNextCursor, setReviewNextCursor] = useState<number | null>(null)
+  const [hasMoreReviews, setHasMoreReviews] = useState(false)
+  const [isReviewsLoading, setIsReviewsLoading] = useState(true)
+  const [isReviewsLoadingMore, setIsReviewsLoadingMore] = useState(false)
+  const [reviewsErrorMessage, setReviewsErrorMessage] = useState<string | null>(null)
 
   const maxStatValue = Math.max(...monthlyStats.map(item => item.value))
 
@@ -111,6 +88,49 @@ export default function MyProfilePage() {
 
     return () => controller.abort()
   }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setIsReviewsLoading(true)
+    setReviewsErrorMessage(null)
+    ;(async () => {
+      try {
+        const response = await getMyReviews({ cursor: null, signal: controller.signal })
+        if (controller.signal.aborted) return
+        setReviews(response.content)
+        setReviewNextCursor(response.nextCursor)
+        setHasMoreReviews(response.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setReviewsErrorMessage(
+          error instanceof Error ? error.message : '감상 목록을 불러오지 못했습니다.'
+        )
+      } finally {
+        if (!controller.signal.aborted) setIsReviewsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [])
+
+  const handleLoadMoreReviews = async () => {
+    if (isReviewsLoadingMore || !hasMoreReviews) return
+
+    setIsReviewsLoadingMore(true)
+    setReviewsErrorMessage(null)
+    try {
+      const response = await getMyReviews({ cursor: reviewNextCursor })
+      setReviews(prev => [...prev, ...response.content])
+      setReviewNextCursor(response.nextCursor)
+      setHasMoreReviews(response.hasNext)
+    } catch (error) {
+      setReviewsErrorMessage(
+        error instanceof Error ? error.message : '감상 목록을 더 불러오지 못했습니다.'
+      )
+    } finally {
+      setIsReviewsLoadingMore(false)
+    }
+  }
 
   if (isLoading) {
     return (
@@ -353,39 +373,92 @@ export default function MyProfilePage() {
           </div>
         </section>
 
-        {/* Public Review Timeline — TODO(M1 후속): Review 목록 API 연동 필요 */}
+        {/* Public Review Timeline */}
         <section className="px-6 pb-10 pt-10">
           <h2 className="mb-5 text-[28px] font-bold tracking-tight text-foreground">
             공개 감상 타임라인
           </h2>
 
-          <div className="space-y-4">
-            {publicTimeline.map(item => (
-              <article
-                key={item.id}
-                className="flex gap-4 rounded-[28px] bg-card p-4 shadow-sm transition-transform hover:scale-[1.01]"
-              >
-                <div
-                  className="flex h-[96px] w-[76px] shrink-0 items-center justify-center rounded-[18px]"
-                  style={{ backgroundColor: item.coverBg }}
+          {isReviewsLoading ? (
+            <p role="status" className="py-8 text-center text-sm text-muted-foreground">
+              감상을 불러오는 중...
+            </p>
+          ) : reviews.length === 0 && !reviewsErrorMessage ? (
+            <div className="rounded-[24px] bg-card px-5 py-8 text-center text-sm text-muted-foreground">
+              아직 공개 감상이 없습니다.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {reviews.map(review => (
+                <article
+                  key={review.reviewId}
+                  onClick={() => navigate(`/review/${review.reviewId}`)}
+                  className="flex cursor-pointer gap-4 rounded-[24px] bg-card p-4 shadow-sm transition-colors hover:bg-primary/5"
                 >
-                  <img
-                    src={item.cover}
-                    alt={`${item.title} 표지`}
-                    className="h-[78px] w-[54px] rounded-[10px] object-cover shadow-sm"
-                  />
-                </div>
+                  <div className="flex h-[96px] w-[76px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-primary/5">
+                    {review.book.coverImageUrl ? (
+                      <img
+                        src={review.book.coverImageUrl}
+                        alt={`${review.book.title} 표지`}
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined text-3xl text-muted-foreground/30">
+                        menu_book
+                      </span>
+                    )}
+                  </div>
 
-                <div className="min-w-0 flex-1 pt-1">
-                  <h3 className="truncate text-xl font-bold text-foreground">{item.title}</h3>
-                  <p className="mt-1 text-sm font-medium text-primary/40">{item.date}</p>
-                  <p className="mt-3 line-clamp-2 text-base leading-6 text-foreground/65">
-                    {item.summary}
-                  </p>
-                </div>
-              </article>
-            ))}
-          </div>
+                  <div className="min-w-0 flex-1 pt-1">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="line-clamp-1 text-xl font-bold text-foreground">
+                        {review.book.title}
+                      </h3>
+                      <span className="shrink-0 text-sm font-bold text-primary">
+                        ★ {review.rating.toFixed(1)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm font-medium text-primary/40">
+                      {formatRelativeTime(review.createdAt)}
+                    </p>
+                    <p className="mt-3 line-clamp-2 text-base leading-6 text-foreground/65">
+                      {review.isSpoiler ? '스포일러가 포함된 감상입니다.' : review.content}
+                    </p>
+                    <div className="mt-3 flex items-center gap-4 text-xs font-semibold text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <span className="material-symbols-outlined text-[16px]">favorite</span>
+                        {review.likeCount}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <span className="material-symbols-outlined text-[16px]">chat_bubble</span>
+                        {review.commentCount}
+                      </span>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          {reviewsErrorMessage && (
+            <p
+              role="alert"
+              className="mt-4 rounded-xl bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {reviewsErrorMessage}
+            </p>
+          )}
+
+          {hasMoreReviews && !isReviewsLoading && (
+            <button
+              type="button"
+              onClick={handleLoadMoreReviews}
+              disabled={isReviewsLoadingMore}
+              className="mt-5 w-full rounded-xl bg-primary/10 py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isReviewsLoadingMore ? '불러오는 중...' : '더 보기'}
+            </button>
+          )}
         </section>
       </main>
 

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -4,10 +4,24 @@ import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import { getUserProfile, type UserProfile } from '@/api/member'
 import { followUser, unfollowUser } from '@/api/follow'
-import { getUserReviews, type ReviewListItem } from '@/api/review'
+import { getUserReviews, REVIEW_PAGE_SIZE, type ReviewListItem } from '@/api/review'
 import { formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
 
+/**
+ * 타 유저 프로필 페이지.
+ *
+ * - URL `userId`가 본인이면 `/profile`로 자동 redirect (myUserId 비교).
+ * - 프로필/감상 fetch 두 effect는 `numericUserId` 기반으로 독립 동작.
+ * - 백엔드 `findUserReviews`는 `reviewVisibility='PUBLIC' AND reviewStatus='PUBLISHED'`
+ *   필터를 적용하므로 응답엔 공개·발행분만 들어옴 → 클라이언트 추가 필터 불필요.
+ * - 페이징은 옵션 A — 응답이 배열이라 `items.length === REVIEW_PAGE_SIZE`로 hasNext 추론.
+ *
+ * **Follow 토글 race 가드** (3중 보호):
+ * - `isMountedRef`: 컴포넌트 unmount 후 setState 방지
+ * - `profileIdRef`: 토글 도중 사용자가 다른 프로필로 이동하면 응답 폐기
+ * - `targetId`(클로저 캡처): await 시점의 대상 userId를 닫아둬 응답 도착 시 비교
+ */
 export default function UserProfilePage() {
   const { userId } = useParams<{ userId: string }>()
   const navigate = useNavigate()
@@ -27,6 +41,11 @@ export default function UserProfilePage() {
   const isMountedRef = useRef(true)
   // 토글 진행 중 사용자가 다른 프로필로 이동하면, 늦게 도착한 응답이 새 프로필에 잘못 반영되는 것을 방지하기 위한 추적 ref
   const profileIdRef = useRef<number | null>(null)
+  /**
+   * "더 보기" 클릭 시 만들어지는 abort controller. 페이지 이탈/재클릭 시 진행 중 요청을
+   * 취소하여 unmount 후 setState 경고 + stale 응답 덮어쓰기 방지.
+   */
+  const loadMoreReviewsControllerRef = useRef<AbortController | null>(null)
 
   // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
   // setup에서 명시적으로 true로 리셋해 ref가 false로 stuck되지 않도록 한다.
@@ -91,9 +110,10 @@ export default function UserProfilePage() {
           signal: controller.signal,
         })
         if (controller.signal.aborted) return
-        setReviews(response.content)
-        setReviewNextCursor(response.nextCursor)
-        setHasMoreReviews(response.hasNext)
+        setReviews(response)
+        // 옵션 A: 마지막 아이템의 reviewId를 다음 cursor로, items.length === PAGE_SIZE이면 hasNext.
+        setReviewNextCursor(response.length > 0 ? response[response.length - 1].reviewId : null)
+        setHasMoreReviews(response.length === REVIEW_PAGE_SIZE)
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setReviewsErrorMessage(
@@ -104,7 +124,10 @@ export default function UserProfilePage() {
       }
     })()
 
-    return () => controller.abort()
+    return () => {
+      controller.abort()
+      loadMoreReviewsControllerRef.current?.abort()
+    }
   }, [userId, isValidId, numericUserId])
 
   if (myUserId && numericUserId === myUserId) {
@@ -145,6 +168,14 @@ export default function UserProfilePage() {
     )
   }
 
+  /**
+   * 팔로우/언팔로우 토글. 진행 도중 사용자가 다른 프로필로 이동하면 늦게 도착한 응답이
+   * 새 프로필에 잘못 반영되지 않도록 3중 stale guard 적용:
+   * - `wasFollowing` 결정 시점 스냅샷
+   * - `targetId` 클로저 캡처
+   * - `isStale()` = `!isMountedRef || profileIdRef !== targetId`
+   * `setIsFollowProcessing(false)`는 stale 여부와 무관하게 항상 reset(영구 disabled 방지).
+   */
   const handleToggleFollow = async () => {
     if (isFollowProcessing) return
     // 결정 시점 스냅샷: 호출 직후 외부에서 profile.isFollowing이 바뀌어도 분기를 일관되게 유지
@@ -195,8 +226,17 @@ export default function UserProfilePage() {
     }
   }
 
+  /**
+   * "더 보기" 핸들러. 이전 in-flight 요청은 abort 후 새 요청으로 교체하고, 응답에는
+   * cancel 가드를 적용해 stale 응답이 새 응답을 덮어쓰지 않도록 한다. 빈 응답이 도착하면
+   * `hasMoreReviews=false`로 종료(옵션 A의 false-positive 자연 종료 정책).
+   */
   const handleLoadMoreReviews = async () => {
     if (isReviewsLoadingMore || !hasMoreReviews) return
+
+    loadMoreReviewsControllerRef.current?.abort()
+    const controller = new AbortController()
+    loadMoreReviewsControllerRef.current = controller
 
     setIsReviewsLoadingMore(true)
     setReviewsErrorMessage(null)
@@ -204,16 +244,23 @@ export default function UserProfilePage() {
       const response = await getUserReviews({
         userId: numericUserId,
         cursor: reviewNextCursor,
+        signal: controller.signal,
       })
-      setReviews(prev => [...prev, ...response.content])
-      setReviewNextCursor(response.nextCursor)
-      setHasMoreReviews(response.hasNext)
+      if (controller.signal.aborted) return
+      if (response.length === 0) {
+        setHasMoreReviews(false)
+        return
+      }
+      setReviews(prev => [...prev, ...response])
+      setReviewNextCursor(response[response.length - 1].reviewId)
+      setHasMoreReviews(response.length === REVIEW_PAGE_SIZE)
     } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
       setReviewsErrorMessage(
         error instanceof Error ? error.message : '감상 목록을 더 불러오지 못했습니다.'
       )
     } finally {
-      setIsReviewsLoadingMore(false)
+      if (!controller.signal.aborted) setIsReviewsLoadingMore(false)
     }
   }
 

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -4,6 +4,8 @@ import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import { getUserProfile, type UserProfile } from '@/api/member'
 import { followUser, unfollowUser } from '@/api/follow'
+import { getUserReviews, type ReviewListItem } from '@/api/review'
+import { formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
 
 export default function UserProfilePage() {
@@ -16,6 +18,12 @@ export default function UserProfilePage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isFollowProcessing, setIsFollowProcessing] = useState(false)
   const [followError, setFollowError] = useState<string | null>(null)
+  const [reviews, setReviews] = useState<ReviewListItem[]>([])
+  const [reviewNextCursor, setReviewNextCursor] = useState<number | null>(null)
+  const [hasMoreReviews, setHasMoreReviews] = useState(false)
+  const [isReviewsLoading, setIsReviewsLoading] = useState(true)
+  const [isReviewsLoadingMore, setIsReviewsLoadingMore] = useState(false)
+  const [reviewsErrorMessage, setReviewsErrorMessage] = useState<string | null>(null)
   const isMountedRef = useRef(true)
   // 토글 진행 중 사용자가 다른 프로필로 이동하면, 늦게 도착한 응답이 새 프로필에 잘못 반영되는 것을 방지하기 위한 추적 ref
   const profileIdRef = useRef<number | null>(null)
@@ -57,6 +65,42 @@ export default function UserProfilePage() {
         setErrorMessage(error instanceof Error ? error.message : '프로필을 불러오지 못했습니다.')
       } finally {
         if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [userId, isValidId, numericUserId])
+
+  useEffect(() => {
+    if (!userId || !isValidId) {
+      setIsReviewsLoading(false)
+      setReviews([])
+      setReviewNextCursor(null)
+      setHasMoreReviews(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsReviewsLoading(true)
+    setReviewsErrorMessage(null)
+    ;(async () => {
+      try {
+        const response = await getUserReviews({
+          userId: numericUserId,
+          cursor: null,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setReviews(response.content)
+        setReviewNextCursor(response.nextCursor)
+        setHasMoreReviews(response.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setReviewsErrorMessage(
+          error instanceof Error ? error.message : '감상 목록을 불러오지 못했습니다.'
+        )
+      } finally {
+        if (!controller.signal.aborted) setIsReviewsLoading(false)
       }
     })()
 
@@ -148,6 +192,28 @@ export default function UserProfilePage() {
     } finally {
       // stale 여부와 무관하게 항상 reset — 그렇지 않으면 사용자가 다른 프로필로 이동한 새 페이지에서 버튼이 영구 disabled
       if (isMountedRef.current) setIsFollowProcessing(false)
+    }
+  }
+
+  const handleLoadMoreReviews = async () => {
+    if (isReviewsLoadingMore || !hasMoreReviews) return
+
+    setIsReviewsLoadingMore(true)
+    setReviewsErrorMessage(null)
+    try {
+      const response = await getUserReviews({
+        userId: numericUserId,
+        cursor: reviewNextCursor,
+      })
+      setReviews(prev => [...prev, ...response.content])
+      setReviewNextCursor(response.nextCursor)
+      setHasMoreReviews(response.hasNext)
+    } catch (error) {
+      setReviewsErrorMessage(
+        error instanceof Error ? error.message : '감상 목록을 더 불러오지 못했습니다.'
+      )
+    } finally {
+      setIsReviewsLoadingMore(false)
     }
   }
 
@@ -259,6 +325,91 @@ export default function UserProfilePage() {
               <p className="mt-2 text-3xl font-bold text-primary">{profile.reviewCount}개</p>
             </div>
           </div>
+        </section>
+
+        <section className="px-6 pb-10 pt-10">
+          <h2 className="mb-5 text-[28px] font-bold tracking-tight text-foreground">공개 감상</h2>
+
+          {isReviewsLoading ? (
+            <p role="status" className="py-8 text-center text-sm text-muted-foreground">
+              감상을 불러오는 중...
+            </p>
+          ) : reviews.length === 0 && !reviewsErrorMessage ? (
+            <div className="rounded-[24px] bg-card px-5 py-8 text-center text-sm text-muted-foreground">
+              아직 공개 감상이 없습니다.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {reviews.map(review => (
+                <article
+                  key={review.reviewId}
+                  onClick={() => navigate(`/review/${review.reviewId}`)}
+                  className="flex cursor-pointer gap-4 rounded-[24px] bg-card p-4 shadow-sm transition-colors hover:bg-primary/5"
+                >
+                  <div className="flex h-[96px] w-[76px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-primary/5">
+                    {review.book.coverImageUrl ? (
+                      <img
+                        src={review.book.coverImageUrl}
+                        alt={`${review.book.title} 표지`}
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined text-3xl text-muted-foreground/30">
+                        menu_book
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="min-w-0 flex-1 pt-1">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="line-clamp-1 text-xl font-bold text-foreground">
+                        {review.book.title}
+                      </h3>
+                      <span className="shrink-0 text-sm font-bold text-primary">
+                        ★ {review.rating.toFixed(1)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm font-medium text-primary/40">
+                      {formatRelativeTime(review.createdAt)}
+                    </p>
+                    <p className="mt-3 line-clamp-2 text-base leading-6 text-foreground/65">
+                      {review.isSpoiler ? '스포일러가 포함된 감상입니다.' : review.content}
+                    </p>
+                    <div className="mt-3 flex items-center gap-4 text-xs font-semibold text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <span className="material-symbols-outlined text-[16px]">favorite</span>
+                        {review.likeCount}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <span className="material-symbols-outlined text-[16px]">chat_bubble</span>
+                        {review.commentCount}
+                      </span>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          {reviewsErrorMessage && (
+            <p
+              role="alert"
+              className="mt-4 rounded-xl bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+            >
+              {reviewsErrorMessage}
+            </p>
+          )}
+
+          {hasMoreReviews && !isReviewsLoading && (
+            <button
+              type="button"
+              onClick={handleLoadMoreReviews}
+              disabled={isReviewsLoadingMore}
+              className="mt-5 w-full rounded-xl bg-primary/10 py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isReviewsLoadingMore ? '불러오는 중...' : '더 보기'}
+            </button>
+          )}
         </section>
       </main>
     </div>


### PR DESCRIPTION
## 작업 내용

프로필 페이지의 감상 목록 API를 연동했습니다.

- 내 감상 목록 API 연동
  - `GET /api/v1/me/reviews`
- 타 유저 감상 목록 API 연동
  - `GET /api/v1/{memberId}/reviews`
- 내 프로필 페이지의 기존 mock 감상 타임라인 제거
- 내 프로필/타 유저 프로필 하단에 실제 감상 목록 렌더링
- 감상 클릭 시 감상 상세 페이지로 이동
- 감상 목록 로딩/빈 상태/에러 상태 처리
- `hasNext` 응답 기반 `더 보기` 버튼 추가

## 주요 변경 파일

- `src/api/review.ts`
- `src/pages/MyProfilePage.tsx`
- `src/pages/UserProfilePage.tsx`

## 확인 사항

- [x] 내 프로필에서 내 감상 목록 조회
- [x] 타 유저 프로필에서 해당 유저 감상 목록 조회
- [x] 감상 카드 클릭 시 `/review/{reviewId}` 이동
- [x] 감상 목록 로딩/빈 상태/에러 상태 표시
- [x] 다음 페이지가 있을 때 `더 보기` 버튼 표시

## 참고 사항

- 이번 PR에서는 요청 범위를 `review.ts`, `MyProfilePage.tsx`, `UserProfilePage.tsx` 3개 파일로 제한했습니다.
- [ ] `ReviewCard` 재사용 또는 프로필 감상 목록 공통 컴포넌트 분리는 후속 PR에서 진행합니다.
- [ ] 무한스크롤 전환도 후속 PR에서 검토합니다.
- [ ] 좋아요/댓글 인터랙션 API 연동은 별도 이슈로 분리합니다.

Closes #122 