### PR TITLE
fix: QA 4건 — BookSearchPage 무한루프/중복 + 홈피드 댓글 이동 + 인용구 fallback 제거 (#136)

### DIFF
--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { likeReview, unlikeReview } from '@/api/review'
 import { cn, formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
@@ -19,6 +19,7 @@ const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }
 }
 
 export default function ReviewCard({ review, className }: ReviewCardProps) {
+  const navigate = useNavigate()
   const currentUserId = useAuthStore(state => state.user?.id)
   const isMyReview = currentUserId != null && review.author.id === currentUserId
 
@@ -184,7 +185,10 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
           </div>
         ) : null}
         <button
-          onClick={e => e.preventDefault()}
+          onClick={e => {
+            e.preventDefault()
+            navigate(`/review/${review.id}#comments`)
+          }}
           className="flex items-center gap-1.5 transition-colors hover:text-primary"
         >
           <span className="material-symbols-outlined text-xl">chat_bubble</span>

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -188,6 +188,9 @@ export default function BookSearchPage() {
   // 바뀌는 경우(브라우저 뒤로/앞으로, deep link 직접 진입, 다른 컴포넌트의 navigate)
   // 본 effect가 그 변경을 컴포넌트에 반영. 같은 값일 때는 setState가 no-op이라
   // 양방향 effect 사이의 무한 루프는 발생하지 않는다.
+  // URL → state 동기화. searchParams 객체는 매 렌더마다 새 인스턴스라
+  // deps에 넣으면 무한 루프가 발생. toString()으로 값 기반 비교.
+  const searchParamsString = searchParams.toString()
   useEffect(() => {
     const urlQuery = searchParams.get('q') ?? ''
     const urlTabRaw = searchParams.get('tab')
@@ -197,7 +200,7 @@ export default function BookSearchPage() {
     // searchQuery/activeTab은 의도적으로 deps에서 제외 — 이 effect는 URL이
     // 바뀔 때만 동기화하면 충분하고, state가 deps에 들어가면 루프 위험.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams])
+  }, [searchParamsString])
 
   // URL 쿼리 동기화 — 탭/검색어 변경 시 ?tab=...&q=... 업데이트
   useEffect(() => {
@@ -417,9 +420,17 @@ export default function BookSearchPage() {
       const response = await searchBooks(requestedQuery, 20, requestedCursor, controller.signal)
       if (controller.signal.aborted) return
       if (stateRef.current.trimmedQuery !== requestedQuery) return
-      setBookResults(prev => [...prev, ...response.content])
-      setBookNextCursor(response.nextCursor)
-      setBookHasNext(response.hasNext)
+      setBookResults(prev => {
+        const existingIds = new Set(prev.map(b => b.bookId))
+        const deduped = response.content.filter(b => !existingIds.has(b.bookId))
+        if (deduped.length === 0) {
+          setBookHasNext(false)
+          return prev
+        }
+        setBookNextCursor(response.nextCursor)
+        setBookHasNext(response.hasNext)
+        return [...prev, ...deduped]
+      })
     } catch (error) {
       if (axios.isCancel(error) || controller.signal.aborted) return
       if (stateRef.current.trimmedQuery !== requestedQuery) return

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -145,17 +145,7 @@ export default function ReviewDetailPage() {
       : [review.book.author, review.book.publisher, reviewStatus].filter((tag): tag is string =>
           Boolean(tag)
         )
-  // [MED-2 fix] 이전엔 quote 결정은 ?? (null/undefined만 fallthrough), source 결정은 || (빈 문자열도 falsy)
-  // 라 백엔드가 quote: ""를 보내면 quote 자리에 빈 문자열이 렌더되면서 라벨은 '감상 중에서'로
-  // 잘못 표기되는 미스매치가 있었다. 두 분기 모두 || 기준으로 통일하고 hasOwnQuote 플래그로
-  // 라벨을 정확히 결정하도록 수정.
-  const hasOwnQuote = Boolean(review.quote)
-  const quote = review.quote || review.book.description || review.content
-  const quoteSource = hasOwnQuote
-    ? '감상 중에서'
-    : review.book.description
-      ? '도서 소개'
-      : '감상 중에서'
+  const hasQuote = Boolean(review.quote)
   const coverImageUrl = review.book.coverImageUrl
   const isMyReview = currentUserId != null && review.user.userId === currentUserId
   const reviewHeading = isMyReview ? '나의 감상' : `${review.user.nickname}의 감상`
@@ -274,19 +264,21 @@ export default function ReviewDetailPage() {
           </div>
         </section>
 
-        {/* Quote Card */}
-        <section className="px-5 py-5">
-          <div className="rounded-[24px] bg-primary/5 p-5">
-            <div className="mb-2 text-primary/20">
-              <span className="material-symbols-outlined text-[38px]">format_quote</span>
-            </div>
+        {/* Quote Card — 인용구가 있을 때만 노출 */}
+        {hasQuote && (
+          <section className="px-5 py-5">
+            <div className="rounded-[24px] bg-primary/5 p-5">
+              <div className="mb-2 text-primary/20">
+                <span className="material-symbols-outlined text-[38px]">format_quote</span>
+              </div>
 
-            <div className="border-l-4 border-primary pl-4">
-              <p className="text-xl italic leading-9 text-foreground/85">{quote}</p>
-              <p className="mt-4 text-base text-muted-foreground">{quoteSource}</p>
+              <div className="border-l-4 border-primary pl-4">
+                <p className="text-xl italic leading-9 text-foreground/85">{review.quote}</p>
+                <p className="mt-4 text-base text-muted-foreground">감상 중에서</p>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
 
         {/* Tags */}
         <section className="px-5 py-2">


### PR DESCRIPTION
  QA에서 발견된 버그 수정

  ## 1. BookSearchPage 무한 렌더링 루프 (CRITICAL)
  searchParams 객체가 매 렌더마다 새 인스턴스로 생성되어 URL → state 동기화
  useEffect의 deps([searchParams])가 매번 발동 → setState → 재렌더 → 무한루프.
  deps를 searchParams.toString()으로 변경하여 값 기반 비교로 안정화.

  ## 2. BookSearchPage 도서 탭 무한 스크롤 중복 결과
  백엔드 searchBooks가 알라딘 API page를 항상 1로 호출해 다음 페이지도 동일
  결과 반환. 프론트에서 bookId 기준 dedup 방어 + 새 아이템 0건이면 hasNext=false
  로 스크롤 종료. 백엔드 수정 요청은 docs에 별도 문서로 분리.

  ## 3. 홈피드 댓글 아이콘 → 감상 상세 댓글 섹션으로 이동
  ReviewCard의 댓글 아이콘 클릭 시 navigate(`/review/${id}#comments`)로 감상
  상세 진입 + 댓글 섹션 스크롤 연결.

  ## 4. 감상 상세 인용구 영역 — quote 없을 때 섹션 미노출
  인용구가 없으면 review.content가 인용구 자리에 복사되던 문제. review.quote가
  없으면 인용구 섹션 자체를 미노출하도록 수정.

  검증:
  - npx tsc -b → 0건
  - npx eslint → 0건
  - npx vitest run → 29/29 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 책 검색 결과에서 중복 항목 제거
  * 검색 결과 페이지네이션 안정성 개선

* **New Features**
  * 리뷰 댓글 섹션으로 직접 이동 가능
  * 리뷰 상세 페이지의 인용문 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->