### PR TITLE
  feat: 댓글 도메인 API 연동 — CRUD + 대댓글 + 좋아요 + 알림 라우팅 (#132)

### DIFF
--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,199 @@
+import apiClient from './client'
+import { type ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
+
+export interface CommentUser {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+}
+
+/**
+ * 대댓글(2단계) 항목. 부모 댓글 아래에 렌더된다.
+ *
+ * 소프트 삭제된 대댓글은 `isDeleted: true`, `user: null`,
+ * `content: "삭제된 댓글입니다"`로 내려온다. UI에서 그대로 표시.
+ */
+export interface ReplyItem {
+  commentId: number
+  user: CommentUser | null
+  content: string
+  parentCommentId: number
+  likeCount: number
+  isLiked: boolean
+  isDeleted: boolean
+  isMine: boolean
+  createdAt: string
+}
+
+/**
+ * 부모 댓글 항목. `replies` 배열로 대댓글을 포함한다.
+ *
+ * 백엔드는 2단계 트리만 지원 — 대댓글의 대댓글은 `NESTED_REPLY_NOT_ALLOWED`(400).
+ * 소프트 삭제된 부모 댓글도 대댓글이 있으면 목록에 남는다.
+ */
+export interface CommentItem {
+  commentId: number
+  user: CommentUser | null
+  content: string
+  parentCommentId: null
+  likeCount: number
+  isLiked: boolean
+  isDeleted: boolean
+  isMine: boolean
+  createdAt: string
+  replies: ReplyItem[]
+}
+
+export interface CommentListResponse {
+  content: CommentItem[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+export interface CommentCreateResponse {
+  commentId: number
+  reviewId: number
+  user: CommentUser
+  content: string
+  parentCommentId: number | null
+  likeCount: number
+  createdAt: string
+}
+
+export interface CommentUpdateResponse {
+  commentId: number
+  content: string
+  updatedAt: string
+}
+
+export interface CommentLikeResponse {
+  commentId: number
+  likeCount: number
+}
+
+/**
+ * 감상의 댓글 목록을 커서 기반으로 조회한다.
+ *
+ * 부모 댓글만 페이징 대상이고 각 부모의 대댓글은 `replies` 배열에 전부 포함.
+ * 삭제된 댓글도 `isDeleted: true`로 내려와 "삭제된 댓글입니다"로 렌더.
+ */
+export async function getComments(
+  reviewId: number,
+  cursor?: number | null,
+  limit = 20,
+  signal?: AbortSignal
+): Promise<CommentListResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<CommentListResponse>>(
+      `/api/v1/reviews/${reviewId}/comments`,
+      {
+        params: {
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+    return parseApiResponse(data, '댓글 목록 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '댓글을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 댓글 또는 대댓글을 작성한다.
+ *
+ * `parentCommentId`가 null이면 부모 댓글, 값이 있으면 해당 댓글의 대댓글.
+ * 대댓글의 대댓글 시도 시 백엔드가 400 `NESTED_REPLY_NOT_ALLOWED` 반환.
+ */
+export async function createComment(
+  reviewId: number,
+  content: string,
+  parentCommentId?: number | null
+): Promise<CommentCreateResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<CommentCreateResponse>>(
+      `/api/v1/reviews/${reviewId}/comments`,
+      {
+        content,
+        ...(parentCommentId != null ? { parentCommentId } : {}),
+      }
+    )
+    return parseApiResponse(data, '댓글 작성 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '댓글 작성에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 본인 댓글의 내용을 수정한다.
+ *
+ * 타인의 댓글이면 백엔드가 403 `NOT_COMMENT_OWNER` 반환.
+ */
+export async function updateComment(
+  reviewId: number,
+  commentId: number,
+  content: string
+): Promise<CommentUpdateResponse> {
+  try {
+    const { data } = await apiClient.put<ApiResponse<CommentUpdateResponse>>(
+      `/api/v1/reviews/${reviewId}/comments/${commentId}`,
+      { content }
+    )
+    return parseApiResponse(data, '댓글 수정 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '댓글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 본인 댓글을 소프트 삭제한다.
+ *
+ * 백엔드에서 `isDeleted=true` + `deletedAt` 세팅. 목록에서는 "삭제된 댓글입니다"로 표시.
+ */
+export async function deleteComment(reviewId: number, commentId: number): Promise<void> {
+  try {
+    await apiClient.delete<ApiResponse<void>>(`/api/v1/reviews/${reviewId}/comments/${commentId}`)
+  } catch (error) {
+    throw normalizeAxiosError(error, '댓글 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+/**
+ * 댓글에 좋아요를 누른다.
+ *
+ * 본인 댓글이면 400 `SELF_LIKE_NOT_ALLOWED`, 이미 좋아요 상태면 409 `ALREADY_COMMENT_LIKED`.
+ */
+export async function likeComment(
+  reviewId: number,
+  commentId: number
+): Promise<CommentLikeResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<CommentLikeResponse>>(
+      `/api/v1/reviews/${reviewId}/comments/${commentId}/likes`
+    )
+    return parseApiResponse(data, '댓글 좋아요 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '댓글 좋아요에 실패했습니다.')
+  }
+}
+
+/**
+ * 댓글 좋아요를 취소한다.
+ *
+ * 좋아요 기록이 없으면 404 `COMMENT_LIKE_NOT_FOUND`.
+ */
+export async function unlikeComment(
+  reviewId: number,
+  commentId: number
+): Promise<CommentLikeResponse> {
+  try {
+    const { data } = await apiClient.delete<ApiResponse<CommentLikeResponse>>(
+      `/api/v1/reviews/${reviewId}/comments/${commentId}/likes`
+    )
+    return parseApiResponse(data, '댓글 좋아요 취소 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '좋아요 취소에 실패했습니다.')
+  }
+}

--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -8,6 +8,9 @@ export interface CreateReviewRequest {
   rating: number
   quote?: string
   isSpoiler?: boolean
+  reviewVisibility: ReviewVisibility
+  reviewStatus: ReviewStatus
+  tags?: string[]
 }
 
 export type UpdateReviewRequest = Omit<CreateReviewRequest, 'bookId'>
@@ -55,7 +58,7 @@ export type ReviewVisibility = 'PUBLIC' | 'PRIVATE'
  * 백엔드 `ReviewStatus` enum과 1:1 매칭. 임시저장/발행 상태 구분.
  * `findUserReviews`는 PUBLISHED만, `findMyReviews`는 `status` 쿼리 파라미터로 선택적 필터링.
  */
-export type ReviewBackendStatus = 'DRAFT' | 'PUBLISHED'
+export type ReviewStatus = 'DRAFT' | 'PUBLISHED'
 
 /**
  * 감상 목록 응답의 단일 아이템 — 백엔드 `ReviewSummaryResponse`와 1:1 매칭.
@@ -77,7 +80,7 @@ export interface ReviewListItem {
   quote: string | null
   isSpoiler: boolean
   reviewVisibility: ReviewVisibility
-  reviewStatus: ReviewBackendStatus
+  reviewStatus: ReviewStatus
   likeCount: number
   commentCount: number
   isLiked: boolean
@@ -88,7 +91,7 @@ export interface ReviewListItem {
 export interface GetMyReviewsParams {
   cursor?: number | null
   limit?: number
-  status?: ReviewBackendStatus
+  status?: ReviewStatus
   signal?: AbortSignal
 }
 

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -1,0 +1,625 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import axios from 'axios'
+import { cn, formatRelativeTime } from '@/lib/utils'
+import {
+  getComments,
+  createComment,
+  updateComment,
+  deleteComment,
+  likeComment,
+  unlikeComment,
+  type CommentItem,
+  type ReplyItem,
+} from '@/api/comment'
+
+interface CommentSectionProps {
+  reviewId: number
+  /** 상단에 표시할 초기 댓글 수 (ReviewDetail.commentCount). 작성/삭제 시 내부에서 ±1. */
+  initialCommentCount: number
+  /** 댓글 수 변경 시 부모에 알림 (리액션 섹션의 카운트 동기화용). */
+  onCommentCountChange?: (count: number) => void
+}
+
+/**
+ * 감상 상세 하단의 댓글 영역. 목록 조회 + 무한 스크롤 + 작성 + 수정 + 삭제 + 좋아요를 한 곳에서 처리.
+ *
+ * ReviewDetailPage에서 `reviewId`와 `initialCommentCount`만 받아 독립적으로 동작한다.
+ * 댓글 상태(목록/커서/로딩)를 부모에 노출하지 않아 ReviewDetailPage의 복잡도를 올리지 않는다.
+ */
+export default function CommentSection({
+  reviewId,
+  initialCommentCount,
+  onCommentCountChange,
+}: CommentSectionProps) {
+  const [comments, setComments] = useState<CommentItem[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  const [commentCount, setCommentCount] = useState(initialCommentCount)
+
+  const [newComment, setNewComment] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const [replyTarget, setReplyTarget] = useState<{ commentId: number; nickname: string } | null>(
+    null
+  )
+  const [editTarget, setEditTarget] = useState<{
+    commentId: number
+    parentCommentId: number | null
+    content: string
+  } | null>(null)
+  const [editContent, setEditContent] = useState('')
+  const [isEditing, setIsEditing] = useState(false)
+
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+
+  const stateRef = useRef({ hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError })
+  stateRef.current = { hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError }
+
+  useEffect(() => {
+    onCommentCountChange?.(commentCount)
+  }, [commentCount, onCommentCountChange])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const response = await getComments(reviewId, null, 20, controller.signal)
+        if (controller.signal.aborted) return
+        setComments(response.content)
+        setNextCursor(response.nextCursor)
+        setHasNext(response.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '댓글을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+    }
+  }, [reviewId])
+
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext || !s.nextCursor) return
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await getComments(reviewId, s.nextCursor, 20, controller.signal)
+      if (controller.signal.aborted) return
+      setComments(prev => [...prev, ...response.content])
+      setNextCursor(response.nextCursor)
+      setHasNext(response.hasNext)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [reviewId])
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (!entries[0]?.isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  const handleSubmit = async () => {
+    const trimmed = newComment.trim()
+    if (!trimmed || isSubmitting) return
+
+    setIsSubmitting(true)
+    setSubmitError(null)
+    try {
+      const result = await createComment(reviewId, trimmed, replyTarget?.commentId ?? null)
+      const newReply: ReplyItem = {
+        commentId: result.commentId,
+        user: result.user,
+        content: result.content,
+        parentCommentId: replyTarget?.commentId ?? 0,
+        likeCount: 0,
+        isLiked: false,
+        isDeleted: false,
+        isMine: true,
+        createdAt: result.createdAt,
+      }
+
+      if (replyTarget) {
+        setComments(prev =>
+          prev.map(c =>
+            c.commentId === replyTarget.commentId ? { ...c, replies: [...c.replies, newReply] } : c
+          )
+        )
+      } else {
+        const newParent: CommentItem = {
+          commentId: result.commentId,
+          user: result.user,
+          content: result.content,
+          parentCommentId: null,
+          likeCount: 0,
+          isLiked: false,
+          isDeleted: false,
+          isMine: true,
+          createdAt: result.createdAt,
+          replies: [],
+        }
+        setComments(prev => [newParent, ...prev])
+      }
+      setCommentCount(prev => prev + 1)
+      setNewComment('')
+      setReplyTarget(null)
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : '댓글 작성에 실패했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleEdit = async () => {
+    if (!editTarget || isEditing) return
+    const trimmed = editContent.trim()
+    if (!trimmed) return
+
+    setIsEditing(true)
+    try {
+      const result = await updateComment(reviewId, editTarget.commentId, trimmed)
+      setComments(prev =>
+        prev.map(c => {
+          if (c.commentId === editTarget.commentId) {
+            return { ...c, content: result.content }
+          }
+          return {
+            ...c,
+            replies: c.replies.map(r =>
+              r.commentId === editTarget.commentId ? { ...r, content: result.content } : r
+            ),
+          }
+        })
+      )
+      setEditTarget(null)
+      setEditContent('')
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : '댓글 수정에 실패했습니다.')
+    } finally {
+      setIsEditing(false)
+    }
+  }
+
+  const handleDelete = async (commentId: number, parentCommentId: number | null) => {
+    if (deletingId != null) return
+    if (!window.confirm('댓글을 삭제하시겠습니까?')) return
+    setDeletingId(commentId)
+    try {
+      await deleteComment(reviewId, commentId)
+      if (parentCommentId != null) {
+        setComments(prev =>
+          prev.map(c =>
+            c.commentId === parentCommentId
+              ? {
+                  ...c,
+                  replies: c.replies.map(r =>
+                    r.commentId === commentId
+                      ? { ...r, isDeleted: true, content: '삭제된 댓글입니다.', user: null }
+                      : r
+                  ),
+                }
+              : c
+          )
+        )
+      } else {
+        setComments(prev =>
+          prev.map(c =>
+            c.commentId === commentId
+              ? { ...c, isDeleted: true, content: '삭제된 댓글입니다.', user: null }
+              : c
+          )
+        )
+      }
+      setCommentCount(prev => Math.max(0, prev - 1))
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : '댓글 삭제에 실패했습니다.')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const handleToggleLike = async (
+    commentId: number,
+    parentCommentId: number | null,
+    currentlyLiked: boolean,
+    currentLikeCount: number
+  ) => {
+    const updateLike = (liked: boolean, count: number) => {
+      setComments(prev =>
+        prev.map(c => {
+          if (c.commentId === commentId) {
+            return { ...c, isLiked: liked, likeCount: count }
+          }
+          return {
+            ...c,
+            replies: c.replies.map(r =>
+              r.commentId === commentId ? { ...r, isLiked: liked, likeCount: count } : r
+            ),
+          }
+        })
+      )
+    }
+
+    // 낙관적 업데이트
+    updateLike(!currentlyLiked, currentLikeCount + (currentlyLiked ? -1 : 1))
+
+    try {
+      const result = currentlyLiked
+        ? await unlikeComment(reviewId, commentId)
+        : await likeComment(reviewId, commentId)
+      updateLike(!currentlyLiked, result.likeCount)
+    } catch {
+      // 롤백
+      updateLike(currentlyLiked, currentLikeCount)
+    }
+  }
+
+  const startReply = (commentId: number, nickname: string) => {
+    setReplyTarget({ commentId, nickname })
+    setEditTarget(null)
+    setNewComment('')
+    setTimeout(() => inputRef.current?.focus(), 0)
+  }
+
+  const startEdit = (commentId: number, parentCommentId: number | null, content: string) => {
+    setEditTarget({ commentId, parentCommentId, content })
+    setEditContent(content)
+    setReplyTarget(null)
+    setNewComment('')
+  }
+
+  const cancelReply = () => {
+    setReplyTarget(null)
+    setNewComment('')
+  }
+
+  const cancelEdit = () => {
+    setEditTarget(null)
+    setEditContent('')
+  }
+
+  return (
+    <>
+      {/* 댓글 목록 */}
+      <section className="px-5 pb-6 pt-2">
+        <h3 className="mb-4 text-lg font-bold">댓글 {commentCount}개</h3>
+
+        {isLoading && (
+          <p
+            role="status"
+            aria-busy="true"
+            className="py-6 text-center text-sm text-muted-foreground"
+          >
+            불러오는 중...
+          </p>
+        )}
+
+        {!isLoading && errorMessage && (
+          <p role="alert" className="py-6 text-center text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        {!isLoading && !errorMessage && comments.length === 0 && (
+          <div className="rounded-xl bg-card px-4 py-8 text-center text-sm text-muted-foreground">
+            아직 댓글이 없습니다. 첫 댓글을 남겨보세요!
+          </div>
+        )}
+
+        {comments.length > 0 && (
+          <div className="space-y-1">
+            {comments.map(comment => (
+              <div key={comment.commentId}>
+                <CommentRow
+                  comment={comment}
+                  parentCommentId={null}
+                  deletingId={deletingId}
+                  onReply={startReply}
+                  onEdit={startEdit}
+                  onDelete={handleDelete}
+                  onToggleLike={handleToggleLike}
+                />
+                {comment.replies.length > 0 && (
+                  <div className="ml-10 border-l-2 border-primary/10 pl-3">
+                    {comment.replies.map(reply => (
+                      <CommentRow
+                        key={reply.commentId}
+                        comment={reply}
+                        parentCommentId={comment.commentId}
+                        deletingId={deletingId}
+                        onEdit={startEdit}
+                        onDelete={handleDelete}
+                        onToggleLike={handleToggleLike}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasNext && <div ref={sentinelRef} className="h-10" aria-hidden="true" />}
+
+        {isLoadingMore && (
+          <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+        )}
+
+        {loadMoreError && !isLoadingMore && (
+          <div className="flex flex-col items-center gap-2 py-4">
+            <p role="alert" className="text-sm text-destructive">
+              {loadMoreError}
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setLoadMoreError(null)
+                fetchMore()
+              }}
+              className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+            >
+              다시 불러오기
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* 수정 모드 인라인 에디터 */}
+      {editTarget && (
+        <section className="border-t border-border px-5 py-3">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">댓글 수정 중</span>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              취소
+            </button>
+          </div>
+          <div className="flex items-center gap-3 rounded-full border border-primary/20 bg-card px-4 py-3">
+            <input
+              type="text"
+              value={editContent}
+              onChange={e => setEditContent(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleEdit()
+              }}
+              disabled={isEditing}
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/50 disabled:opacity-60"
+              placeholder="댓글을 수정하세요"
+            />
+            <button
+              type="button"
+              onClick={handleEdit}
+              disabled={isEditing || !editContent.trim()}
+              className="text-sm font-bold text-primary disabled:opacity-40"
+            >
+              {isEditing ? '수정 중...' : '수정'}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* 댓글 입력 */}
+      {!editTarget && (
+        <section className="border-t border-border px-5 py-3">
+          {replyTarget && (
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">
+                <span className="font-bold">{replyTarget.nickname}</span>님에게 답글
+              </span>
+              <button
+                type="button"
+                onClick={cancelReply}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                취소
+              </button>
+            </div>
+          )}
+          <div className="flex items-center gap-3 rounded-full border border-primary/10 bg-card px-4 py-3">
+            <input
+              ref={inputRef}
+              type="text"
+              value={newComment}
+              onChange={e => setNewComment(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleSubmit()
+              }}
+              disabled={isSubmitting}
+              placeholder={replyTarget ? '답글을 입력하세요' : '댓글을 입력하세요'}
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/50 disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting || !newComment.trim()}
+              className="text-sm font-bold text-primary disabled:opacity-40"
+            >
+              {isSubmitting ? '게시 중...' : '게시'}
+            </button>
+          </div>
+          {submitError && (
+            <p role="alert" className="mt-2 text-xs text-destructive">
+              {submitError}
+            </p>
+          )}
+        </section>
+      )}
+    </>
+  )
+}
+
+/**
+ * 댓글 한 줄. 부모/대댓글 공용. 삭제된 댓글은 user=null로 표시.
+ */
+function CommentRow({
+  comment,
+  parentCommentId,
+  deletingId,
+  onReply,
+  onEdit,
+  onDelete,
+  onToggleLike,
+}: {
+  comment: CommentItem | ReplyItem
+  parentCommentId: number | null
+  deletingId: number | null
+  onReply?: (commentId: number, nickname: string) => void
+  onEdit: (commentId: number, parentCommentId: number | null, content: string) => void
+  onDelete: (commentId: number, parentCommentId: number | null) => void
+  onToggleLike: (
+    commentId: number,
+    parentCommentId: number | null,
+    isLiked: boolean,
+    likeCount: number
+  ) => void
+}) {
+  if (comment.isDeleted) {
+    return <div className="py-3 text-sm text-muted-foreground/50 italic">삭제된 댓글입니다.</div>
+  }
+
+  const isBeingDeleted = deletingId === comment.commentId
+
+  return (
+    <div className={cn('py-3', isBeingDeleted && 'opacity-50')}>
+      <div className="flex items-start gap-3">
+        {/* 아바타 */}
+        <div className="size-8 shrink-0 overflow-hidden rounded-full bg-primary/10">
+          {comment.user?.profileImageUrl ? (
+            <img
+              src={comment.user.profileImageUrl}
+              alt={comment.user.nickname}
+              className="size-full object-cover"
+            />
+          ) : (
+            <div className="flex size-full items-center justify-center">
+              <span className="material-symbols-outlined text-[16px] text-primary/40">person</span>
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          {/* 닉네임 + 시간 */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-bold">{comment.user?.nickname ?? '알 수 없음'}</span>
+            <span className="text-xs text-muted-foreground">
+              {formatRelativeTime(comment.createdAt)}
+            </span>
+          </div>
+
+          {/* 본문 */}
+          <p className="mt-1 text-sm leading-relaxed text-foreground/90">{comment.content}</p>
+
+          {/* 액션 버튼 */}
+          <div className="mt-1.5 flex items-center gap-4 text-xs text-muted-foreground">
+            {/* 좋아요 */}
+            {!comment.isMine && (
+              <button
+                type="button"
+                onClick={() =>
+                  onToggleLike(
+                    comment.commentId,
+                    parentCommentId,
+                    comment.isLiked,
+                    comment.likeCount
+                  )
+                }
+                className={cn(
+                  'flex items-center gap-1 transition-colors',
+                  comment.isLiked ? 'text-red-500' : 'hover:text-foreground'
+                )}
+              >
+                <span
+                  className="material-symbols-outlined text-[14px]"
+                  style={{ fontVariationSettings: `'FILL' ${comment.isLiked ? 1 : 0}` }}
+                >
+                  favorite
+                </span>
+                {comment.likeCount > 0 && <span>{comment.likeCount}</span>}
+              </button>
+            )}
+            {comment.isMine && comment.likeCount > 0 && (
+              <span className="flex items-center gap-1">
+                <span className="material-symbols-outlined text-[14px]">favorite</span>
+                {comment.likeCount}
+              </span>
+            )}
+
+            {/* 답글 — 부모 댓글에만 (대댓글에는 미노출) */}
+            {onReply && comment.user && (
+              <button
+                type="button"
+                onClick={() => onReply(comment.commentId, comment.user?.nickname ?? '')}
+                className="hover:text-foreground"
+              >
+                답글
+              </button>
+            )}
+
+            {/* 수정/삭제 — 본인 댓글만 */}
+            {comment.isMine && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => onEdit(comment.commentId, parentCommentId, comment.content)}
+                  className="hover:text-foreground"
+                >
+                  수정
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(comment.commentId, parentCommentId)}
+                  disabled={isBeingDeleted}
+                  className="hover:text-destructive disabled:opacity-50"
+                >
+                  삭제
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -259,7 +259,7 @@ export default function CommentSection({
 
   const handleToggleLike = async (
     commentId: number,
-    parentCommentId: number | null,
+    _parentCommentId: number | null,
     currentlyLiked: boolean,
     currentLikeCount: number
   ) => {

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -72,6 +72,10 @@ export default function CommentSection({
     const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
+    setComments([])
+    setNextCursor(null)
+    setHasNext(false)
+    setCommentCount(initialCommentCount)
     ;(async () => {
       try {
         const response = await getComments(reviewId, null, 20, controller.signal)
@@ -90,7 +94,7 @@ export default function CommentSection({
       controller.abort()
       moreControllerRef.current?.abort()
     }
-  }, [reviewId])
+  }, [reviewId, initialCommentCount])
 
   const fetchMore = useCallback(async () => {
     const s = stateRef.current

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -59,9 +59,10 @@ function buildNotificationMessage(n: NotificationItem): string {
 function resolveDestination(n: NotificationItem): string | null {
   switch (n.type) {
     case 'REVIEW_LIKE':
+      return n.reviewId != null ? `/review/${n.reviewId}` : null
     case 'COMMENT':
     case 'COMMENT_LIKE':
-      return n.reviewId != null ? `/review/${n.reviewId}` : null
+      return n.reviewId != null ? `/review/${n.reviewId}#comments` : null
     case 'FOLLOW':
       return n.actor ? `/user/${n.actor.userId}` : null
     case 'SYSTEM':

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { deleteReview, getReviewDetail, type ReviewDetail } from '@/api/review'
 import { backendToFrontStatus } from '@/api/library'
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import CommentSection from '@/components/comment/CommentSection'
 import { useAuthStore } from '@/store/authStore'
 import type { ReadingStatus } from '@/types'
 
@@ -26,11 +27,14 @@ const readingStatusLabel: Record<ReadingStatus, string> = {
 export default function ReviewDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const currentUserId = useAuthStore(state => state.user?.id)
+  const commentSectionRef = useRef<HTMLDivElement>(null)
   const reviewId = Number(id)
   const [review, setReview] = useState<ReviewDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [displayCommentCount, setDisplayCommentCount] = useState<number | null>(null)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null)
@@ -63,6 +67,17 @@ export default function ReviewDetailPage() {
 
     return () => controller.abort()
   }, [reviewId])
+
+  // 알림에서 #comments 해시로 진입 시 댓글 섹션으로 스크롤.
+  // CommentSection의 첫 렌더가 완료된 뒤 스크롤해야 하므로 짧은 지연 사용.
+  useEffect(() => {
+    if (review && location.hash === '#comments' && commentSectionRef.current) {
+      const timer = setTimeout(() => {
+        commentSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
+      }, 350)
+      return () => clearTimeout(timer)
+    }
+  }, [location.hash, review])
 
   if (isLoading) {
     return (
@@ -131,6 +146,7 @@ export default function ReviewDetailPage() {
       : '감상 중에서'
   const coverImageUrl = review.book.coverImageUrl
   const isMyReview = currentUserId != null && review.user.userId === currentUserId
+  const reviewHeading = isMyReview ? '나의 감상' : `${review.user.nickname}의 감상`
 
   const handleDeleteReview = async () => {
     setIsDeleting(true)
@@ -218,7 +234,7 @@ export default function ReviewDetailPage() {
 
         {/* Review Content */}
         <section className="px-5 py-3">
-          <h2 className="mb-4 text-2xl font-bold">나의 감상</h2>
+          <h2 className="mb-4 text-2xl font-bold">{reviewHeading}</h2>
           <div className="space-y-5 text-lg leading-8 text-foreground/90">
             {review.content.split('\n\n').map((paragraph, index) => (
               <p key={index}>{paragraph}</p>
@@ -281,7 +297,7 @@ export default function ReviewDetailPage() {
 
               <div className="flex items-center gap-1.5">
                 <span className="material-symbols-outlined text-[20px]">chat_bubble</span>
-                <span>{review.commentCount}</span>
+                <span>{displayCommentCount ?? review.commentCount}</span>
               </div>
             </div>
 
@@ -296,36 +312,13 @@ export default function ReviewDetailPage() {
           </div>
         </section>
 
-        {/* Comments
-            [MED-4 fix] 이전엔 commentTemplates ("독자 1: 문장 해석이 인상적이네요…")로 가짜 댓글을
-            진짜처럼 렌더해 사용자가 실제 댓글로 오해할 수 있었다. 댓글 API가 본 PR 범위 밖이므로
-            placeholder("댓글 기능은 곧 제공될 예정입니다.")로 교체하여 명시적 "준비 중" 상태를
-            표시. 댓글 API 연동은 후속 이슈에서 처리. */}
-        <section className="px-5 pb-6 pt-2">
-          <h3 className="mb-4 text-lg font-bold">댓글 {review.commentCount}개</h3>
-          <div className="rounded-xl bg-card px-4 py-5 text-center text-sm text-muted-foreground">
-            댓글 기능은 곧 제공될 예정입니다.
-          </div>
-        </section>
-
-        {/* Comment Input — [MED-4 fix] 위와 동일 사유로 입력창/게시 버튼 모두 disabled 처리 */}
-        <section className="border-t border-border px-5 py-4">
-          <div className="flex items-center gap-3 rounded-full border border-primary/10 bg-card px-4 py-3 opacity-60">
-            <input
-              type="text"
-              disabled
-              placeholder="댓글 기능 준비 중"
-              className="min-w-0 flex-1 cursor-not-allowed bg-transparent text-sm outline-none placeholder:text-muted-foreground/50"
-            />
-            <button
-              type="button"
-              disabled
-              className="cursor-not-allowed text-sm font-bold text-primary/40"
-            >
-              게시
-            </button>
-          </div>
-        </section>
+        <div ref={commentSectionRef}>
+          <CommentSection
+            reviewId={review.reviewId}
+            initialCommentCount={review.commentCount}
+            onCommentCountChange={setDisplayCommentCount}
+          />
+        </div>
       </main>
 
       <Dialog

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -144,6 +144,8 @@ export default function WriteReviewPage() {
         rating,
         // [HIGH-1 fix] 사용자가 토글로 명시적으로 표시한 값을 그대로 전송 (이전엔 false 고정)
         isSpoiler,
+        reviewVisibility: 'PUBLIC' as const,
+        reviewStatus: 'PUBLISHED' as const,
       }
 
       if (isEditMode) {


### PR DESCRIPTION
  감상 상세 페이지(ReviewDetailPage)의 댓글 placeholder를 실제 댓글 기능으로
  교체. 댓글 작성/수정/삭제, 2단계 대댓글, 좋아요 토글, 무한 스크롤을 구현하고,
  알림 클릭 시 댓글 섹션으로 스크롤되도록 연동.

  ## src/api/comment.ts (신규)
  - 6개 API 함수: getComments, createComment, updateComment, deleteComment, likeComment, unlikeComment
  - 전체 타입: CommentItem, ReplyItem, CommentListResponse 등
  - parseApiResponse + normalizeAxiosError 헬퍼 사용

  ## src/components/comment/CommentSection.tsx (신규)
  - 커서 기반 무한 스크롤 (NotificationsPage 패턴 재사용)
  - 댓글 작성: Enter 키 지원, IME 조합 중 중복 전송 방지
  - 2단계 대댓글: 부모 댓글에만 "답글" 버튼, 대댓글에는 미노출
  - 댓글 수정: 인라인 에디터, 댓글 삭제: window.confirm 확인 후 소프트 삭제
  - 좋아요 낙관적 업데이트 + 롤백 (본인 댓글은 좋아요 버튼 미노출)
  - onCommentCountChange 콜백으로 부모 리액션 카운트 동기화

  ## src/pages/ReviewDetailPage.tsx (수정)
  - placeholder 댓글 섹션 제거, CommentSection 컴포넌트로 교체
  - "나의 감상" → 본인이면 "나의 감상", 타인이면 "{닉네임}의 감상"
  - #comments 해시 감지 시 댓글 섹션으로 스무스 스크롤
  - 리액션 섹션 댓글 카운트를 CommentSection과 동기화

  ## src/pages/NotificationsPage.tsx (수정)
  - COMMENT/COMMENT_LIKE 알림 클릭 시 /review/{id}#comments로 이동 (REVIEW_LIKE는 기존대로 #comments 없이 이동)

  ## src/api/review.ts (수정)
  - CreateReviewRequest에 reviewVisibility, reviewStatus, tags 필드 추가 (백엔드 @NotNull 검증 실패 수정)
  - ReviewVisibility 중복 타입 제거, ReviewBackendStatus를 ReviewStatus로 통일

  ## src/pages/WriteReviewPage.tsx (수정)
  - basePayload에 reviewVisibility: 'PUBLIC', reviewStatus: 'PUBLISHED' 기본값 추가

  검증:
  - npx tsc --noEmit → 0건
  - npx eslint → 0건
  - npx vitest run → 29/29 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 기능 추가: 댓글 작성, 수정, 삭제, 좋아요 기능 구현
  * 댓글 무한 스크롤 페이지네이션으로 더 많은 댓글 조회 가능
  * 리뷰 상세 페이지에 실시간 댓글 섹션 통합
  * 댓글 관련 알림 네비게이션 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->