### PR TITLE
fix: 통합 검색 백엔드 결함에 대한 임시 회피 + 결함 보고 docs (#126)

### DIFF
--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -29,22 +29,33 @@ export function parseApiResponse<T>(response: ApiResponse<T>, fallback: string):
  * 취소 에러(CanceledError / AbortError)는 원본 그대로 rethrow하여
  * 호출자가 `axios.isCancel`로 분기할 수 있게 한다.
  *
- * **409 임시 회피** (`docs/통합_검색_백엔드_결함_보고.md` 참고):
+ * **409 임시 회피 (옵트인)** (`docs/통합_검색_백엔드_결함_보고.md` 참고):
  * 백엔드의 `GlobalExceptionHandler.handleDataIntegrityViolation`이 모든
  * `DataIntegrityViolationException`을 "이미 존재하는 데이터입니다." 메시지로
  * 일괄 응답하는 구조라, read 시나리오(예: 도서 검색)에서도 알라딘 응답 ISBN
- * 중복으로 인한 unique 위반이 사용자에게 그대로 노출된다. 백엔드 수정 전까지
- * 409 응답에 한해 도메인 무관한 일반 메시지로 변환. 백엔드가 도메인별
- * 메시지로 분기하거나 검색 흐름의 unique 위반 자체를 막으면 본 분기는 자연
- * 히 효과 없어진다 (정상 응답은 200이라 함수 자체가 안 호출됨).
+ * 중복으로 인한 unique 위반이 사용자에게 그대로 노출된다.
+ *
+ * 단, 다른 도메인(예: 서재 추가의 정상 conflict)은 409가 의미 있는 응답이라
+ * 전역 override가 부적절. `options.suppress409Message: true`로 호출하는
+ * 검색 도메인에서만 일반 메시지로 변환하고, 미지정 시 기존 분기(apiMessage
+ * 우선)로 fallthrough해 도메인 메시지를 보존한다.
  */
-export function normalizeAxiosError(error: unknown, fallback: string): Error {
+export interface NormalizeAxiosErrorOptions {
+  /** 409 응답을 도메인 무관 일반 메시지로 치환 (검색 도메인 전용 회피) */
+  suppress409Message?: boolean
+}
+
+export function normalizeAxiosError(
+  error: unknown,
+  fallback: string,
+  options?: NormalizeAxiosErrorOptions
+): Error {
   if (axios.isCancel(error) || (error instanceof DOMException && error.name === 'AbortError')) {
     throw error
   }
   if (axios.isAxiosError(error)) {
     const status = error.response?.status
-    if (status === 409) {
+    if (status === 409 && options?.suppress409Message) {
       return new Error('일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }
     const apiMessage = error.response?.data?.message

--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -28,12 +28,25 @@ export function parseApiResponse<T>(response: ApiResponse<T>, fallback: string):
  * Axios 에러를 한국어 메시지의 일반 Error로 정규화한다.
  * 취소 에러(CanceledError / AbortError)는 원본 그대로 rethrow하여
  * 호출자가 `axios.isCancel`로 분기할 수 있게 한다.
+ *
+ * **409 임시 회피** (`docs/통합_검색_백엔드_결함_보고.md` 참고):
+ * 백엔드의 `GlobalExceptionHandler.handleDataIntegrityViolation`이 모든
+ * `DataIntegrityViolationException`을 "이미 존재하는 데이터입니다." 메시지로
+ * 일괄 응답하는 구조라, read 시나리오(예: 도서 검색)에서도 알라딘 응답 ISBN
+ * 중복으로 인한 unique 위반이 사용자에게 그대로 노출된다. 백엔드 수정 전까지
+ * 409 응답에 한해 도메인 무관한 일반 메시지로 변환. 백엔드가 도메인별
+ * 메시지로 분기하거나 검색 흐름의 unique 위반 자체를 막으면 본 분기는 자연
+ * 히 효과 없어진다 (정상 응답은 200이라 함수 자체가 안 호출됨).
  */
 export function normalizeAxiosError(error: unknown, fallback: string): Error {
   if (axios.isCancel(error) || (error instanceof DOMException && error.name === 'AbortError')) {
     throw error
   }
   if (axios.isAxiosError(error)) {
+    const status = error.response?.status
+    if (status === 409) {
+      return new Error('일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
+    }
     const apiMessage = error.response?.data?.message
     if (apiMessage) return new Error(apiMessage)
     if (error.code === 'ECONNABORTED') {

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -66,7 +66,16 @@ export async function getBookByIsbn(isbn13: string, signal?: AbortSignal): Promi
     }
     return data.data
   } catch (error) {
-    throw normalizeAxiosError(error, 'ISBN으로 도서를 찾지 못했습니다. 잠시 후 다시 시도해주세요.')
+    // ISBN 조회는 백엔드 `findOrCreateBook`(알라딘 호출 + DB save)을 거치므로
+    // 검색과 동일하게 ISBN 중복 결함으로 409가 발생할 수 있어 도메인 무관
+    // 일반 메시지로 치환 (docs/통합_검색_백엔드_결함_보고.md 참고).
+    throw normalizeAxiosError(
+      error,
+      'ISBN으로 도서를 찾지 못했습니다. 잠시 후 다시 시도해주세요.',
+      {
+        suppress409Message: true,
+      }
+    )
   }
 }
 
@@ -93,6 +102,10 @@ export async function searchBooks(
     }
     return data.data
   } catch (error) {
-    throw normalizeAxiosError(error, '도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    // 도서 검색은 백엔드 알라딘 ISBN 중복 결함으로 409가 발생할 수 있어
+    // 도메인 무관 일반 메시지로 치환 (docs/통합_검색_백엔드_결함_보고.md 참고).
+    throw normalizeAxiosError(error, '도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요.', {
+      suppress409Message: true,
+    })
   }
 }

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -109,6 +109,10 @@ export async function searchAll({
     })
     return parseApiResponse(data, '검색 응답이 올바르지 않습니다.')
   } catch (error) {
-    throw normalizeAxiosError(error, '검색에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    // 통합 검색은 백엔드 알라딘 ISBN 중복 결함으로 409가 발생할 수 있어
+    // 도메인 무관 일반 메시지로 치환 (docs/통합_검색_백엔드_결함_보고.md 참고).
+    throw normalizeAxiosError(error, '검색에 실패했습니다. 잠시 후 다시 시도해주세요.', {
+      suppress409Message: true,
+    })
   }
 }


### PR DESCRIPTION
QA에서 두 가지 백엔드 결함이 발견되었으나 본 PR 범위는 프론트 통합 검색이라
백엔드 수정은 별도 후속 이슈로 분리. 본 커밋은 사용자 경험만 즉시 개선하는
임시 회피와 백엔드 담당자용 결함 보고 문서를 추가.

## 결함 진단 (백엔드)
1. 통합 검색의 도서 결과가 처음엔 비어있음 — SearchService.searchBooks는 DB LIKE 쿼리만 사용하지만 BookService.searchBooks는 알라딘 API + DB 캐싱이라 데이터 소스가 다름. 신규 키워드는 DB에 책이 없어 통합 검색 0건, 도서 탭 거쳐 알라딘 호출되어 DB INSERT된 후에야 통합 검색에서 보임.
2. "이미 존재하는 데이터입니다." 빨간 문구 — 알라딘 응답 자체에 동일 ISBN 중복이 있을 때 BookService.searchBooks의 saveAll이 unique 위반 발생, GlobalExceptionHandler가 일괄 409 + 해당 메시지로 응답.

## src/api/_helpers.ts (수정)
- normalizeAxiosError에 status === 409 분기 추가 — 백엔드 message 그대로 노출하지 않고 "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요." 로 변환. read 시나리오에서 도메인 무관한 unique 위반 메시지가 사용자에게 노출되는 UX 회귀 방지.
- 백엔드 수정(알라딘 응답 ISBN dedup) 후엔 200 응답이 되어 본 분기 자연스럽게 무효화 — 영구 손실 없음.

검증:
- npx tsc --noEmit → 0건
- npx eslint → 0건
- npx vitest run → 20/20 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 도서 검색 및 ISBN 조회 시 오류 처리 개선: 특정 서버 오류 상황에서 사용자에게 보다 친화적인 일반 오류 메시지("잠시 후 다시 시도해주세요")를 표시하도록 변경하여 서비스 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->