### PR TITLE
feat: 도서 상세 감상 목록 API 연동 — 미리보기 + 전체보기 페이지 (#138)

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import { ApiResponse, normalizeAxiosError } from './_helpers'
+import { ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
 
 export interface BookSummary {
   bookId: number
@@ -107,5 +107,71 @@ export async function searchBooks(
     throw normalizeAxiosError(error, '도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요.', {
       suppress409Message: true,
     })
+  }
+}
+
+export interface BookReviewUser {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+}
+
+export interface BookReviewItem {
+  reviewId: number
+  user: BookReviewUser
+  rating: number
+  content: string
+  quote: string | null
+  isSpoiler: boolean
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  createdAt: string
+}
+
+export interface BookReviewListResponse {
+  content: BookReviewItem[]
+  nextCursor: number | null
+  nextCursorRating: number | null
+  hasNext: boolean
+  size: number
+}
+
+export type BookReviewSort = 'latest' | 'popular' | 'rating_high' | 'rating_low'
+
+/**
+ * 도서별 감상 목록을 조회한다.
+ *
+ * 정렬 중 `rating_high`/`rating_low`는 복합 커서(`cursorRating` + `cursor`)를 사용.
+ * `latest`/`popular`는 단일 `cursor`만 사용.
+ * `isLiked`는 백엔드에서 실제 연동됨 (BookService.getBookReviews에서 findLikedReviewIds 사용).
+ */
+export async function getBookReviews(
+  bookId: number,
+  options?: {
+    sort?: BookReviewSort
+    cursor?: number | null
+    cursorRating?: number | null
+    limit?: number
+    signal?: AbortSignal
+  }
+): Promise<BookReviewListResponse> {
+  const { sort = 'latest', cursor, cursorRating, limit = 20, signal } = options ?? {}
+  try {
+    const { data } = await apiClient.get<ApiResponse<BookReviewListResponse>>(
+      `/api/v1/books/${bookId}/reviews`,
+      {
+        params: {
+          sort,
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+          ...(cursorRating != null ? { cursorRating } : {}),
+        },
+        signal,
+      }
+    )
+    return parseApiResponse(data, '감상 목록 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '감상 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.')
   }
 }

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -74,6 +74,7 @@ export default function BookDetailPage() {
     const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
+    setPreviewReviews([])
     ;(async () => {
       try {
         const [result, reviewResult] = await Promise.all([

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -5,8 +5,15 @@ import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
-import { getBook, type BookDetail, type BackendReadingStatus } from '@/api/book'
+import {
+  getBook,
+  getBookReviews,
+  type BookDetail,
+  type BookReviewItem,
+  type BackendReadingStatus,
+} from '@/api/book'
 import { addLibraryBook, updateLibraryBookStatus } from '@/api/library'
+import { formatRelativeTime } from '@/lib/utils'
 import type { ReadingStatus } from '@/types'
 
 const statusEmoji: Record<ReadingStatus, string> = {
@@ -42,6 +49,7 @@ export default function BookDetailPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
+  const [previewReviews, setPreviewReviews] = useState<BookReviewItem[]>([])
   const isMountedRef = useRef(true)
 
   // StrictMode dev 모드에서 effect가 mount → unmount → mount로 더블 인보크되므로
@@ -68,10 +76,14 @@ export default function BookDetailPage() {
     setErrorMessage(null)
     ;(async () => {
       try {
-        const result = await getBook(parsedBookId, controller.signal)
+        const [result, reviewResult] = await Promise.all([
+          getBook(parsedBookId, controller.signal),
+          getBookReviews(parsedBookId, { limit: 3, signal: controller.signal }).catch(() => null),
+        ])
         if (controller.signal.aborted) return
         setBook(result)
         setSavedStatus(toFrontStatus(result.myLibraryStatus))
+        if (reviewResult) setPreviewReviews(reviewResult.content)
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setErrorMessage(error instanceof Error ? error.message : '도서 정보를 불러오지 못했습니다.')
@@ -252,14 +264,67 @@ export default function BookDetailPage() {
               전체보기
             </Link>
           </div>
-          {/* TODO(B3): 도서별 감상 목록 API 연동 시 미리보기 리스트 표시 */}
           <div className="px-6">
-            <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-primary/10 py-8 text-center">
-              <span className="material-symbols-outlined text-3xl text-muted-foreground/40">
-                menu_book
-              </span>
-              <p className="text-sm text-muted-foreground">전체보기에서 모든 감상을 확인하세요</p>
-            </div>
+            {previewReviews.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-primary/10 py-8 text-center">
+                <span className="material-symbols-outlined text-3xl text-muted-foreground/40">
+                  rate_review
+                </span>
+                <p className="text-sm text-muted-foreground">아직 감상이 없습니다</p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                {previewReviews.map(review => (
+                  <Link
+                    key={review.reviewId}
+                    to={`/review/${review.reviewId}`}
+                    className="rounded-xl bg-card p-4 shadow-sm transition-colors hover:bg-primary/5"
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="size-7 overflow-hidden rounded-full bg-primary/10">
+                          {review.user.profileImageUrl ? (
+                            <img
+                              src={review.user.profileImageUrl}
+                              alt={review.user.nickname}
+                              className="size-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex size-full items-center justify-center">
+                              <span className="material-symbols-outlined text-[14px] text-primary/40">
+                                person
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                        <span className="text-sm font-bold">{review.user.nickname}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {formatRelativeTime(review.createdAt)}
+                        </span>
+                      </div>
+                      <StarRating rating={review.rating} size="sm" />
+                    </div>
+                    <p className="line-clamp-2 text-sm leading-relaxed text-foreground/80">
+                      {review.content}
+                    </p>
+                    <div className="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
+                      {review.likeCount > 0 && (
+                        <span className="flex items-center gap-1">
+                          <span className="material-symbols-outlined text-[14px]">favorite</span>
+                          {review.likeCount}
+                        </span>
+                      )}
+                      {review.commentCount > 0 && (
+                        <span className="flex items-center gap-1">
+                          <span className="material-symbols-outlined text-[14px]">chat_bubble</span>
+                          {review.commentCount}
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
           </div>
         </section>
       </main>

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -304,9 +304,15 @@ export default function BookDetailPage() {
                       </div>
                       <StarRating rating={review.rating} size="sm" />
                     </div>
-                    <p className="line-clamp-2 text-sm leading-relaxed text-foreground/80">
-                      {review.content}
-                    </p>
+                    {review.isSpoiler ? (
+                      <p className="line-clamp-2 text-sm italic text-muted-foreground">
+                        스포일러 포함 — 전체보기에서 확인하세요
+                      </p>
+                    ) : (
+                      <p className="line-clamp-2 text-sm leading-relaxed text-foreground/80">
+                        {review.content}
+                      </p>
+                    )}
                     <div className="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
                       {review.likeCount > 0 && (
                         <span className="flex items-center gap-1">

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -1,33 +1,201 @@
-import { useState, useMemo } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
-import { cn } from '@/lib/utils'
-import { mockBooks, mockBookDetailReviews } from '@/mocks/data'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import axios from 'axios'
+import {
+  getBook,
+  getBookReviews,
+  type BookDetail,
+  type BookReviewItem,
+  type BookReviewSort,
+} from '@/api/book'
+import { likeReview, unlikeReview } from '@/api/review'
+import { cn, formatRelativeTime } from '@/lib/utils'
+import { useAuthStore } from '@/store/authStore'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 
-const sortOptions = [
+const sortOptions: { label: string; value: BookReviewSort }[] = [
   { label: '최신순', value: 'latest' },
-  { label: '별점 높은순', value: 'rating_desc' },
-  { label: '별점 낮은순', value: 'rating_asc' },
+  { label: '인기순', value: 'popular' },
+  { label: '별점 높은순', value: 'rating_high' },
+  { label: '별점 낮은순', value: 'rating_low' },
 ]
 
+/**
+ * 도서별 감상 전체보기 페이지.
+ *
+ * BookDetailPage의 "전체보기" 링크에서 진입. 정렬 변경 시 목록을 초기화하고
+ * 첫 페이지를 다시 로드. 무한 스크롤로 다음 페이지 추가.
+ */
 export default function BookReviewsListPage() {
-  const { bookId: id } = useParams()
+  const { bookId: bookIdParam } = useParams()
   const navigate = useNavigate()
-  const [activeSort, setActiveSort] = useState('latest')
+  const currentUserId = useAuthStore(state => state.user?.id)
+  const bookId = Number(bookIdParam)
+
+  const [book, setBook] = useState<BookDetail | null>(null)
+  const [reviews, setReviews] = useState<BookReviewItem[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [nextCursorRating, setNextCursorRating] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [activeSort, setActiveSort] = useState<BookReviewSort>('latest')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
   const [revealedSpoilers, setRevealedSpoilers] = useState<Set<number>>(new Set())
 
-  const book = mockBooks.find(b => b.isbn === id)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+  const stateRef = useRef({
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    nextCursorRating,
+    loadMoreError,
+    activeSort,
+  })
+  stateRef.current = {
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    nextCursor,
+    nextCursorRating,
+    loadMoreError,
+    activeSort,
+  }
 
-  const sortedReviews = useMemo(() => {
-    const reviews = [...mockBookDetailReviews]
-    if (activeSort === 'rating_desc')
-      return reviews.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
-    if (activeSort === 'rating_asc')
-      return reviews.sort((a, b) => (a.rating ?? 0) - (b.rating ?? 0))
-    return reviews
-  }, [activeSort])
+  // 도서 정보 + 첫 페이지 로드
+  useEffect(() => {
+    if (!Number.isFinite(bookId)) {
+      setErrorMessage('도서 정보가 올바르지 않습니다.')
+      setIsLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    setReviews([])
+    setNextCursor(null)
+    setNextCursorRating(null)
+    setHasNext(false)
+    setRevealedSpoilers(new Set())
+    ;(async () => {
+      try {
+        const [bookResult, reviewResult] = await Promise.all([
+          getBook(bookId, controller.signal),
+          getBookReviews(bookId, { sort: activeSort, limit: 20, signal: controller.signal }),
+        ])
+        if (controller.signal.aborted) return
+        setBook(bookResult)
+        setReviews(reviewResult.content)
+        setNextCursor(reviewResult.nextCursor)
+        setNextCursorRating(reviewResult.nextCursorRating)
+        setHasNext(reviewResult.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '감상을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+    }
+    // activeSort 변경 시 목록 초기화 + 재로드
+  }, [bookId, activeSort])
+
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const response = await getBookReviews(bookId, {
+        sort: s.activeSort,
+        cursor: s.nextCursor,
+        cursorRating: s.nextCursorRating,
+        limit: 20,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      setReviews(prev => {
+        const existingIds = new Set(prev.map(r => r.reviewId))
+        const deduped = response.content.filter(r => !existingIds.has(r.reviewId))
+        if (deduped.length === 0) {
+          setHasNext(false)
+          return prev
+        }
+        setNextCursor(response.nextCursor)
+        setNextCursorRating(response.nextCursorRating)
+        setHasNext(response.hasNext)
+        return [...prev, ...deduped]
+      })
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [bookId])
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (!entries[0]?.isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  const handleToggleLike = async (
+    reviewId: number,
+    currentlyLiked: boolean,
+    currentCount: number
+  ) => {
+    setReviews(prev =>
+      prev.map(r =>
+        r.reviewId === reviewId
+          ? { ...r, isLiked: !currentlyLiked, likeCount: currentCount + (currentlyLiked ? -1 : 1) }
+          : r
+      )
+    )
+    try {
+      const result = currentlyLiked ? await unlikeReview(reviewId) : await likeReview(reviewId)
+      setReviews(prev =>
+        prev.map(r => (r.reviewId === reviewId ? { ...r, likeCount: result.likeCount } : r))
+      )
+    } catch {
+      setReviews(prev =>
+        prev.map(r =>
+          r.reviewId === reviewId ? { ...r, isLiked: currentlyLiked, likeCount: currentCount } : r
+        )
+      )
+    }
+  }
 
   const toggleSpoiler = (reviewId: number) => {
     setRevealedSpoilers(prev => {
@@ -37,7 +205,21 @@ export default function BookReviewsListPage() {
     })
   }
 
-  if (!book) {
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="독자 감상" showBack />
+        <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (errorMessage || !book) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
         <AppHeader title="독자 감상" showBack />
@@ -46,6 +228,11 @@ export default function BookReviewsListPage() {
             search_off
           </span>
           <p className="text-lg font-bold text-muted-foreground">도서를 찾을 수 없습니다</p>
+          {errorMessage && (
+            <p role="alert" className="max-w-[280px] text-center text-sm text-muted-foreground">
+              {errorMessage}
+            </p>
+          )}
           <button
             onClick={() => navigate(-1)}
             className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
@@ -66,28 +253,32 @@ export default function BookReviewsListPage() {
         {/* Book Context */}
         <section className="px-6 pb-4 pt-6">
           <div className="flex items-center gap-3 rounded-xl bg-primary/10 p-3 shadow-sm">
-            <img
-              src={book.coverImageUrl}
-              alt={book.title}
-              className="h-14 w-10 rounded-md object-cover shadow-sm"
-            />
-            <div className="flex flex-col">
-              <div className="flex items-baseline gap-2">
-                <span className="text-lg font-bold">{book.title}</span>
-                <span className="text-sm text-muted-foreground">{book.author}</span>
+            {book.coverImageUrl ? (
+              <img
+                src={book.coverImageUrl}
+                alt={book.title}
+                className="h-14 w-10 rounded-md object-cover shadow-sm"
+              />
+            ) : (
+              <div className="flex h-14 w-10 items-center justify-center rounded-md bg-primary/5">
+                <span className="material-symbols-outlined text-primary/40">menu_book</span>
               </div>
+            )}
+            <div className="flex flex-col">
+              <span className="text-lg font-bold">{book.title}</span>
+              <span className="text-sm text-muted-foreground">{book.author}</span>
             </div>
           </div>
         </section>
 
-        {/* Sort & Count */}
-        <section className="mb-8 px-6">
+        {/* Sort */}
+        <section className="mb-4 px-6">
           <div className="mb-4 flex items-center justify-between">
             <span className="text-sm font-medium text-muted-foreground">
-              감상 {sortedReviews.length}개
+              감상 {reviews.length}개{hasNext && '+'}
             </span>
           </div>
-          <div className="no-scrollbar flex gap-2 overflow-x-auto pb-2">
+          <div className="no-scrollbar flex gap-2 overflow-x-auto pb-2 pr-6">
             {sortOptions.map(option => (
               <button
                 key={option.value}
@@ -106,76 +297,132 @@ export default function BookReviewsListPage() {
         </section>
 
         {/* Review List */}
-        <div className="flex flex-col gap-8 px-6">
-          {sortedReviews.map(review => (
-            <article
-              key={review.id}
-              onClick={() => navigate(`/review/${review.id}`)}
-              className="cursor-pointer rounded-lg border-l-4 border-primary bg-card p-6 shadow-sm transition-colors hover:bg-primary/5"
-            >
-              {/* Header */}
-              <div className="mb-4 flex items-start justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="size-10 overflow-hidden rounded-full">
-                    {review.author.profileImageUrl ? (
-                      <img
-                        src={review.author.profileImageUrl}
-                        alt={review.author.nickname}
-                        className="size-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex size-full items-center justify-center bg-primary/10">
-                        <span className="material-symbols-outlined text-primary/40">person</span>
-                      </div>
-                    )}
-                  </div>
-                  <div>
-                    <p className="text-sm font-bold">{review.author.nickname}</p>
-                    <p className="text-xs text-muted-foreground">{review.createdAt}</p>
-                  </div>
-                </div>
-                <StarRating rating={review.rating ?? 0} size="sm" />
-              </div>
+        {reviews.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              rate_review
+            </span>
+            <p className="text-sm text-muted-foreground">아직 감상이 없습니다</p>
+          </div>
+        )}
 
-              {/* Content */}
-              {review.hasSpoiler && !revealedSpoilers.has(review.id) ? (
-                <button
-                  onClick={e => {
-                    e.stopPropagation()
-                    toggleSpoiler(review.id)
-                  }}
-                  className="group relative w-full cursor-pointer text-left"
-                >
-                  <div className="pointer-events-none select-none blur-md">
-                    <p className="leading-relaxed">{review.content}</p>
+        <div className="flex flex-col gap-6 px-6">
+          {reviews.map(review => {
+            const isMyReview = currentUserId != null && review.user.userId === currentUserId
+            return (
+              <article
+                key={review.reviewId}
+                onClick={() => navigate(`/review/${review.reviewId}`)}
+                className="cursor-pointer rounded-lg border-l-4 border-primary bg-card p-6 shadow-sm transition-colors hover:bg-primary/5"
+              >
+                <div className="mb-4 flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="size-10 overflow-hidden rounded-full bg-primary/10">
+                      {review.user.profileImageUrl ? (
+                        <img
+                          src={review.user.profileImageUrl}
+                          alt={review.user.nickname}
+                          className="size-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex size-full items-center justify-center">
+                          <span className="material-symbols-outlined text-primary/40">person</span>
+                        </div>
+                      )}
+                    </div>
+                    <div>
+                      <p className="text-sm font-bold">{review.user.nickname}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatRelativeTime(review.createdAt)}
+                      </p>
+                    </div>
                   </div>
-                  <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-primary/5 transition-colors group-hover:bg-primary/10">
-                    <span className="material-symbols-outlined mb-1 text-primary">
-                      visibility_off
-                    </span>
-                    <p className="text-sm font-semibold text-primary">
-                      스포일러 포함 — 탭하여 보기
-                    </p>
-                  </div>
-                </button>
-              ) : (
-                <p className="mb-4 leading-relaxed">{review.content}</p>
-              )}
+                  <StarRating rating={review.rating} size="sm" />
+                </div>
 
-              {/* Actions */}
-              <div className="mt-4 flex items-center gap-6 text-muted-foreground">
-                <div className="flex items-center gap-1">
-                  <span className="material-symbols-outlined text-lg">favorite</span>
-                  <span className="text-xs">{review.likeCount}</span>
+                {review.isSpoiler && !revealedSpoilers.has(review.reviewId) ? (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation()
+                      toggleSpoiler(review.reviewId)
+                    }}
+                    className="group relative w-full cursor-pointer text-left"
+                  >
+                    <div className="pointer-events-none select-none blur-md">
+                      <p className="leading-relaxed">{review.content}</p>
+                    </div>
+                    <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-primary/5 transition-colors group-hover:bg-primary/10">
+                      <span className="material-symbols-outlined mb-1 text-primary">
+                        visibility_off
+                      </span>
+                      <p className="text-sm font-semibold text-primary">
+                        스포일러 포함 — 탭하여 보기
+                      </p>
+                    </div>
+                  </button>
+                ) : (
+                  <p className="mb-4 line-clamp-4 leading-relaxed">{review.content}</p>
+                )}
+
+                <div className="mt-4 flex items-center gap-6 text-muted-foreground">
+                  {!isMyReview ? (
+                    <button
+                      onClick={e => {
+                        e.stopPropagation()
+                        handleToggleLike(review.reviewId, review.isLiked, review.likeCount)
+                      }}
+                      className={cn(
+                        'flex items-center gap-1 transition-colors',
+                        review.isLiked ? 'text-primary' : 'hover:text-primary'
+                      )}
+                    >
+                      <span
+                        className="material-symbols-outlined text-lg"
+                        style={{ fontVariationSettings: `'FILL' ${review.isLiked ? 1 : 0}` }}
+                      >
+                        favorite
+                      </span>
+                      <span className="text-xs">{review.likeCount}</span>
+                    </button>
+                  ) : review.likeCount > 0 ? (
+                    <div className="flex items-center gap-1">
+                      <span className="material-symbols-outlined text-lg">favorite</span>
+                      <span className="text-xs">{review.likeCount}</span>
+                    </div>
+                  ) : null}
+                  <div className="flex items-center gap-1">
+                    <span className="material-symbols-outlined text-lg">chat_bubble</span>
+                    <span className="text-xs">{review.commentCount}</span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1">
-                  <span className="material-symbols-outlined text-lg">chat_bubble</span>
-                  <span className="text-xs">{review.commentCount ?? 0}</span>
-                </div>
-              </div>
-            </article>
-          ))}
+              </article>
+            )
+          })}
         </div>
+
+        {hasNext && <div ref={sentinelRef} className="h-10" aria-hidden="true" />}
+
+        {isLoadingMore && (
+          <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+        )}
+
+        {loadMoreError && !isLoadingMore && (
+          <div className="flex flex-col items-center gap-2 py-4">
+            <p role="alert" className="text-sm text-destructive">
+              {loadMoreError}
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setLoadMoreError(null)
+                fetchMore()
+              }}
+              className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+            >
+              다시 불러오기
+            </button>
+          </div>
+        )}
       </main>
 
       <BottomNav />

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -46,6 +46,7 @@ export default function BookReviewsListPage() {
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
   const [revealedSpoilers, setRevealedSpoilers] = useState<Set<number>>(new Set())
 
+  const likingIdsRef = useRef(new Set<number>())
   const observerRef = useRef<IntersectionObserver | null>(null)
   const moreControllerRef = useRef<AbortController | null>(null)
   const stateRef = useRef({
@@ -67,13 +68,32 @@ export default function BookReviewsListPage() {
     activeSort,
   }
 
-  // 도서 정보 + 첫 페이지 로드
+  // 도서 정보 로드 — bookId에만 의존
   useEffect(() => {
     if (!Number.isFinite(bookId)) {
       setErrorMessage('도서 정보가 올바르지 않습니다.')
       setIsLoading(false)
       return
     }
+
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const result = await getBook(bookId, controller.signal)
+        if (controller.signal.aborted) return
+        setBook(result)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '도서 정보를 불러오지 못했습니다.')
+      }
+    })()
+
+    return () => controller.abort()
+  }, [bookId])
+
+  // 감상 목록 로드 — bookId + activeSort 변경 시 초기화 + 재로드
+  useEffect(() => {
+    if (!Number.isFinite(bookId)) return
 
     const controller = new AbortController()
     setIsLoading(true)
@@ -85,12 +105,12 @@ export default function BookReviewsListPage() {
     setRevealedSpoilers(new Set())
     ;(async () => {
       try {
-        const [bookResult, reviewResult] = await Promise.all([
-          getBook(bookId, controller.signal),
-          getBookReviews(bookId, { sort: activeSort, limit: 20, signal: controller.signal }),
-        ])
+        const reviewResult = await getBookReviews(bookId, {
+          sort: activeSort,
+          limit: 20,
+          signal: controller.signal,
+        })
         if (controller.signal.aborted) return
-        setBook(bookResult)
         setReviews(reviewResult.content)
         setNextCursor(reviewResult.nextCursor)
         setNextCursorRating(reviewResult.nextCursorRating)
@@ -107,7 +127,6 @@ export default function BookReviewsListPage() {
       controller.abort()
       moreControllerRef.current?.abort()
     }
-    // activeSort 변경 시 목록 초기화 + 재로드
   }, [bookId, activeSort])
 
   const fetchMore = useCallback(async () => {
@@ -132,15 +151,14 @@ export default function BookReviewsListPage() {
       setReviews(prev => {
         const existingIds = new Set(prev.map(r => r.reviewId))
         const deduped = response.content.filter(r => !existingIds.has(r.reviewId))
-        if (deduped.length === 0) {
-          setHasNext(false)
-          return prev
-        }
+        return deduped.length > 0 ? [...prev, ...deduped] : prev
+      })
+      const hasNewItems = response.content.length > 0
+      if (hasNewItems) {
         setNextCursor(response.nextCursor)
         setNextCursorRating(response.nextCursorRating)
-        setHasNext(response.hasNext)
-        return [...prev, ...deduped]
-      })
+      }
+      setHasNext(hasNewItems && response.hasNext)
     } catch (error) {
       if (axios.isCancel(error) || controller.signal.aborted) return
       setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
@@ -176,6 +194,8 @@ export default function BookReviewsListPage() {
     currentlyLiked: boolean,
     currentCount: number
   ) => {
+    if (likingIdsRef.current.has(reviewId)) return
+    likingIdsRef.current.add(reviewId)
     setReviews(prev =>
       prev.map(r =>
         r.reviewId === reviewId
@@ -194,6 +214,8 @@ export default function BookReviewsListPage() {
           r.reviewId === reviewId ? { ...r, isLiked: currentlyLiked, likeCount: currentCount } : r
         )
       )
+    } finally {
+      likingIdsRef.current.delete(reviewId)
     }
   }
 
@@ -281,6 +303,7 @@ export default function BookReviewsListPage() {
           <div className="no-scrollbar flex gap-2 overflow-x-auto pb-2 pr-6">
             {sortOptions.map(option => (
               <button
+                type="button"
                 key={option.value}
                 onClick={() => setActiveSort(option.value)}
                 className={cn(
@@ -367,10 +390,12 @@ export default function BookReviewsListPage() {
                 <div className="mt-4 flex items-center gap-6 text-muted-foreground">
                   {!isMyReview ? (
                     <button
+                      type="button"
                       onClick={e => {
                         e.stopPropagation()
                         handleToggleLike(review.reviewId, review.isLiked, review.likeCount)
                       }}
+                      aria-label={review.isLiked ? '좋아요 취소' : '좋아요'}
                       className={cn(
                         'flex items-center gap-1 transition-colors',
                         review.isLiked ? 'text-primary' : 'hover:text-primary'

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -15,9 +15,9 @@ import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 
-const sortOptions: { label: string; value: BookReviewSort }[] = [
+const sortOptions: { label: string; value: BookReviewSort; disabled?: boolean }[] = [
   { label: '최신순', value: 'latest' },
-  { label: '인기순', value: 'popular' },
+  { label: '인기순 (준비 중)', value: 'popular', disabled: true },
   { label: '별점 높은순', value: 'rating_high' },
   { label: '별점 낮은순', value: 'rating_low' },
 ]
@@ -95,6 +95,7 @@ export default function BookReviewsListPage() {
   useEffect(() => {
     if (!Number.isFinite(bookId)) return
 
+    moreControllerRef.current?.abort()
     const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
@@ -102,6 +103,8 @@ export default function BookReviewsListPage() {
     setNextCursor(null)
     setNextCursorRating(null)
     setHasNext(false)
+    setIsLoadingMore(false)
+    setLoadMoreError(null)
     setRevealedSpoilers(new Set())
     ;(async () => {
       try {
@@ -305,12 +308,15 @@ export default function BookReviewsListPage() {
               <button
                 type="button"
                 key={option.value}
-                onClick={() => setActiveSort(option.value)}
+                onClick={() => !option.disabled && setActiveSort(option.value)}
+                disabled={option.disabled}
                 className={cn(
                   'whitespace-nowrap rounded-full px-5 py-2 text-sm font-semibold transition-colors',
-                  activeSort === option.value
-                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
-                    : 'border border-primary/10 bg-primary/5 text-primary'
+                  option.disabled
+                    ? 'border border-primary/10 bg-muted text-muted-foreground opacity-50'
+                    : activeSort === option.value
+                      ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
+                      : 'border border-primary/10 bg-primary/5 text-primary'
                 )}
               >
                 {option.label}


### PR DESCRIPTION
  도서 상세 페이지의 "독자들의 감상" placeholder와 전체보기 페이지의 mock
  데이터를 실 API로 교체.

  ## src/api/book.ts (수정)
  - BookReviewItem, BookReviewListResponse, BookReviewSort 타입 추가
  - getBookReviews(bookId, options?) 함수 추가 — 4종 정렬 + 복합 커서 지원
  - parseApiResponse 헬퍼 import 추가

  ## src/pages/BookDetailPage.tsx (수정)
  - "독자들의 감상" TODO placeholder → 실 API 미리보기 3건 표시
  - 도서 로드와 감상 미리보기를 Promise.all로 병렬 fetch
  - 미리보기 카드: 닉네임, 별점, 내용 2줄, 좋아요/댓글 수
  - 감상 없으면 "아직 감상이 없습니다" 안내

  ## src/pages/BookReviewsListPage.tsx (전면 재작성)
  - mock 데이터(mockBooks, mockBookDetailReviews) 전면 제거
  - getBook + getBookReviews 실 API 연동
  - 커서 기반 무한 스크롤 (NotificationsPage 패턴)
  - 4종 정렬(최신순/인기순/별점 높은순/낮은순) — 변경 시 목록 초기화 + 재로드
  - 좋아요 낙관적 토글 + 본인 감상 분기
  - 스포일러 블러 처리
  - 중복 reviewId dedup 방어
  - 정렬 칩 우측 잘림 수정 (pr-6 추가)

  알려진 한계:
  - 인기순(sort=popular) 백엔드 500 — JPQL 파라미터 바인딩 불일치
    (cursorLike/cursorId 미선언). 백엔드에 수정 요청 완료.

  검증:
  - npx tsc -b → 0건
  - npx eslint → 0건
  - npx vitest run → 29/29 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 도서별 리뷰 조회 및 표시 기능 추가
* 도서 상세 페이지에서 리뷰 미리보기 표시
* 리뷰 목록 페이지에서 무한 스크롤 지원
* 리뷰에 대한 좋아요/싫어요 기능 추가
* 리뷰 정렬 옵션(최신순, 인기순, 평점순) 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->