### PR TITLE
feat: 감상 좋아요 API 연동 — 낙관적 토글 + 본인 감상 분기 (#134)

### DIFF
--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -240,3 +240,41 @@ export async function deleteReview(reviewId: number): Promise<void> {
     throw normalizeAxiosError(error, '감상을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }
+
+export interface ReviewLikeResponse {
+  reviewId: number
+  likeCount: number
+}
+
+/**
+ * 감상에 좋아요를 누른다.
+ *
+ * 본인 감상이면 400 `SELF_LIKE_NOT_ALLOWED`, 이미 좋아요면 409 `ALREADY_REVIEW_LIKED`.
+ * UI에서 본인 감상 좋아요 버튼을 미노출해 사전 차단하지만 백엔드도 방어.
+ */
+export async function likeReview(reviewId: number): Promise<ReviewLikeResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<ReviewLikeResponse>>(
+      `/api/v1/reviews/${reviewId}/likes`
+    )
+    return parseApiResponse(data, '좋아요 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '좋아요에 실패했습니다.')
+  }
+}
+
+/**
+ * 감상 좋아요를 취소한다.
+ *
+ * 좋아요 기록이 없으면 404 `REVIEW_LIKE_NOT_FOUND`.
+ */
+export async function unlikeReview(reviewId: number): Promise<ReviewLikeResponse> {
+  try {
+    const { data } = await apiClient.delete<ApiResponse<ReviewLikeResponse>>(
+      `/api/v1/reviews/${reviewId}/likes`
+    )
+    return parseApiResponse(data, '좋아요 취소 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '좋아요 취소에 실패했습니다.')
+  }
+}

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { likeReview, unlikeReview } from '@/api/review'
 import { cn, formatRelativeTime } from '@/lib/utils'
+import { useAuthStore } from '@/store/authStore'
 import type { Memo } from '@/types'
 import StarRating from './StarRating'
 
@@ -17,14 +19,50 @@ const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }
 }
 
 export default function ReviewCard({ review, className }: ReviewCardProps) {
+  const currentUserId = useAuthStore(state => state.user?.id)
+  const isMyReview = currentUserId != null && review.author.id === currentUserId
+
   const [spoilerRevealed, setSpoilerRevealed] = useState(false)
   const [liked, setLiked] = useState(review.isLiked)
   const [likeCount, setLikeCount] = useState(review.likeCount)
+  const [isLiking, setIsLiking] = useState(false)
   const status = review.readingStatus ? statusLabel[review.readingStatus] : null
 
-  const toggleLike = () => {
-    setLiked(prev => !prev)
-    setLikeCount(prev => (liked ? prev - 1 : prev + 1))
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    setLiked(review.isLiked)
+    setLikeCount(review.likeCount)
+  }, [review.id, review.isLiked, review.likeCount])
+
+  /**
+   * 낙관적 토글 + 롤백. 즉시 UI 반영 후 API 호출, 실패 시 원래 값으로 복원.
+   * `isLiking` 가드로 연타 방지, `isMountedRef`로 언마운트 후 setState 방지.
+   */
+  const toggleLike = async () => {
+    if (isLiking) return
+    const wasLiked = liked
+    const prevCount = likeCount
+    setLiked(!wasLiked)
+    setLikeCount(prevCount + (wasLiked ? -1 : 1))
+    setIsLiking(true)
+    try {
+      const result = wasLiked ? await unlikeReview(review.id) : await likeReview(review.id)
+      if (!isMountedRef.current) return
+      setLikeCount(result.likeCount)
+    } catch {
+      if (!isMountedRef.current) return
+      setLiked(wasLiked)
+      setLikeCount(prevCount)
+    } finally {
+      if (isMountedRef.current) setIsLiking(false)
+    }
   }
 
   const cardClassName = cn(
@@ -121,21 +159,29 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
 
       {/* Actions */}
       <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
-        <button
-          onClick={e => {
-            e.preventDefault()
-            toggleLike()
-          }}
-          className={cn(
-            'flex items-center gap-1.5 transition-colors hover:text-primary',
-            liked && 'text-primary'
-          )}
-        >
-          <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
-            favorite
-          </span>
-          <span className="text-xs font-bold">{likeCount}</span>
-        </button>
+        {!isMyReview ? (
+          <button
+            onClick={e => {
+              e.preventDefault()
+              toggleLike()
+            }}
+            disabled={isLiking}
+            className={cn(
+              'flex items-center gap-1.5 transition-colors disabled:opacity-60',
+              liked ? 'text-primary' : 'hover:text-primary'
+            )}
+          >
+            <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
+              favorite
+            </span>
+            <span className="text-xs font-bold">{likeCount}</span>
+          </button>
+        ) : likeCount > 0 ? (
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <span className="material-symbols-outlined text-xl">favorite</span>
+            <span className="text-xs font-bold">{likeCount}</span>
+          </div>
+        ) : null}
         <button
           onClick={e => e.preventDefault()}
           className="flex items-center gap-1.5 transition-colors hover:text-primary"

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -166,6 +166,7 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
               toggleLike()
             }}
             disabled={isLiking}
