### PR TITLE
  fix: 도서 검색 페이지네이션 page 전환 + 감상 인기순 복합 커서 반영 (#140)

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -79,10 +79,15 @@ export async function getBookByIsbn(isbn13: string, signal?: AbortSignal): Promi
   }
 }
 
+/**
+ * 도서 검색. 백엔드가 알라딘 API를 page 번호 기반으로 호출하므로
+ * 프론트도 cursor 대신 page를 전달한다. 응답의 `nextCursor`(bookId)는
+ * DB 커서용으로 남아있지만 검색 페이지네이션에는 page 증가만 사용.
+ */
 export async function searchBooks(
   query: string,
   limit = 20,
-  cursor?: number | null,
+  page = 1,
   signal?: AbortSignal
 ): Promise<BookSearchListResponse> {
   try {
@@ -92,7 +97,7 @@ export async function searchBooks(
         params: {
           query,
           limit,
-          ...(cursor != null ? { cursor } : {}),
+          page,
         },
         signal,
       }
@@ -133,6 +138,7 @@ export interface BookReviewListResponse {
   content: BookReviewItem[]
   nextCursor: number | null
   nextCursorRating: number | null
+  nextCursorLike: number | null
   hasNext: boolean
   size: number
 }
@@ -142,9 +148,10 @@ export type BookReviewSort = 'latest' | 'popular' | 'rating_high' | 'rating_low'
 /**
  * 도서별 감상 목록을 조회한다.
  *
- * 정렬 중 `rating_high`/`rating_low`는 복합 커서(`cursorRating` + `cursor`)를 사용.
- * `latest`/`popular`는 단일 `cursor`만 사용.
- * `isLiked`는 백엔드에서 실제 연동됨 (BookService.getBookReviews에서 findLikedReviewIds 사용).
+ * 정렬별 복합 커서 정책:
+ * - `latest`: 단일 `cursor`(reviewId)
+ * - `popular`: `cursorLike`(likeCount) + `cursor`(reviewId)
+ * - `rating_high`/`rating_low`: `cursorRating`(rating) + `cursor`(reviewId)
  */
 export async function getBookReviews(
   bookId: number,
@@ -152,11 +159,12 @@ export async function getBookReviews(
     sort?: BookReviewSort
     cursor?: number | null
     cursorRating?: number | null
+    cursorLike?: number | null
     limit?: number
     signal?: AbortSignal
   }
 ): Promise<BookReviewListResponse> {
-  const { sort = 'latest', cursor, cursorRating, limit = 20, signal } = options ?? {}
+  const { sort = 'latest', cursor, cursorRating, cursorLike, limit = 20, signal } = options ?? {}
   try {
     const { data } = await apiClient.get<ApiResponse<BookReviewListResponse>>(
       `/api/v1/books/${bookId}/reviews`,
@@ -166,6 +174,7 @@ export async function getBookReviews(
           limit,
           ...(cursor != null ? { cursor } : {}),
           ...(cursorRating != null ? { cursorRating } : {}),
+          ...(cursorLike != null ? { cursorLike } : {}),
         },
         signal,
       }

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -102,10 +102,7 @@ export async function searchBooks(
         signal,
       }
     )
-    if (!data.data) {
-      throw new Error(data.message ?? '도서 검색 응답이 올바르지 않습니다.')
-    }
-    return data.data
+    return parseApiResponse(data, '도서 검색 응답이 올바르지 않습니다.')
   } catch (error) {
     // 도서 검색은 백엔드 알라딘 ISBN 중복 결함으로 409가 발생할 수 있어
     // 도메인 무관 일반 메시지로 치환 (docs/통합_검색_백엔드_결함_보고.md 참고).

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -15,9 +15,9 @@ import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import StarRating from '@/components/common/StarRating'
 
-const sortOptions: { label: string; value: BookReviewSort; disabled?: boolean }[] = [
+const sortOptions: { label: string; value: BookReviewSort }[] = [
   { label: '최신순', value: 'latest' },
-  { label: '인기순 (준비 중)', value: 'popular', disabled: true },
+  { label: '인기순', value: 'popular' },
   { label: '별점 높은순', value: 'rating_high' },
   { label: '별점 낮은순', value: 'rating_low' },
 ]
@@ -38,6 +38,7 @@ export default function BookReviewsListPage() {
   const [reviews, setReviews] = useState<BookReviewItem[]>([])
   const [nextCursor, setNextCursor] = useState<number | null>(null)
   const [nextCursorRating, setNextCursorRating] = useState<number | null>(null)
+  const [nextCursorLike, setNextCursorLike] = useState<number | null>(null)
   const [hasNext, setHasNext] = useState(false)
   const [activeSort, setActiveSort] = useState<BookReviewSort>('latest')
   const [isLoading, setIsLoading] = useState(true)
@@ -55,6 +56,7 @@ export default function BookReviewsListPage() {
     isLoadingMore,
     nextCursor,
     nextCursorRating,
+    nextCursorLike,
     loadMoreError,
     activeSort,
   })
@@ -64,6 +66,7 @@ export default function BookReviewsListPage() {
     isLoadingMore,
     nextCursor,
     nextCursorRating,
+    nextCursorLike,
     loadMoreError,
     activeSort,
   }
@@ -102,6 +105,7 @@ export default function BookReviewsListPage() {
     setReviews([])
     setNextCursor(null)
     setNextCursorRating(null)
+    setNextCursorLike(null)
     setHasNext(false)
     setIsLoadingMore(false)
     setLoadMoreError(null)
@@ -117,6 +121,7 @@ export default function BookReviewsListPage() {
         setReviews(reviewResult.content)
         setNextCursor(reviewResult.nextCursor)
         setNextCursorRating(reviewResult.nextCursorRating)
+        setNextCursorLike(reviewResult.nextCursorLike)
         setHasNext(reviewResult.hasNext)
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
@@ -147,6 +152,7 @@ export default function BookReviewsListPage() {
         sort: s.activeSort,
         cursor: s.nextCursor,
         cursorRating: s.nextCursorRating,
+        cursorLike: s.nextCursorLike,
         limit: 20,
         signal: controller.signal,
       })
@@ -160,6 +166,7 @@ export default function BookReviewsListPage() {
       if (hasNewItems) {
         setNextCursor(response.nextCursor)
         setNextCursorRating(response.nextCursorRating)
+        setNextCursorLike(response.nextCursorLike)
       }
       setHasNext(hasNewItems && response.hasNext)
     } catch (error) {
@@ -308,15 +315,12 @@ export default function BookReviewsListPage() {
               <button
                 type="button"
                 key={option.value}
-                onClick={() => !option.disabled && setActiveSort(option.value)}
-                disabled={option.disabled}
+                onClick={() => setActiveSort(option.value)}
                 className={cn(
                   'whitespace-nowrap rounded-full px-5 py-2 text-sm font-semibold transition-colors',
-                  option.disabled
-                    ? 'border border-primary/10 bg-muted text-muted-foreground opacity-50'
-                    : activeSort === option.value
-                      ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
-                      : 'border border-primary/10 bg-primary/5 text-primary'
+                  activeSort === option.value
+                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
+                    : 'border border-primary/10 bg-primary/5 text-primary'
                 )}
               >
                 {option.label}

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -108,9 +108,9 @@ export default function BookSearchPage() {
   const [activeTab, setActiveTab] = useState<SearchType>(initialTab)
   const [isScannerOpen, setIsScannerOpen] = useState(false)
 
-  // 도서 탭 (searchBooks 응답)
+  // 도서 탭 (searchBooks 응답) — 백엔드가 page 기반 페이지네이션으로 변경됨
   const [bookResults, setBookResults] = useState<BookSummary[]>([])
-  const [bookNextCursor, setBookNextCursor] = useState<number | null>(null)
+  const [bookNextPage, setBookNextPage] = useState<number | null>(null)
   const [bookHasNext, setBookHasNext] = useState(false)
   const [isBookLoading, setIsBookLoading] = useState(false)
   const [isBookLoadingMore, setIsBookLoadingMore] = useState(false)
@@ -151,7 +151,7 @@ export default function BookSearchPage() {
     bookHasNext,
     isBookLoading,
     isBookLoadingMore,
-    bookNextCursor,
+    bookNextPage,
     bookLoadMoreError,
     userHasNext,
     isUserLoading,
@@ -165,7 +165,7 @@ export default function BookSearchPage() {
     bookHasNext,
     isBookLoading,
     isBookLoadingMore,
-    bookNextCursor,
+    bookNextPage,
     bookLoadMoreError,
     userHasNext,
     isUserLoading,
@@ -237,7 +237,7 @@ export default function BookSearchPage() {
       // 다른 탭이거나 검색어 비어있으면 도서 결과 초기화
       if (!trimmedQuery) {
         setBookResults([])
-        setBookNextCursor(null)
+        setBookNextPage(null)
         setBookHasNext(false)
         setBookErrorMessage(null)
       }
@@ -249,7 +249,7 @@ export default function BookSearchPage() {
     // stale UI 방지 — setTimeout 들어가기 전에 결과/cursor/에러 초기화하여
     // 사용자가 "검색 중..." placeholder만 보도록 한다.
     setBookResults([])
-    setBookNextCursor(null)
+    setBookNextPage(null)
     setBookHasNext(false)
     setBookErrorMessage(null)
     setIsBookLoading(true)
@@ -261,20 +261,20 @@ export default function BookSearchPage() {
           const book = await getBookByIsbn(trimmedQuery, controller.signal)
           if (controller.signal.aborted) return
           setBookResults([isbnResultToSummary(book)])
-          setBookNextCursor(null)
+          setBookNextPage(null)
           setBookHasNext(false)
         } else {
-          const response = await searchBooks(trimmedQuery, 20, null, controller.signal)
+          const response = await searchBooks(trimmedQuery, 20, 1, controller.signal)
           if (controller.signal.aborted) return
           setBookResults(response.content)
-          setBookNextCursor(response.nextCursor)
+          setBookNextPage(response.hasNext ? 2 : null)
           setBookHasNext(response.hasNext)
         }
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setBookErrorMessage(error instanceof Error ? error.message : '검색에 실패했습니다.')
         setBookResults([])
-        setBookNextCursor(null)
+        setBookNextPage(null)
         setBookHasNext(false)
       } finally {
         if (!controller.signal.aborted) setIsBookLoading(false)
@@ -406,9 +406,10 @@ export default function BookSearchPage() {
     // 진행되지 않도록 진입부 가드. observer disconnect와 별개의 안전망.
     if (s.activeTab !== 'book') return
     if (s.isBookLoadingMore || s.isBookLoading || !s.bookHasNext) return
+    if (!s.bookNextPage) return
     if (isValidIsbn13(s.trimmedQuery)) return // ISBN 모드는 단일 결과
     const requestedQuery = s.trimmedQuery
-    const requestedCursor = s.bookNextCursor
+    const requestedPage = s.bookNextPage
 
     bookMoreControllerRef.current?.abort()
     const controller = new AbortController()
@@ -417,7 +418,7 @@ export default function BookSearchPage() {
     setIsBookLoadingMore(true)
     setBookLoadMoreError(null)
     try {
-      const response = await searchBooks(requestedQuery, 20, requestedCursor, controller.signal)
+      const response = await searchBooks(requestedQuery, 20, requestedPage, controller.signal)
       if (controller.signal.aborted) return
       if (stateRef.current.trimmedQuery !== requestedQuery) return
       setBookResults(prev => {
@@ -427,7 +428,7 @@ export default function BookSearchPage() {
           setBookHasNext(false)
           return prev
         }
-        setBookNextCursor(response.nextCursor)
+        setBookNextPage(response.hasNext && requestedPage != null ? requestedPage + 1 : null)
         setBookHasNext(response.hasNext)
         return [...prev, ...deduped]
       })


### PR DESCRIPTION
  - searchBooks() cursor → page 파라미터 변경 (백엔드 알라딘 API page 방식 전환 대응)
  - BookSearchPage 무한스크롤: cursor 기반 → page 번호 증가 방식으로 변경
  - getBookReviews()에 cursorLike 파라미터 추가 (인기순 복합 커서)
  - BookReviewListResponse에 nextCursorLike 필드 추가
  - BookReviewsListPage 인기순 정렬 비활성화 해제 + cursorLike 전달 로직

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 도서 리뷰 인기순 정렬 옵션 활성화

## 개선사항
- 도서 검색 페이지네이션 알고리즘 업데이트
- 도서 리뷰 페이지네이션 기능 강화로 더욱 정확한 결과 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->