### PR TITLE
  fix: 세션 무효 사용자 자동 로그아웃 + 인증 흐름 토큰 미부착 (#130)

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -233,13 +233,16 @@ describe('apiClient response interceptor — 401 분기', () => {
   function makeAxiosError(
     url: string,
     status: number | undefined,
-    extraConfig: Partial<{ _retry: boolean }> = {}
+    extraConfig: Partial<{ _retry: boolean }> = {},
+    responseData: Record<string, unknown> = {}
   ): AxiosError {
     return {
       isAxiosError: true,
       config: { url, headers: {}, ...extraConfig },
       response:
-        status != null ? { status, data: {}, headers: {}, config: {}, statusText: '' } : undefined,
+        status != null
+          ? { status, data: responseData, headers: {}, config: {}, statusText: '' }
+          : undefined,
       message: 'mock',
       name: 'AxiosError',
       toJSON: () => ({}),
@@ -427,5 +430,161 @@ describe('apiClient response interceptor — 401 분기', () => {
     resolveInner!('cross-account-token')
     await expect(handlerPromise).rejects.toBe(error)
     expect(setAuthMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('isMemberNotFound', () => {
+  it('404 + "존재하지 않는 회원입니다." → true', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: { message: '존재하지 않는 회원입니다.' } },
+    }
+    expect(isMemberNotFound(error)).toBe(true)
+  })
+
+  it('404 + 다른 메시지 → false', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: { message: '존재하지 않는 도서입니다.' } },
+    }
+    expect(isMemberNotFound(error)).toBe(false)
+  })
+
+  it('404 + 메시지 없음 → false', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: {} },
+    }
+    expect(isMemberNotFound(error)).toBe(false)
+  })
+
+  it('401 + 회원 메시지 → false (status 불일치)', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 401, data: { message: '존재하지 않는 회원입니다.' } },
+    }
+    expect(isMemberNotFound(error)).toBe(false)
+  })
+
+  it('non-Axios 에러 → false', async () => {
+    const { isMemberNotFound } = await import('./client')
+    expect(isMemberNotFound(new Error('test'))).toBe(false)
+    expect(isMemberNotFound(null)).toBe(false)
+  })
+})
+
+describe('MEMBER_NOT_FOUND 인터셉터 — stale 세션 감지', () => {
+  async function getErrorHandler() {
+    const client = await import('./client')
+    return client.handleApiClientResponseError
+  }
+
+  function makeAxiosError(
+    url: string,
+    status: number | undefined,
+    extraConfig: Partial<{ _retry: boolean }> = {},
+    responseData: Record<string, unknown> = {}
+  ): AxiosError {
+    return {
+      isAxiosError: true,
+      config: { url, headers: {}, ...extraConfig },
+      response:
+        status != null
+          ? { status, data: responseData, headers: {}, config: {}, statusText: '' }
+          : undefined,
+      message: 'mock',
+      name: 'AxiosError',
+      toJSON: () => ({}),
+    } as unknown as AxiosError
+  }
+
+  it('404 + MEMBER_NOT_FOUND + refresh도 MEMBER_NOT_FOUND 실패 → logout', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockRejectedValueOnce(
+      Object.assign(new Error('refresh 404'), {
+        isAxiosError: true,
+        response: { status: 404, data: { message: '존재하지 않는 회원입니다.' } },
+      })
+    )
+
+    const error = makeAxiosError(
+      '/api/v1/feed/following',
+      404,
+      {},
+      {
+        message: '존재하지 않는 회원입니다.',
+      }
+    )
+    await expect(handler(error)).rejects.toBeDefined()
+    expect(clearAuthMock).toHaveBeenCalledOnce()
+    expect(locationStub.href).toBe('/login')
+  })
+
+  it('404 + MEMBER_NOT_FOUND + refresh 성공 → logout 안 함 (타 유저 404)', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    vi.spyOn(client.refreshClient, 'post').mockResolvedValueOnce({
+      data: {
+        status: 'SUCCESS',
+        code: 200,
+        data: { accessToken: 'fresh-token', accessTokenExpiresIn: 3600 },
+      },
+    } as never)
+
+    const error = makeAxiosError(
+      '/api/v1/members/999/reviews',
+      404,
+      {},
+      {
+        message: '존재하지 않는 회원입니다.',
+      }
+    )
+    // refresh 성공 후 재시도 → apiClient(originalRequest)가 실행되지만
+    // 네트워크 없으므로 catch. 중요한 건 logout이 안 되는 것.
+    await handler(error).catch(() => undefined)
+    expect(clearAuthMock).not.toHaveBeenCalled()
+    expect(locationStub.href).toBe('')
+  })
+
+  it('일반 404 (다른 메시지) → refresh 시도 안 함, 그대로 reject', async () => {
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    const refreshSpy = vi.spyOn(client.refreshClient, 'post')
+
+    const error = makeAxiosError(
+      '/api/v1/books/999',
+      404,
+      {},
+      {
+        message: '존재하지 않는 도서입니다.',
+      }
+    )
+    await expect(handler(error)).rejects.toBe(error)
+    expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it('404 + MEMBER_NOT_FOUND + 비로그인 → refresh 시도 안 함', async () => {
+    authState.isAuthenticated = false
+    authState.user = null
+    authState.accessToken = null
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+    const refreshSpy = vi.spyOn(client.refreshClient, 'post')
+
+    const error = makeAxiosError(
+      '/api/v1/feed/following',
+      404,
+      {},
+      {
+        message: '존재하지 않는 회원입니다.',
+      }
+    )
+    await expect(handler(error)).rejects.toBe(error)
+    expect(refreshSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -106,14 +106,27 @@ function logoutAndRedirect() {
  *
  * 매 요청마다 authStore의 최신 accessToken을 Authorization 헤더에 부착.
  * 토큰 갱신 직후 재시도되는 요청도 새 토큰을 자동으로 받음.
+ *
+ * 인증 흐름 자체의 호출(login/signup/oauth2 등)에는 토큰을 부착하지 않는다.
+ * stale 토큰이 헤더에 실리면 백엔드가 토큰 검증부터 수행해 401로 거부하는
+ * 문제가 발생한다 (예: Google 로그인 URL 요청 시 만료 토큰 → 401).
  */
 apiClient.interceptors.request.use(config => {
   const token = useAuthStore.getState().accessToken
-  if (token) {
+  if (token && !isAuthFlowUrl(config.url ?? '')) {
     config.headers.Authorization = `Bearer ${token}`
   }
   return config
 })
+
+/**
+ * 백엔드 MEMBER_NOT_FOUND 응답 메시지.
+ *
+ * `ErrorCode.MEMBER_NOT_FOUND(404, "M001", "존재하지 않는 회원입니다.")`이지만
+ * `GlobalExceptionHandler.handleBusinessException`이 message만 응답 body에 포함하므로
+ * 에러 코드("M001")가 아닌 메시지 문자열로 판별한다.
+ */
+const MEMBER_NOT_FOUND_MESSAGE = '존재하지 않는 회원입니다.'
 
 /**
  * Refresh를 시도하지 않을 인증 흐름 자체의 호출 경로.
@@ -141,9 +154,25 @@ function isAuthFlowUrl(url: string): boolean {
 }
 
 /**
- * Refresh 실패가 인증 자체 문제(refresh token 누락/만료)인지 판단.
+ * 응답이 MEMBER_NOT_FOUND(HTTP 404 + 특정 message)인지 판별.
+ *
+ * DB 초기화·회원 삭제 등으로 JWT의 사용자가 DB에 없을 때 백엔드의 거의 모든
+ * 인증 필요 API가 이 응답을 반환한다. 401(토큰 만료)과 달리 토큰 자체는 유효하므로
+ * 별도 감지가 필요하다.
+ */
+function isMemberNotFound(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false
+  const data = error.response?.data as { message?: string } | undefined
+  return error.response?.status === 404 && data?.message === MEMBER_NOT_FOUND_MESSAGE
+}
+
+/**
+ * Refresh 실패가 인증 자체 문제인지 판단.
  *
  * 백엔드 명세상 refresh API는 400(쿠키 누락) / 401(만료)만 인증 문제.
+ * 추가로 404 + MEMBER_NOT_FOUND는 JWT의 사용자 자체가 DB에 없는 경우로,
+ * refresh를 반복해도 복구 불가 — logout이 유일한 해결책.
+ *
  * 그 외(네트워크/timeout/5xx)는 일시적 장애일 가능성이 높아 강제 logout은 UX 회귀.
  * 따라서 이 함수가 true일 때만 logoutAndRedirect를 호출하고, 그 외엔 세션을
  * 보존한 채 원본 에러만 propagate.
@@ -151,7 +180,7 @@ function isAuthFlowUrl(url: string): boolean {
 function isAuthFailureRefreshError(error: unknown): boolean {
   if (!axios.isAxiosError(error)) return false
   const status = error.response?.status
-  return status === 400 || status === 401
+  return status === 400 || status === 401 || isMemberNotFound(error)
 }
 
 /**
@@ -160,7 +189,7 @@ function isAuthFailureRefreshError(error: unknown): boolean {
  * 인터셉터 등록 안에 anonymous로 두지 않고 export하여 단위 테스트가 axios 내부
  * (interceptors.response.handlers[0].rejected) 접근 없이 직접 호출 가능하도록 한다.
  *
- * 401 응답 흐름:
+ * 401 / MEMBER_NOT_FOUND 응답 흐름:
  * 1. 인증 흐름(login/signup/refresh 등) 호출이거나 이미 한 번 재시도한 요청이면 그대로 reject
  * 2. 비로그인 상태면 그대로 reject (이전 동작 유지 — 보호 라우트 진입 자체를 막지 않음)
  * 3. 그 외엔 _retry 플래그 부여 후 getRefreshPromise()로 새 토큰 획득 시도
@@ -168,8 +197,17 @@ function isAuthFailureRefreshError(error: unknown): boolean {
  *      (Authorization 헤더는 요청 인터셉터가 store의 최신 토큰을 자동 부착하므로 명시 부착 불필요)
  *    - 성공이지만 그 사이 logout/계정 전환 → 재시도하지 않고 원본 에러 reject (stale 토큰
  *      주입 방지)
- *    - refresh 실패가 400/401(인증 문제)이면 clearAuth + /login 리다이렉트
+ *    - refresh 실패가 400/401/MEMBER_NOT_FOUND(인증 문제)이면 clearAuth + /login 리다이렉트
  *    - refresh 실패가 그 외(네트워크/timeout/5xx)면 세션 유지하고 에러만 propagate
+ *
+ * MEMBER_NOT_FOUND(404 + "존재하지 않는 회원입니다.") 추가 배경:
+ * DB 초기화 등으로 JWT의 사용자가 DB에 없을 때, 토큰 자체는 유효해 Spring Security를
+ * 통과하지만 Service 레이어에서 Member 조회 실패 → 404. 이를 401처럼 refresh 경로로
+ * 진입시키면:
+ * - 현재 유저가 없는 경우: refresh도 MEMBER_NOT_FOUND → isAuthFailureRefreshError
+ *   → logoutAndRedirect (올바른 동작)
+ * - 타 유저 조회 404인 경우: refresh 성공(현재 유저는 존재) → 원래 요청 재시도
+ *   → 다시 404 → _retry 플래그로 인해 그대로 reject → 페이지 에러 표시 (올바른 동작)
  */
 async function handleApiClientResponseError(error: AxiosError) {
   const originalRequest = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined
@@ -178,12 +216,13 @@ async function handleApiClientResponseError(error: AxiosError) {
   const requestUrl: string = originalRequest.url ?? ''
   const status = error.response?.status
 
-  if (
-    status === 401 &&
+  const shouldAttemptRefresh =
+    (status === 401 || isMemberNotFound(error)) &&
     !isAuthFlowUrl(requestUrl) &&
     !originalRequest._retry &&
     useAuthStore.getState().isAuthenticated
-  ) {
+
+  if (shouldAttemptRefresh) {
     originalRequest._retry = true
     // refresh 직전의 user id를 스냅샷 — refresh 진행 중 logout/계정 전환 감지용
     const userBefore = useAuthStore.getState().user
@@ -221,5 +260,6 @@ export {
   performRefresh,
   getRefreshPromise,
   isAuthFlowUrl,
+  isMemberNotFound,
   handleApiClientResponseError,
 }


### PR DESCRIPTION
  두 가지 인증 관련 결함 수정.

  ## 결함 1 — DB 삭제 후 stale 세션이 로그아웃되지 않음
  DB 초기화(ddl-auto: create) 등으로 회원 레코드가 삭제된 상태에서 프론트에
  stale JWT가 남아있으면, ProtectedRoute를 통과해 홈피드까지 진입 후 "존재하지
  않는 회원입니다." 에러가 페이지에 그대로 노출. JWT 자체는 유효해 Spring
  Security를 통과하지만 Service 레이어에서 Member 조회 실패 → HTTP 404.
  기존 인터셉터는 401만 refresh → logout 흐름을 탔기 때문에 감지 불가.

  수정:
  - isMemberNotFound 판별 함수 추가 (404 + "존재하지 않는 회원입니다.")
  - handleApiClientResponseError: 401뿐 아니라 MEMBER_NOT_FOUND도 refresh 경로 진입. 현재 유저가 없으면 refresh도 실패 → logoutAndRedirect. 타 유저 조회 404는 refresh 성공 → 재시도 → 정상 에러 전파.
  - isAuthFailureRefreshError: MEMBER_NOT_FOUND도 인증 실패로 판단

  ## 결함 2 — 인증 흐름 요청에 stale 토큰 부착 → 401
  Google 로그인 버튼 클릭 시 GET /api/v1/auth/oauth2/google 요청에 만료된
  Bearer 토큰이 Authorization 헤더로 실려 백엔드가 401 거부. 요청 인터셉터가
  모든 요청에 토큰을 부착했기 때문.

  수정:
  - 요청 인터셉터에서 isAuthFlowUrl이면 토큰 부착 건너뜀

  ## 테스트 (client.test.ts)
  - isMemberNotFound: 5건 추가 (true/false 분기 전수 검증)
  - MEMBER_NOT_FOUND 인터셉터: 4건 추가 (refresh 실패→logout, refresh 성공→타유저 정상 에러, 일반 404 무시, 비로그인 무시)
  - makeAxiosError 헬퍼에 responseData 파라미터 추가

  검증:
  - npx tsc --noEmit → 0건
  - npx eslint → 0건
  - npx vitest run → 29/29 통과 (기존 20 + 신규 9)