+            aria-label={liked ? '좋아요 취소' : '좋아요'}
             className={cn(
               'flex items-center gap-1.5 transition-colors disabled:opacity-60',
               liked ? 'text-primary' : 'hover:text-primary'

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
-import { deleteReview, getReviewDetail, type ReviewDetail } from '@/api/review'
+import { cn } from '@/lib/utils'
+import {
+  deleteReview,
+  getReviewDetail,
+  likeReview,
+  unlikeReview,
+  type ReviewDetail,
+} from '@/api/review'
 import { backendToFrontStatus } from '@/api/library'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
@@ -35,6 +42,9 @@ export default function ReviewDetailPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [displayCommentCount, setDisplayCommentCount] = useState<number | null>(null)
+  const [liked, setLiked] = useState(false)
+  const [likeCount, setLikeCount] = useState(0)
+  const [isLiking, setIsLiking] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null)
@@ -53,6 +63,8 @@ export default function ReviewDetailPage() {
       try {
         const result = await getReviewDetail(reviewId, controller.signal)
         setReview(result)
+        setLiked(result.isLiked)
+        setLikeCount(result.likeCount)
       } catch (error) {
         // [MED-1 fix] try 블록 내 controller.signal.aborted 가드는 사실상 도달 불가
         // (요청이 abort되면 axios가 throw로 빠짐) + _helpers.ts의 normalizeAxiosError가
@@ -147,6 +159,26 @@ export default function ReviewDetailPage() {
   const coverImageUrl = review.book.coverImageUrl
   const isMyReview = currentUserId != null && review.user.userId === currentUserId
   const reviewHeading = isMyReview ? '나의 감상' : `${review.user.nickname}의 감상`
+
+  const handleToggleLike = async () => {
+    if (isLiking) return
+    const wasLiked = liked
+    const prevCount = likeCount
+    setLiked(!wasLiked)
+    setLikeCount(prevCount + (wasLiked ? -1 : 1))
+    setIsLiking(true)
+    try {
+      const result = wasLiked
+        ? await unlikeReview(review.reviewId)
+        : await likeReview(review.reviewId)
+      setLikeCount(result.likeCount)
+    } catch {
+      setLiked(wasLiked)
+      setLikeCount(prevCount)
+    } finally {
+      setIsLiking(false)
+    }
+  }
 
   const handleDeleteReview = async () => {
     setIsDeleting(true)
@@ -280,20 +312,32 @@ export default function ReviewDetailPage() {
         <section className="mt-4 border-t border-border px-5 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-5 text-sm font-semibold text-muted-foreground">
-              <button
-                type="button"
-                disabled
-                aria-label="좋아요 (준비 중)"
-                className="flex items-center gap-1.5 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <span
-                  className="material-symbols-outlined text-[20px]"
-                  style={{ fontVariationSettings: `'FILL' ${review.isLiked ? 1 : 0}` }}
+              {!isMyReview && (
+                <button
+                  type="button"
+                  onClick={handleToggleLike}
+                  disabled={isLiking}
+                  aria-label={liked ? '좋아요 취소' : '좋아요'}
+                  className={cn(
+                    'flex items-center gap-1.5 transition-colors disabled:opacity-60',
+                    liked ? 'text-primary' : 'hover:text-primary'
+                  )}
                 >
-                  favorite
-                </span>
-                <span>{review.likeCount}</span>
-              </button>
+                  <span
+                    className="material-symbols-outlined text-[20px]"
+                    style={{ fontVariationSettings: `'FILL' ${liked ? 1 : 0}` }}
+                  >
+                    favorite
+                  </span>
+                  <span>{likeCount}</span>
+                </button>
+              )}
+              {isMyReview && likeCount > 0 && (
+                <div className="flex items-center gap-1.5 text-sm font-semibold text-muted-foreground">
+                  <span className="material-symbols-outlined text-[20px]">favorite</span>
+                  <span>{likeCount}</span>
+                </div>
+              )}
 
               <div className="flex items-center gap-1.5">
                 <span className="material-symbols-outlined text-[20px]">chat_bubble</span>


### PR DESCRIPTION
  감상 상세 페이지와 홈 피드의 좋아요 버튼을 백엔드 API와 연동.
  기존에 상세 페이지는 disabled 상태였고, 피드의 ReviewCard는 로컬
  state만 토글하여 새로고침 시 초기화되는 문제가 있었음.

  ## src/api/review.ts (수정)
  - likeReview(reviewId), unlikeReview(reviewId) 함수 추가
  - ReviewLikeResponse 타입 추가 ({ reviewId, likeCount })
  - parseApiResponse + normalizeAxiosError 패턴 사용

  ## src/pages/ReviewDetailPage.tsx (수정)
  - disabled 좋아요 버튼 → 낙관적 토글로 활성화
  - 본인 감상이면 좋아요 버튼 미노출, 카운트만 표시
  - isLiking 가드로 연타 방지
  - review 로드 시 liked/likeCount 초기화

  ## src/components/common/ReviewCard.tsx (수정)
  - 로컬 전용 toggleLike → API 호출 + 낙관적 업데이트 + 롤백
  - isMountedRef 언마운트 가드 추가 (리스트 컨텍스트에서 탭 전환 시
    언마운트 후 setState 방지)
  - prop 변경 시 liked/likeCount 동기화 useEffect 추가
  - 본인 감상 좋아요 버튼 미노출
  - 좋아요 색상 text-primary로 디자인 시스템 통일

  검증:
  - npx tsc -b → 0건
  - npx eslint → 0건
  - npx vitest run → 29/29 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **리뷰 좋아요 기능 추가** - 다른 사용자의 리뷰에 좋아요를 표시하고 취소할 수 있습니다
* **최적화된 상호작용** - 빠른 반응 속도와 함께 오류 발생 시 자동 복구 기능 포함
* **개선된 리뷰 표시** - 본인이 작성한 리뷰와 다른 사용자의 리뷰에 대해 서로 다른 좋아요 인터페이스 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->