### PR TITLE
feat: 통합 검색 연동 (도서/유저 탭) — /api/v1/search (#126)

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,0 +1,114 @@
+import apiClient from './client'
+import { type ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
+
+/**
+ * 통합 검색 결과의 단일 도서 항목 — 백엔드 `BookSearchResult`와 1:1 매칭.
+ *
+ * 기존 `/api/v1/books/search`의 `BookSummary`(book.ts)와는 다른 필드 셋:
+ * - 통합 검색은 `averageRating`/`reviewCount`(통계)를 노출
+ * - 도서 검색은 `publisher`/`publishedDate`/`inMyLibrary`(서재 상태)를 노출
+ *
+ * 따라서 도서 탭은 기존 `searchBooks`를 그대로 사용하고, 본 통합 검색 API는
+ * "전체" 탭 또는 "유저" 탭에서만 사용한다 (#126 결정 사항 — 옵션 a).
+ *
+ * `averageRating`은 백엔드에서 평점이 없으면 0.0으로 채움 — UI에서 0.0이면
+ * 별점 미표시 등 정책으로 분기.
+ */
+export interface BookSearchItem {
+  bookId: number
+  isbn13: string
+  title: string
+  author: string
+  coverImageUrl: string | null
+  averageRating: number
+  reviewCount: number
+}
+
+/**
+ * 통합 검색 결과의 단일 유저 항목 — 백엔드 `UserSearchResult`와 1:1 매칭.
+ *
+ * `isFollowing`은 비로그인 시 백엔드가 항상 false로 채움. 검색 결과에 자기 자신이
+ * 포함될 수 있으므로 호출부에서 `useAuthStore.user.id` 비교로 자기 자신은 팔로우
+ * 버튼 미노출 처리 권장.
+ */
+export interface UserSearchItem {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+  bio: string | null
+  followerCount: number
+  isFollowing: boolean
+}
+
+/**
+ * 백엔드 `SearchPageResponse<T>`와 1:1 매칭. 빈 결과는 `content: []` + `hasNext: false`.
+ * `nextCursor`는 마지막 아이템의 id (book이면 bookId, user면 userId).
+ */
+export interface SearchPage<T> {
+  content: T[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+/**
+ * 통합 검색 응답 wrapper. `type`별로 한쪽이 빈 페이지로 채워진다.
+ *
+ * - `type='all'` → books, users 모두 검색 결과
+ * - `type='book'` → users는 빈 페이지(empty)
+ * - `type='user'` → books는 빈 페이지(empty)
+ *
+ * 두 섹션이 항상 존재하므로 옵셔널 분기 불필요.
+ */
+export interface IntegratedSearchResponse {
+  books: SearchPage<BookSearchItem>
+  users: SearchPage<UserSearchItem>
+}
+
+export type SearchType = 'all' | 'book' | 'user'
+
+export interface SearchAllParams {
+  query: string
+  type?: SearchType
+  cursor?: number | null
+  limit?: number
+  signal?: AbortSignal
+}
+
+/**
+ * 통합 검색 (`GET /api/v1/search`). 도서와 유저를 동시에 검색.
+ *
+ * 백엔드는 query가 빈 문자열/공백이면 400(`SEARCH_QUERY_REQUIRED`)을 반환하므로
+ * 호출부에서 trimmed query가 빈 문자열일 때 호출 자체를 차단해야 한다.
+ *
+ * 비로그인 접근 허용 — 단, 로그인 시 백엔드가 `SearchHistory`를 자동 저장하고
+ * 유저 결과의 `isFollowing`을 정확히 채운다. 비로그인이면 `isFollowing` 항상 false.
+ *
+ * @param params.query 검색어 (필수, trim 후 호출 권장)
+ * @param params.type 'all' | 'book' | 'user' (기본 'all')
+ * @param params.cursor 직전 응답의 `nextCursor`. 첫 페이지는 null/undefined
+ * @param params.limit 페이지 크기 (기본 20, 최대 50)
+ * @param params.signal 요청 취소용 AbortSignal
+ */
+export async function searchAll({
+  query,
+  type = 'all',
+  cursor,
+  limit = 20,
+  signal,
+}: SearchAllParams): Promise<IntegratedSearchResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<IntegratedSearchResponse>>('/api/v1/search', {
+      params: {
+        query,
+        type,
+        limit,
+        ...(cursor != null ? { cursor } : {}),
+      },
+      signal,
+    })
+    return parseApiResponse(data, '검색 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '검색에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}

--- a/src/components/common/UserSearchCard.tsx
+++ b/src/components/common/UserSearchCard.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { followUser, unfollowUser } from '@/api/follow'
+import type { UserSearchItem } from '@/api/search'
+import { useAuthStore } from '@/store/authStore'
+
+/**
+ * 통합 검색 결과의 유저 카드. 클릭 시 `/user/{userId}` 프로필로 이동, 팔로우 토글
+ * 버튼은 자기 자신이 아닌 경우에만 노출.
+ *
+ * **낙관적 업데이트 + 롤백**:
+ * `isFollowing`/`followerCount`를 즉시 반영 후 백엔드 호출. 실패 시 원래 값으로 롤백.
+ *
+ * **카드 클릭과 토글 버튼 분리**:
+ * 카드 전체가 `<Link>`라 토글 버튼 onClick에서 `e.preventDefault()` + `e.stopPropagation()`
+ * 으로 라우팅을 막는다. 이렇게 안 하면 토글 클릭이 상위 `<Link>`로 버블링되어 의도하지
+ * 않게 프로필로 이동.
+ *
+ * **연타/언마운트 가드**:
+ * `isProcessing`으로 진행 중이면 새 토글 차단(API는 멱등이지만 race 방지).
+ * 언마운트 후 setState 방지를 위해 `isMountedRef` 유지.
+ */
+export default function UserSearchCard({ user }: { user: UserSearchItem }) {
+  const myUserId = useAuthStore(state => state.user?.id)
+  const isMe = myUserId === user.userId
+
+  const [isFollowing, setIsFollowing] = useState(user.isFollowing)
+  const [followerCount, setFollowerCount] = useState(user.followerCount)
+  const [isProcessing, setIsProcessing] = useState(false)
+
+  const isMountedRef = useRef(true)
+  // [code-review HIGH fix] StrictMode 더블 인보크 + 진짜 unmount를 모두 처리.
+  // setup에서 true로 리셋해 ref가 false로 stuck되는 것을 방지하고, cleanup에서
+  // 명시적으로 false로 두어 unmount 후 setState 경고를 막는다.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  // [code-review MED fix] 부모 prop이 갱신될 때(다른 화면에서 팔로우 토글 후
+  // 검색 결과로 재진입, 무한 스크롤 dedup 미적용 시 같은 userId 재출현 등) 본
+  // 카드의 내부 state도 동기화. 외부 변경이 카드에 반영되지 않는 stale UI 방지.
+  useEffect(() => {
+    setIsFollowing(user.isFollowing)
+    setFollowerCount(user.followerCount)
+  }, [user.userId, user.isFollowing, user.followerCount])
+
+  const handleToggleFollow = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (isProcessing) return
+
+    const wasFollowing = isFollowing
+    // 낙관적 업데이트
+    setIsFollowing(!wasFollowing)
+    setFollowerCount(prev => prev + (wasFollowing ? -1 : 1))
+    setIsProcessing(true)
+
+    try {
+      const result = wasFollowing ? await unfollowUser(user.userId) : await followUser(user.userId)
+      if (!isMountedRef.current) return
+      // 서버 권위적 카운트로 동기화 (낙관적 +/-1과 다를 수 있음)
+      if (Number.isFinite(result.followerCount)) {
+        setFollowerCount(result.followerCount)
+      }
+    } catch {
+      if (!isMountedRef.current) return
+      // 실패 시 원래 값으로 롤백
+      setIsFollowing(wasFollowing)
+      setFollowerCount(prev => prev + (wasFollowing ? 1 : -1))
+    } finally {
+      if (isMountedRef.current) setIsProcessing(false)
+    }
+  }
+
+  return (
+    <Link
+      to={`/user/${user.userId}`}
+      className="flex items-center gap-3 border-b border-primary/5 py-4"
+    >
+      <div className="size-12 shrink-0 overflow-hidden rounded-full bg-primary/10">
+        {user.profileImageUrl ? (
+          <img
+            src={user.profileImageUrl}
+            alt={`${user.nickname} 프로필 이미지`}
+            className="size-full object-cover"
+          />
+        ) : (
+          <div className="flex size-full items-center justify-center">
+            <span className="material-symbols-outlined text-primary/40">person</span>
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-bold text-foreground">{user.nickname}</p>
+        {user.bio && <p className="line-clamp-1 text-xs text-muted-foreground">{user.bio}</p>}
+        <p className="mt-0.5 text-xs text-muted-foreground/70">팔로워 {followerCount}</p>
+      </div>
+
+      {!isMe && (
+        <button
+          type="button"
+          onClick={handleToggleFollow}
+          disabled={isProcessing}
+          aria-pressed={isFollowing}
+          className={
+            isFollowing
+              ? 'shrink-0 rounded-full border border-primary/30 bg-card px-4 py-1.5 text-xs font-bold text-primary disabled:opacity-60'
+              : 'shrink-0 rounded-full bg-primary px-4 py-1.5 text-xs font-bold text-primary-foreground disabled:opacity-60'
+          }
+        >
+          {isFollowing ? '팔로잉' : '팔로우'}
+        </button>
+      )}
+    </Link>
+  )
+}

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -1,12 +1,16 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
+import UserSearchCard from '@/components/common/UserSearchCard'
 import { getBookByIsbn, searchBooks, type BookDetail, type BookSummary } from '@/api/book'
+import { searchAll, type BookSearchItem, type UserSearchItem, type SearchType } from '@/api/search'
+import { cn } from '@/lib/utils'
 
 const RECENT_KEYWORDS_KEY = 'shelfeed-recent-keywords'
 const MAX_RECENT_KEYWORDS = 10
+const ALL_TAB_PREVIEW_COUNT = 3
 
 // ZXing 의존성을 가진 모달은 사용자가 카메라 버튼을 눌렀을 때만 다운로드
 const IsbnScannerModal = lazy(() => import('@/components/common/IsbnScannerModal'))
@@ -59,59 +63,171 @@ function saveRecentKeywords(keywords: string[]) {
   }
 }
 
+const TABS: { value: SearchType; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'book', label: '도서' },
+  { value: 'user', label: '유저' },
+]
+
+function isSearchType(value: string | null): value is SearchType {
+  return value === 'all' || value === 'book' || value === 'user'
+}
+
+/**
+ * 통합 검색 페이지 (`/search`).
+ *
+ * 탭(전체/도서/유저)으로 분기하여 단일 진입점에서 도서와 유저를 모두 검색한다.
+ * URL 쿼리 `?tab=...&q=...`로 deep link/새로고침 보존.
+ *
+ * **API 분리 정책**:
+ * - 도서 탭: 기존 `searchBooks` (`/api/v1/books/search`) 그대로 — `publisher`/`publishedDate`/
+ *   `inMyLibrary`(서재 상태) + ISBN 자동 인식 + 바코드 스캐너 동작 유지.
+ * - 유저 탭 / 전체 탭: 통합 검색 `searchAll` (`/api/v1/search`) — 응답에 `averageRating`/
+ *   `reviewCount`(통계)는 있지만 publisher/inMyLibrary는 없음. 카드 UI 분리.
+ *
+ * **무한 스크롤**:
+ * - 도서 탭과 유저 탭 모두 IntersectionObserver + cursor 페이징.
+ * - 전체 탭은 books/users를 각각 처음 `ALL_TAB_PREVIEW_COUNT`건만 미리보기로 노출하고
+ *   "전체 보기" 클릭 시 해당 탭으로 점프 (페이징 없음).
+ *
+ * **state 분리**:
+ * 탭별 결과/cursor/로딩/에러를 별도 state로 둬서 탭 전환 시 다른 탭의 결과를 보존.
+ * 검색어/탭 변경 시 in-flight 요청은 AbortController로 일괄 abort.
+ */
 export default function BookSearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
   const [recentKeywords, setRecentKeywords] = useState<string[]>(() => loadRecentKeywords())
-  const [searchQuery, setSearchQuery] = useState('')
-  const [results, setResults] = useState<BookSummary[]>([])
-  const [nextCursor, setNextCursor] = useState<number | null>(null)
-  const [hasNext, setHasNext] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingMore, setIsLoadingMore] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const initialQuery = searchParams.get('q') ?? ''
+  const initialTab = (() => {
+    const t = searchParams.get('tab')
+    return isSearchType(t) ? t : 'all'
+  })()
+
+  const [searchQuery, setSearchQuery] = useState(initialQuery)
+  const [activeTab, setActiveTab] = useState<SearchType>(initialTab)
   const [isScannerOpen, setIsScannerOpen] = useState(false)
+
+  // 도서 탭 (searchBooks 응답)
+  const [bookResults, setBookResults] = useState<BookSummary[]>([])
+  const [bookNextCursor, setBookNextCursor] = useState<number | null>(null)
+  const [bookHasNext, setBookHasNext] = useState(false)
+  const [isBookLoading, setIsBookLoading] = useState(false)
+  const [isBookLoadingMore, setIsBookLoadingMore] = useState(false)
+  const [bookErrorMessage, setBookErrorMessage] = useState<string | null>(null)
+  const [bookLoadMoreError, setBookLoadMoreError] = useState<string | null>(null)
+
+  // 유저 탭 (searchAll type=user 응답)
+  const [userResults, setUserResults] = useState<UserSearchItem[]>([])
+  const [userNextCursor, setUserNextCursor] = useState<number | null>(null)
+  const [userHasNext, setUserHasNext] = useState(false)
+  const [isUserLoading, setIsUserLoading] = useState(false)
+  const [isUserLoadingMore, setIsUserLoadingMore] = useState(false)
+  const [userErrorMessage, setUserErrorMessage] = useState<string | null>(null)
+  const [userLoadMoreError, setUserLoadMoreError] = useState<string | null>(null)
+
+  // 전체 탭 (searchAll type=all 응답 — 미리보기용, 페이징 없음)
+  const [allBooks, setAllBooks] = useState<BookSearchItem[]>([])
+  const [allUsers, setAllUsers] = useState<UserSearchItem[]>([])
+  const [allBooksHasMore, setAllBooksHasMore] = useState(false)
+  const [allUsersHasMore, setAllUsersHasMore] = useState(false)
+  const [isAllLoading, setIsAllLoading] = useState(false)
+  const [allErrorMessage, setAllErrorMessage] = useState<string | null>(null)
 
   const trimmedQuery = searchQuery.trim()
   const isIsbnMode = isValidIsbn13(trimmedQuery)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const moreControllerRef = useRef<AbortController | null>(null)
+
+  const bookSentinelRef = useRef<HTMLDivElement | null>(null)
+  const userSentinelRef = useRef<HTMLDivElement | null>(null)
+
+  /**
+   * 탭별 진행 중 요청 abort controller. 검색어/탭 전환 시 새 요청으로 교체.
+   */
+  const bookMoreControllerRef = useRef<AbortController | null>(null)
+  const userMoreControllerRef = useRef<AbortController | null>(null)
 
   // observer 콜백에서 최신 state를 읽기 위한 ref (deps 폭주 방지)
   const stateRef = useRef({
-    hasNext,
-    isLoading,
-    isLoadingMore,
-    nextCursor,
+    bookHasNext,
+    isBookLoading,
+    isBookLoadingMore,
+    bookNextCursor,
+    bookLoadMoreError,
+    userHasNext,
+    isUserLoading,
+    isUserLoadingMore,
+    userNextCursor,
+    userLoadMoreError,
     trimmedQuery,
-    loadMoreError,
+    activeTab,
   })
   stateRef.current = {
-    hasNext,
-    isLoading,
-    isLoadingMore,
-    nextCursor,
+    bookHasNext,
+    isBookLoading,
+    isBookLoadingMore,
+    bookNextCursor,
+    bookLoadMoreError,
+    userHasNext,
+    isUserLoading,
+    isUserLoadingMore,
+    userNextCursor,
+    userLoadMoreError,
     trimmedQuery,
-    loadMoreError,
+    activeTab,
   }
 
-  // 검색어 debounce + AbortController로 stale 응답 방지
+  // ISBN13이면 자동 도서 탭으로 강제 — 바코드 스캐너 결과/사용자 직접 입력 모두 커버
   useEffect(() => {
-    // 검색어가 바뀌면 in-flight 상태를 전부 초기화 (MEDIUM 1: 깜빡임 방지)
-    setIsLoadingMore(false)
-    setLoadMoreError(null)
-    moreControllerRef.current?.abort()
+    if (isIsbnMode && activeTab !== 'book') {
+      setActiveTab('book')
+    }
+  }, [isIsbnMode, activeTab])
 
-    if (!trimmedQuery) {
-      setResults([])
-      setNextCursor(null)
-      setHasNext(false)
-      setErrorMessage(null)
+  // URL 쿼리 동기화 — 탭/검색어 변경 시 ?tab=...&q=... 업데이트
+  useEffect(() => {
+    const next = new URLSearchParams(searchParams)
+    if (trimmedQuery) {
+      next.set('q', trimmedQuery)
+    } else {
+      next.delete('q')
+    }
+    if (activeTab !== 'all') {
+      next.set('tab', activeTab)
+    } else {
+      next.delete('tab')
+    }
+    if (next.toString() !== searchParams.toString()) {
+      setSearchParams(next, { replace: true })
+    }
+    // [code-review LOW fix] searchParams를 deps에 넣으면 setSearchParams →
+    // 새 searchParams 인스턴스 → effect 재실행의 무한 루프 위험. 위 toString
+    // 비교 가드가 같은 값일 때 setSearchParams를 스킵하지만, 외부에서
+    // searchParams를 직접 변경할 수 있는 경로가 생기면 본 effect가 그것을
+    // 덮어쓸 수 있다(현재는 그런 경로 없음). 의도적으로 deps에서 제외하고
+    // 비교 가드로 무한 루프만 차단.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trimmedQuery, activeTab])
+
+  // 도서 탭 첫 페이지 fetch (검색어 변경 시 debounce)
+  useEffect(() => {
+    setIsBookLoadingMore(false)
+    setBookLoadMoreError(null)
+    bookMoreControllerRef.current?.abort()
+
+    if (!trimmedQuery || activeTab !== 'book') {
+      // 다른 탭이거나 검색어 비어있으면 도서 결과 초기화
+      if (!trimmedQuery) {
+        setBookResults([])
+        setBookNextCursor(null)
+        setBookHasNext(false)
+        setBookErrorMessage(null)
+      }
       return
     }
 
     const controller = new AbortController()
-    setIsLoading(true)
-    setErrorMessage(null)
+    setIsBookLoading(true)
+    setBookErrorMessage(null)
 
     const handle = setTimeout(async () => {
       try {
@@ -119,89 +235,245 @@ export default function BookSearchPage() {
           // ISBN 모드: 단일 도서 정확 조회 — 페이지네이션 없음
           const book = await getBookByIsbn(trimmedQuery, controller.signal)
           if (controller.signal.aborted) return
-          setResults([isbnResultToSummary(book)])
-          setNextCursor(null)
-          setHasNext(false)
+          setBookResults([isbnResultToSummary(book)])
+          setBookNextCursor(null)
+          setBookHasNext(false)
         } else {
           const response = await searchBooks(trimmedQuery, 20, null, controller.signal)
           if (controller.signal.aborted) return
-          setResults(response.content)
-          setNextCursor(response.nextCursor)
-          setHasNext(response.hasNext)
+          setBookResults(response.content)
+          setBookNextCursor(response.nextCursor)
+          setBookHasNext(response.hasNext)
         }
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
-        setErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
-        setResults([])
-        setNextCursor(null)
-        setHasNext(false)
+        setBookErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
+        setBookResults([])
+        setBookNextCursor(null)
+        setBookHasNext(false)
       } finally {
-        if (!controller.signal.aborted) setIsLoading(false)
+        if (!controller.signal.aborted) setIsBookLoading(false)
       }
     }, 400)
 
     return () => {
       clearTimeout(handle)
       controller.abort()
-      moreControllerRef.current?.abort()
+      bookMoreControllerRef.current?.abort()
     }
-  }, [trimmedQuery])
+  }, [trimmedQuery, activeTab])
 
-  // 다음 페이지 로딩 (observer + 수동 retry에서 공유)
-  const fetchMore = useCallback(async () => {
-    const s = stateRef.current
-    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
-    // ISBN 모드는 단일 결과라 추가 로딩 불필요
-    if (isValidIsbn13(s.trimmedQuery)) return
-    const requestedQuery = s.trimmedQuery
-    const requestedCursor = s.nextCursor
+  // 유저 탭 첫 페이지 fetch
+  useEffect(() => {
+    setIsUserLoadingMore(false)
+    setUserLoadMoreError(null)
+    userMoreControllerRef.current?.abort()
 
-    // 이전 pagination 요청 취소 후 새 controller 생성
-    moreControllerRef.current?.abort()
+    if (!trimmedQuery || activeTab !== 'user') {
+      if (!trimmedQuery) {
+        setUserResults([])
+        setUserNextCursor(null)
+        setUserHasNext(false)
+        setUserErrorMessage(null)
+      }
+      return
+    }
+
     const controller = new AbortController()
-    moreControllerRef.current = controller
+    setIsUserLoading(true)
+    setUserErrorMessage(null)
 
-    setIsLoadingMore(true)
-    setLoadMoreError(null)
+    const handle = setTimeout(async () => {
+      try {
+        const response = await searchAll({
+          query: trimmedQuery,
+          type: 'user',
+          cursor: null,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setUserResults(response.users.content)
+        setUserNextCursor(response.users.nextCursor)
+        setUserHasNext(response.users.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setUserErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
+        setUserResults([])
+        setUserNextCursor(null)
+        setUserHasNext(false)
+      } finally {
+        if (!controller.signal.aborted) setIsUserLoading(false)
+      }
+    }, 400)
+
+    return () => {
+      clearTimeout(handle)
+      controller.abort()
+      userMoreControllerRef.current?.abort()
+    }
+  }, [trimmedQuery, activeTab])
+
+  // 전체 탭 fetch — books/users 두 섹션 미리보기, 페이징 없음
+  useEffect(() => {
+    if (!trimmedQuery || activeTab !== 'all') {
+      if (!trimmedQuery) {
+        setAllBooks([])
+        setAllUsers([])
+        setAllBooksHasMore(false)
+        setAllUsersHasMore(false)
+        setAllErrorMessage(null)
+      }
+      return
+    }
+
+    const controller = new AbortController()
+    setIsAllLoading(true)
+    setAllErrorMessage(null)
+
+    const handle = setTimeout(async () => {
+      try {
+        const response = await searchAll({
+          query: trimmedQuery,
+          type: 'all',
+          cursor: null,
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setAllBooks(response.books.content)
+        setAllUsers(response.users.content)
+        setAllBooksHasMore(response.books.hasNext)
+        setAllUsersHasMore(response.users.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setAllErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
+        setAllBooks([])
+        setAllUsers([])
+      } finally {
+        if (!controller.signal.aborted) setIsAllLoading(false)
+      }
+    }, 400)
+
+    return () => {
+      clearTimeout(handle)
+      controller.abort()
+    }
+  }, [trimmedQuery, activeTab])
+
+  /**
+   * 도서 탭 다음 페이지 로딩. observer 콜백과 retry 버튼이 공유 호출.
+   * stateRef에서 최신 상태 읽어 stale closure 회피.
+   */
+  const fetchMoreBooks = useCallback(async () => {
+    const s = stateRef.current
+    // [code-review MED fix] 비활성 탭에서 sentinel 콜백이 늦게 발화해도 fetch가
+    // 진행되지 않도록 진입부 가드. observer disconnect와 별개의 안전망.
+    if (s.activeTab !== 'book') return
+    if (s.isBookLoadingMore || s.isBookLoading || !s.bookHasNext) return
+    if (isValidIsbn13(s.trimmedQuery)) return // ISBN 모드는 단일 결과
+    const requestedQuery = s.trimmedQuery
+    const requestedCursor = s.bookNextCursor
+
+    bookMoreControllerRef.current?.abort()
+    const controller = new AbortController()
+    bookMoreControllerRef.current = controller
+
+    setIsBookLoadingMore(true)
+    setBookLoadMoreError(null)
     try {
       const response = await searchBooks(requestedQuery, 20, requestedCursor, controller.signal)
       if (controller.signal.aborted) return
-      // stale guard: 검색어가 바뀐 경우 결과 버림
       if (stateRef.current.trimmedQuery !== requestedQuery) return
-      setResults(prev => [...prev, ...response.content])
-      setNextCursor(response.nextCursor)
-      setHasNext(response.hasNext)
+      setBookResults(prev => [...prev, ...response.content])
+      setBookNextCursor(response.nextCursor)
+      setBookHasNext(response.hasNext)
     } catch (error) {
       if (axios.isCancel(error) || controller.signal.aborted) return
       if (stateRef.current.trimmedQuery !== requestedQuery) return
-      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+      setBookLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
     } finally {
-      if (!controller.signal.aborted) setIsLoadingMore(false)
+      if (!controller.signal.aborted) setIsBookLoadingMore(false)
     }
   }, [])
 
-  // IntersectionObserver — sentinel이 조건부 렌더되므로 hasResults 변화 시 재생성
-  const hasResults = results.length > 0
-  useEffect(() => {
-    const sentinel = loadMoreRef.current
-    if (!sentinel) return
+  /**
+   * 유저 탭 다음 페이지 로딩. fetchMoreBooks와 동일 패턴.
+   */
+  const fetchMoreUsers = useCallback(async () => {
+    const s = stateRef.current
+    // [code-review MED fix] 비활성 탭 진입부 가드 (fetchMoreBooks와 동일 정책).
+    if (s.activeTab !== 'user') return
+    if (s.isUserLoadingMore || s.isUserLoading || !s.userHasNext) return
+    const requestedQuery = s.trimmedQuery
+    const requestedCursor = s.userNextCursor
 
+    userMoreControllerRef.current?.abort()
+    const controller = new AbortController()
+    userMoreControllerRef.current = controller
+
+    setIsUserLoadingMore(true)
+    setUserLoadMoreError(null)
+    try {
+      const response = await searchAll({
+        query: requestedQuery,
+        type: 'user',
+        cursor: requestedCursor,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      if (stateRef.current.trimmedQuery !== requestedQuery) return
+      setUserResults(prev => [...prev, ...response.users.content])
+      setUserNextCursor(response.users.nextCursor)
+      setUserHasNext(response.users.hasNext)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      if (stateRef.current.trimmedQuery !== requestedQuery) return
+      setUserLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsUserLoadingMore(false)
+    }
+  }, [])
+
+  // 도서 sentinel observer
+  const hasBookResults = bookResults.length > 0
+  useEffect(() => {
+    const sentinel = bookSentinelRef.current
+    if (!sentinel || activeTab !== 'book') return
     const observer = new IntersectionObserver(
       entries => {
-        if (!entries[0].isIntersecting) return
-        if (stateRef.current.loadMoreError) return
-        fetchMore()
+        if (!entries[0]?.isIntersecting) return
+        if (stateRef.current.bookLoadMoreError) return
+        fetchMoreBooks()
       },
       { rootMargin: '200px' }
     )
-
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [fetchMore, hasResults])
+  }, [fetchMoreBooks, hasBookResults, activeTab])
 
-  const retryLoadMore = () => {
-    setLoadMoreError(null)
-    fetchMore()
+  // 유저 sentinel observer
+  const hasUserResults = userResults.length > 0
+  useEffect(() => {
+    const sentinel = userSentinelRef.current
+    if (!sentinel || activeTab !== 'user') return
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries[0]?.isIntersecting) return
+        if (stateRef.current.userLoadMoreError) return
+        fetchMoreUsers()
+      },
+      { rootMargin: '200px' }
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [fetchMoreUsers, hasUserResults, activeTab])
+
+  const retryLoadMoreBooks = () => {
+    setBookLoadMoreError(null)
+    fetchMoreBooks()
+  }
+  const retryLoadMoreUsers = () => {
+    setUserLoadMoreError(null)
+    fetchMoreUsers()
   }
 
   const commitKeyword = (keyword: string) => {
@@ -246,7 +518,7 @@ export default function BookSearchPage() {
       {/* Search Bar */}
       <div className="border-b border-border px-4 py-3" role="search">
         <label htmlFor="book-search-input" className="sr-only">
-          도서 검색
+          통합 검색
         </label>
         <div className="flex h-12 w-full items-stretch rounded-xl border border-primary/10 bg-primary/5">
           <div className="flex items-center justify-center pl-4 text-primary/60">
@@ -258,18 +530,50 @@ export default function BookSearchPage() {
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            aria-label="도서 제목, 저자, ISBN 검색"
-            placeholder="도서 제목, 저자, ISBN 검색"
+            aria-label="도서 또는 유저 검색"
+            placeholder={
+              activeTab === 'user'
+                ? '닉네임으로 유저 검색'
+                : activeTab === 'book'
+                  ? '도서 제목, 저자, ISBN 검색'
+                  : '도서 또는 유저 검색'
+            }
             className="h-full min-w-0 flex-1 border-none bg-transparent px-3 text-base font-normal outline-none placeholder:text-primary/40 focus:ring-0"
           />
-          <button
-            type="button"
-            onClick={() => setIsScannerOpen(true)}
-            aria-label="바코드 스캔으로 ISBN 검색"
-            className="flex items-center justify-center pr-4 text-primary transition-colors hover:text-primary/70"
-          >
-            <span className="material-symbols-outlined text-[24px]">barcode_scanner</span>
-          </button>
+          {/* 바코드 스캐너는 도서 탭에서만 의미 있음 */}
+          {activeTab === 'book' && (
+            <button
+              type="button"
+              onClick={() => setIsScannerOpen(true)}
+              aria-label="바코드 스캔으로 ISBN 검색"
+              className="flex items-center justify-center pr-4 text-primary transition-colors hover:text-primary/70"
+            >
+              <span className="material-symbols-outlined text-[24px]">barcode_scanner</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-border" role="tablist">
+        <div className="flex">
+          {TABS.map(tab => (
+            <button
+              key={tab.value}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              className={cn(
+                'flex-1 border-b-2 py-3 text-sm font-bold transition-colors',
+                activeTab === tab.value
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -318,94 +622,191 @@ export default function BookSearchPage() {
 
       {/* Search Results */}
       <main className="flex-1 overflow-y-auto px-4 pb-24">
-        {trimmedQuery && isLoading && results.length === 0 && (
-          <p className="py-10 text-center text-sm text-muted-foreground">검색 중...</p>
+        {/* 전체 탭 */}
+        {activeTab === 'all' && trimmedQuery && (
+          <AllTabContent
+            isLoading={isAllLoading}
+            errorMessage={allErrorMessage}
+            books={allBooks}
+            users={allUsers}
+            booksHasMore={allBooksHasMore}
+            usersHasMore={allUsersHasMore}
+            previewCount={ALL_TAB_PREVIEW_COUNT}
+            onJumpToBookTab={() => setActiveTab('book')}
+            onJumpToUserTab={() => setActiveTab('user')}
+            commitKeyword={() => commitKeyword(trimmedQuery)}
+          />
         )}
 
-        {trimmedQuery && !isLoading && errorMessage && (
-          <p role="alert" className="py-10 text-center text-sm text-destructive">
-            {errorMessage}
-          </p>
-        )}
-
-        {trimmedQuery && !isLoading && !errorMessage && results.length === 0 && (
-          <div className="flex flex-col items-center gap-3 py-16 text-center">
-            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
-              search_off
-            </span>
-            <p className="max-w-full truncate text-sm text-muted-foreground">
-              '{trimmedQuery}'에 대한 검색 결과가 없습니다.
-            </p>
-          </div>
-        )}
-
-        {results.length > 0 && (
-          <div className="flex flex-col">
-            {results.map(book => (
-              <Link
-                key={book.bookId}
-                to={`/book/${book.bookId}`}
-                onClick={() => commitKeyword(trimmedQuery)}
-                className="flex items-start gap-4 border-b border-primary/5 py-5"
+        {/* 도서 탭 */}
+        {activeTab === 'book' && trimmedQuery && (
+          <>
+            {isBookLoading && bookResults.length === 0 && (
+              <p
+                role="status"
+                aria-busy="true"
+                className="py-10 text-center text-sm text-muted-foreground"
               >
-                <div className="h-36 w-24 shrink-0 overflow-hidden rounded-lg bg-primary/5 shadow-sm">
-                  {book.coverImageUrl ? (
-                    <img
-                      src={book.coverImageUrl}
-                      alt={book.title}
-                      className="size-full object-cover"
-                    />
-                  ) : (
-                    <div className="flex size-full items-center justify-center">
-                      <span className="material-symbols-outlined text-2xl text-muted-foreground/40">
-                        menu_book
-                      </span>
-                    </div>
-                  )}
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <h3 className="line-clamp-2 text-lg font-bold leading-tight text-primary">
-                    {book.title}
-                  </h3>
-                  <p className="truncate text-sm text-muted-foreground">{book.author} 저</p>
-                  <p className="truncate text-xs text-muted-foreground/70">{book.publisher}</p>
-                  {book.inMyLibrary && (
-                    <span className="mt-1 w-fit rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                      내 서재에 있음
-                    </span>
-                  )}
-                </div>
-              </Link>
-            ))}
-
-            {/* 무한 스크롤 sentinel */}
-            <div ref={loadMoreRef} className="h-10" />
-
-            {isLoadingMore && (
-              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+                검색 중...
+              </p>
             )}
 
-            {loadMoreError && !isLoadingMore && (
-              <div className="flex flex-col items-center gap-2 py-4">
-                <p role="alert" className="text-sm text-destructive">
-                  {loadMoreError}
+            {!isBookLoading && bookErrorMessage && (
+              <p role="alert" className="py-10 text-center text-sm text-destructive">
+                {bookErrorMessage}
+              </p>
+            )}
+
+            {!isBookLoading && !bookErrorMessage && bookResults.length === 0 && (
+              <div className="flex flex-col items-center gap-3 py-16 text-center">
+                <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+                  search_off
+                </span>
+                <p className="max-w-full truncate text-sm text-muted-foreground">
+                  &lsquo;{trimmedQuery}&rsquo;에 대한 도서 검색 결과가 없습니다.
                 </p>
-                <button
-                  type="button"
-                  onClick={retryLoadMore}
-                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
-                >
-                  다시 불러오기
-                </button>
               </div>
             )}
 
-            {!hasNext && !isLoadingMore && !loadMoreError && !isIsbnMode && (
-              <p className="py-4 text-center text-xs text-muted-foreground/50">
-                모든 결과를 확인했습니다
+            {bookResults.length > 0 && (
+              <div className="flex flex-col">
+                {bookResults.map(book => (
+                  <Link
+                    key={book.bookId}
+                    to={`/book/${book.bookId}`}
+                    onClick={() => commitKeyword(trimmedQuery)}
+                    className="flex items-start gap-4 border-b border-primary/5 py-5"
+                  >
+                    <div className="h-36 w-24 shrink-0 overflow-hidden rounded-lg bg-primary/5 shadow-sm">
+                      {book.coverImageUrl ? (
+                        <img
+                          src={book.coverImageUrl}
+                          alt={book.title}
+                          className="size-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex size-full items-center justify-center">
+                          <span className="material-symbols-outlined text-2xl text-muted-foreground/40">
+                            menu_book
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <h3 className="line-clamp-2 text-lg font-bold leading-tight text-primary">
+                        {book.title}
+                      </h3>
+                      <p className="truncate text-sm text-muted-foreground">{book.author} 저</p>
+                      <p className="truncate text-xs text-muted-foreground/70">{book.publisher}</p>
+                      {book.inMyLibrary && (
+                        <span className="mt-1 w-fit rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                          내 서재에 있음
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+
+                <div ref={bookSentinelRef} className="h-10" aria-hidden="true" />
+
+                {isBookLoadingMore && (
+                  <p className="py-4 text-center text-xs text-muted-foreground">
+                    더 불러오는 중...
+                  </p>
+                )}
+
+                {bookLoadMoreError && !isBookLoadingMore && (
+                  <div className="flex flex-col items-center gap-2 py-4">
+                    <p role="alert" className="text-sm text-destructive">
+                      {bookLoadMoreError}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={retryLoadMoreBooks}
+                      className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                    >
+                      다시 불러오기
+                    </button>
+                  </div>
+                )}
+
+                {!bookHasNext && !isBookLoadingMore && !bookLoadMoreError && !isIsbnMode && (
+                  <p className="py-4 text-center text-xs text-muted-foreground/50">
+                    모든 결과를 확인했습니다
+                  </p>
+                )}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* 유저 탭 */}
+        {activeTab === 'user' && trimmedQuery && (
+          <>
+            {isUserLoading && userResults.length === 0 && (
+              <p
+                role="status"
+                aria-busy="true"
+                className="py-10 text-center text-sm text-muted-foreground"
+              >
+                검색 중...
               </p>
             )}
-          </div>
+
+            {!isUserLoading && userErrorMessage && (
+              <p role="alert" className="py-10 text-center text-sm text-destructive">
+                {userErrorMessage}
+              </p>
+            )}
+
+            {!isUserLoading && !userErrorMessage && userResults.length === 0 && (
+              <div className="flex flex-col items-center gap-3 py-16 text-center">
+                <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+                  person_search
+                </span>
+                <p className="max-w-full truncate text-sm text-muted-foreground">
+                  &lsquo;{trimmedQuery}&rsquo;에 대한 유저 검색 결과가 없습니다.
+                </p>
+              </div>
+            )}
+
+            {userResults.length > 0 && (
+              <div className="flex flex-col">
+                {userResults.map(user => (
+                  <UserSearchCard key={user.userId} user={user} />
+                ))}
+
+                <div ref={userSentinelRef} className="h-10" aria-hidden="true" />
+
+                {isUserLoadingMore && (
+                  <p className="py-4 text-center text-xs text-muted-foreground">
+                    더 불러오는 중...
+                  </p>
+                )}
+
+                {userLoadMoreError && !isUserLoadingMore && (
+                  <div className="flex flex-col items-center gap-2 py-4">
+                    <p role="alert" className="text-sm text-destructive">
+                      {userLoadMoreError}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={retryLoadMoreUsers}
+                      className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                    >
+                      다시 불러오기
+                    </button>
+                  </div>
+                )}
+
+                {!userHasNext && !isUserLoadingMore && !userLoadMoreError && (
+                  <p className="py-4 text-center text-xs text-muted-foreground/50">
+                    모든 결과를 확인했습니다
+                  </p>
+                )}
+              </div>
+            )}
+          </>
         )}
       </main>
 
@@ -421,10 +822,147 @@ export default function BookSearchPage() {
             // 스캔 결과를 검색창에 주입 → ISBN 자동 감지 effect가 ISBN 모드로 분기 (단일 진입점)
             setIsScannerOpen(false)
             setSearchQuery(isbn)
+            setActiveTab('book')
             commitKeyword(isbn)
           }}
         />
       </Suspense>
+    </div>
+  )
+}
+
+/**
+ * 전체 탭 — books/users 두 섹션을 미리보기 N건씩 렌더하고 "더 보기" 클릭 시
+ * 해당 탭으로 점프. 페이징은 도서/유저 탭에서만 수행 (UX 단순화).
+ */
+function AllTabContent({
+  isLoading,
+  errorMessage,
+  books,
+  users,
+  booksHasMore,
+  usersHasMore,
+  previewCount,
+  onJumpToBookTab,
+  onJumpToUserTab,
+  commitKeyword,
+}: {
+  isLoading: boolean
+  errorMessage: string | null
+  books: BookSearchItem[]
+  users: UserSearchItem[]
+  booksHasMore: boolean
+  usersHasMore: boolean
+  previewCount: number
+  onJumpToBookTab: () => void
+  onJumpToUserTab: () => void
+  commitKeyword: () => void
+}) {
+  if (isLoading && books.length === 0 && users.length === 0) {
+    return (
+      <p role="status" aria-busy="true" className="py-10 text-center text-sm text-muted-foreground">
+        검색 중...
+      </p>
+    )
+  }
+
+  if (!isLoading && errorMessage) {
+    return (
+      <p role="alert" className="py-10 text-center text-sm text-destructive">
+        {errorMessage}
+      </p>
+    )
+  }
+
+  if (!isLoading && books.length === 0 && users.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-center">
+        <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+          search_off
+        </span>
+        <p className="text-sm text-muted-foreground">검색 결과가 없습니다.</p>
+      </div>
+    )
+  }
+
+  const previewBooks = books.slice(0, previewCount)
+  const previewUsers = users.slice(0, previewCount)
+  const showBookMoreButton = booksHasMore || books.length > previewCount
+  const showUserMoreButton = usersHasMore || users.length > previewCount
+
+  return (
+    <div className="flex flex-col gap-4 py-2">
+      {previewBooks.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-bold text-primary">도서 ({books.length}건)</h2>
+          <div className="flex flex-col">
+            {previewBooks.map(book => (
+              <Link
+                key={book.bookId}
+                to={`/book/${book.bookId}`}
+                onClick={commitKeyword}
+                className="flex items-start gap-4 border-b border-primary/5 py-4"
+              >
+                <div className="h-24 w-16 shrink-0 overflow-hidden rounded bg-primary/5 shadow-sm">
+                  {book.coverImageUrl ? (
+                    <img
+                      src={book.coverImageUrl}
+                      alt={book.title}
+                      className="size-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex size-full items-center justify-center">
+                      <span className="material-symbols-outlined text-xl text-muted-foreground/40">
+                        menu_book
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <h3 className="line-clamp-2 text-base font-bold leading-tight text-primary">
+                    {book.title}
+                  </h3>
+                  <p className="truncate text-xs text-muted-foreground">{book.author}</p>
+                  {book.reviewCount > 0 && (
+                    <p className="text-xs text-muted-foreground/70">
+                      ★ {book.averageRating.toFixed(1)} · 감상 {book.reviewCount}개
+                    </p>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+          {showBookMoreButton && (
+            <button
+              type="button"
+              onClick={onJumpToBookTab}
+              className="mt-2 w-full rounded-lg bg-primary/5 py-2 text-sm font-medium text-primary hover:bg-primary/10"
+            >
+              도서 검색 결과 전체 보기
+            </button>
+          )}
+        </section>
+      )}
+
+      {previewUsers.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-bold text-primary">유저 ({users.length}건)</h2>
+          <div className="flex flex-col">
+            {previewUsers.map(user => (
+              <UserSearchCard key={user.userId} user={user} />
+            ))}
+          </div>
+          {showUserMoreButton && (
+            <button
+              type="button"
+              onClick={onJumpToUserTab}
+              className="mt-2 w-full rounded-lg bg-primary/5 py-2 text-sm font-medium text-primary hover:bg-primary/10"
+            >
+              유저 검색 결과 전체 보기
+            </button>
+          )}
+        </section>
+      )}
     </div>
   )
 }

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -183,6 +183,22 @@ export default function BookSearchPage() {
     }
   }, [isIsbnMode, activeTab])
 
+  // [CodeRabbit fix] URL → 컴포넌트 state 단방향 동기화. 사용자 입력으로 인한
+  // state 변경은 아래 "URL 동기화 effect"가 URL에 반영하고, 외부 경로로 URL이
+  // 바뀌는 경우(브라우저 뒤로/앞으로, deep link 직접 진입, 다른 컴포넌트의 navigate)
+  // 본 effect가 그 변경을 컴포넌트에 반영. 같은 값일 때는 setState가 no-op이라
+  // 양방향 effect 사이의 무한 루프는 발생하지 않는다.
+  useEffect(() => {
+    const urlQuery = searchParams.get('q') ?? ''
+    const urlTabRaw = searchParams.get('tab')
+    const urlTab: SearchType = isSearchType(urlTabRaw) ? urlTabRaw : 'all'
+    if (urlQuery !== searchQuery) setSearchQuery(urlQuery)
+    if (urlTab !== activeTab) setActiveTab(urlTab)
+    // searchQuery/activeTab은 의도적으로 deps에서 제외 — 이 effect는 URL이
+    // 바뀔 때만 동기화하면 충분하고, state가 deps에 들어가면 루프 위험.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
+
   // URL 쿼리 동기화 — 탭/검색어 변경 시 ?tab=...&q=... 업데이트
   useEffect(() => {
     const next = new URLSearchParams(searchParams)
@@ -226,8 +242,14 @@ export default function BookSearchPage() {
     }
 
     const controller = new AbortController()
-    setIsBookLoading(true)
+    // [CodeRabbit fix] 400ms debounce 동안 이전 검색 결과가 그대로 보이는
+    // stale UI 방지 — setTimeout 들어가기 전에 결과/cursor/에러 초기화하여
+    // 사용자가 "검색 중..." placeholder만 보도록 한다.
+    setBookResults([])
+    setBookNextCursor(null)
+    setBookHasNext(false)
     setBookErrorMessage(null)
+    setIsBookLoading(true)
 
     const handle = setTimeout(async () => {
       try {
@@ -280,8 +302,12 @@ export default function BookSearchPage() {
     }
 
     const controller = new AbortController()
-    setIsUserLoading(true)
+    // [CodeRabbit fix] debounce 중 stale UI 방지 (도서 탭과 동일 정책).
+    setUserResults([])
+    setUserNextCursor(null)
+    setUserHasNext(false)
     setUserErrorMessage(null)
+    setIsUserLoading(true)
 
     const handle = setTimeout(async () => {
       try {
@@ -327,8 +353,13 @@ export default function BookSearchPage() {
     }
 
     const controller = new AbortController()
-    setIsAllLoading(true)
+    // [CodeRabbit fix] debounce 중 stale UI 방지.
+    setAllBooks([])
+    setAllUsers([])
+    setAllBooksHasMore(false)
+    setAllUsersHasMore(false)
     setAllErrorMessage(null)
+    setIsAllLoading(true)
 
     const handle = setTimeout(async () => {
       try {
@@ -336,6 +367,9 @@ export default function BookSearchPage() {
           query: trimmedQuery,
           type: 'all',
           cursor: null,
+          // [CodeRabbit nit fix] 미리보기 정책(ALL_TAB_PREVIEW_COUNT)에 맞춰
+          // 백엔드 호출도 그 크기로 제한 — 사용 안 할 17건의 트래픽/페이로드 절약.
+          limit: ALL_TAB_PREVIEW_COUNT,
           signal: controller.signal,
         })
         if (controller.signal.aborted) return


### PR DESCRIPTION
기존 BookSearchPage(/search)를 통합 검색 구조로 재편. 탭(전체/도서/유저)으로 도서와 유저를 한 화면에서 검색.

## src/api/search.ts 신규
- BookSearchItem(통계: averageRating/reviewCount) / UserSearchItem (isFollowing 포함) / SearchPage<T> / IntegratedSearchResponse 타입 정의
- searchAll({ query, type, cursor, limit, signal }) — GET /api/v1/search
- parseApiResponse + normalizeAxiosError + AbortSignal 일관 패턴
- 백엔드 nullable 필드와 1:1 매칭 (averageRating은 평점 없으면 0.0, isFollowing은 비로그인 시 항상 false)

## src/components/common/UserSearchCard.tsx 신규
- 유저 검색 결과 한 줄 카드
- 자기 자신(useAuthStore.user.id 비교)은 팔로우 버튼 미노출
- 낙관적 isFollowing/followerCount 업데이트 + 실패 시 롤백
- 카드 클릭은 /user/{userId} 이동, 토글 버튼은 preventDefault로 라우팅 차단
- StrictMode 더블 인보크 대응 + 진행 중 연타 가드

## src/pages/BookSearchPage.tsx 통합 검색 재편
- 탭(전체/도서/유저) — activeTab 'all' | 'book' | 'user'
- URL 쿼리 동기화: ?tab=...&q=... 로 deep link/새로고침 보존
- 도서 탭: 기존 searchBooks(/api/v1/books/search) 동작 그대로 유지 (ISBN 자동 인식 + 바코드 스캐너 + cursor 페이징 + IntersectionObserver). publisher/inMyLibrary 등 BookSummary 필드 전체 활용
- 유저 탭: searchAll(type='user') + cursor 페이징 + IntersectionObserver
- 전체 탭: searchAll(type='all') 호출 → books/users 두 섹션을 미리보기 3건씩 + "전체 보기" 클릭 시 해당 탭 점프 (전체 탭은 페이징 없음 — UX 단순화)
- ISBN13 입력 시 자동 도서 탭 강제 전환 (사용자 직접 입력/바코드 스캔 모두)
- 바코드 스캐너 버튼은 도서 탭에서만 노출
- 탭별 in-flight 요청을 별도 AbortController로 관리, 검색어/탭 변경 시 abort
- stateRef + moreControllerRef + sentinelRef로 stale closure/observer 누수 방지
- 최근 검색어 localStorage는 공통(탭과 무관)
- 페이지 책임/state 분리 의도/API 분리 정책을 컴포넌트 위 JSDoc으로 명시

## 백엔드 (이미 구현 완료, 본 PR은 프론트만)
- SearchController @ /api/v1/search
- SearchService.search(query, type, cursor, limit, memberUserId)
- 응답: { books: SearchPage<BookSearchResult>, users: SearchPage<UserSearchResult> }
- 비로그인 허용 (isFollowing은 false), 로그인 시 SearchHistory 자동 저장

## 코드 리뷰 반영 (HIGH 1, MED 2, LOW 1)
- [HIGH] UserSearchCard isMountedRef cleanup 누락 — useEffect 없이 인라인 리셋만 있어 진짜 unmount를 감지하지 못하던 결함. setup/cleanup 명시한 useEffect로 교체하여 StrictMode 더블 인보크 + 진짜 unmount 모두 처리.
- [MED] UserSearchCard props 변경 시 stale state — useState(user.isFollowing) / useState(user.followerCount)가 마운트 시점에만 초기화되어 부모가 다시 내려보내는 prop 변화를 반영 못 하던 문제. user.userId/isFollowing/ followerCount deps의 동기화 useEffect 추가.
- [MED] fetchMoreBooks/fetchMoreUsers 진입부에 activeTab 가드 추가. observer disconnect와 별개의 안전망 — 비활성 탭 sentinel 콜백이 늦게 발화해도 fetch가 진행되지 않도록 차단.
- [LOW] URL 동기화 effect의 주석 정정. searchParams는 react-router-dom v6 에서 매 URL 변경마다 새 인스턴스이므로 "안정 ref"라는 기존 주석 부정확. "deps 포함 시 무한 루프 위험, 비교 가드(toString)로 차단" 의도 명시.

## 후속 (본 PR 외)
- 통합 검색 API와 기존 /api/v1/books/search 응답 필드 정합성 검토 후 도서 검색 일원화 가능성 (현재는 publisher/inMyLibrary 차이로 두 API 공존)
- 서버 측 SearchHistory 기반 최근 검색어 API 도입 시 localStorage와 통합 검토
- 검색 빈도 높아지면 react-query 등 캐시 도입
- [MED] commitKeyword의 setRecentKeywords 안에서 saveRecentKeywords 부수효과 를 호출하는 패턴을 effect로 분리 (React 18 배치/StrictMode 호환)
- [LOW] BookSearchItem.coverImageUrl 백엔드 nullable 명세 재확인 후 주석 보강
- [NIT] 전체 탭 도서/유저 카운트 표기 — 첫 페이지 기준이라 hasMore면 "20+" 로 표기 또는 카운트 자체 제거

검증:
- npx tsc --noEmit → 0건
- npx eslint → 0건
- npx vitest run → 20/20 통과 (회귀 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 통합 검색 기능 추가: 도서, 사용자, 전체 콘텐츠를 탭으로 검색할 수 있습니다.
  * 사용자 검색 결과 카드에 팔로우/언팔로우 기능 추가.
  * 도서 및 사용자 탭에 무한 스크롤 기능 추가.
  * 전체 탭에서 도서 및 사용자 프리뷰 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->