### PR TITLE
  feat: 사용자 차단 기능 — 설정 차단 관리 + 차단 목록 페이지 + 프로필 차단 버튼 (#142)

### DIFF
--- a/src/api/block.ts
+++ b/src/api/block.ts
@@ -1,0 +1,65 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
+
+export interface BlockedUser {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+  blockedAt: string
+}
+
+export interface BlockListResponse {
+  content: BlockedUser[]
+  nextCursor: number | null
+  hasNext: boolean
+  size: number
+}
+
+/**
+ * 차단 목록 조회. cursor 기반 페이지네이션.
+ * 백엔드 `FollowController.getBlockList` → `GET /api/v1/users/me/blocks`
+ */
+export async function getBlockedUsers(options?: {
+  cursor?: number | null
+  limit?: number
+  signal?: AbortSignal
+}): Promise<BlockListResponse> {
+  const { cursor, limit = 20, signal } = options ?? {}
+  try {
+    const { data } = await apiClient.get<ApiResponse<BlockListResponse>>(
+      '/api/v1/users/me/blocks',
+      {
+        params: {
+          limit,
+          ...(cursor != null ? { cursor } : {}),
+        },
+        signal,
+      }
+    )
+    return parseApiResponse(data, '차단 목록 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '차단 목록을 불러오지 못했습니다.')
+  }
+}
+
+/**
+ * 사용자 차단. 양방향 팔로우 해제 + 피드 삭제가 백엔드에서 함께 처리됨.
+ */
+export async function blockUser(userId: number): Promise<void> {
+  try {
+    await apiClient.post(`/api/v1/users/${userId}/block`)
+  } catch (error) {
+    throw normalizeAxiosError(error, '차단에 실패했습니다.')
+  }
+}
+
+/**
+ * 사용자 차단 해제.
+ */
+export async function unblockUser(userId: number): Promise<void> {
+  try {
+    await apiClient.delete(`/api/v1/users/${userId}/block`)
+  } catch (error) {
+    throw normalizeAxiosError(error, '차단 해제에 실패했습니다.')
+  }
+}

--- a/src/pages/BlockedUsersPage.tsx
+++ b/src/pages/BlockedUsersPage.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import axios from 'axios'
+import AppHeader from '@/components/layout/AppHeader'
+import BottomNav from '@/components/layout/BottomNav'
+import { getBlockedUsers, unblockUser, type BlockedUser } from '@/api/block'
+
+/**
+ * 차단한 사용자 목록 페이지 (`/settings/blocked`).
+ *
+ * SettingsPage "차단한 사용자" 항목에서 진입. 차단 해제 시 confirm 후
+ * 즉시 목록에서 제거(낙관적) → API 실패 시 함수형 setState로 롤백하여
+ * 동시 해제 요청 간 stale closure 문제를 방지.
+ */
+export default function BlockedUsersPage() {
+  const [users, setUsers] = useState<BlockedUser[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasNext, setHasNext] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+
+  const unblockingIdsRef = useRef(new Set<number>())
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const moreControllerRef = useRef<AbortController | null>(null)
+  const stateRef = useRef({ hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError })
+  stateRef.current = { hasNext, isLoading, isLoadingMore, nextCursor, loadMoreError }
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const result = await getBlockedUsers({ signal: controller.signal })
+        if (controller.signal.aborted) return
+        setUsers(result.content)
+        setNextCursor(result.nextCursor)
+        setHasNext(result.hasNext)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '차단 목록을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+    return () => {
+      controller.abort()
+      moreControllerRef.current?.abort()
+    }
+  }, [])
+
+  const fetchMore = useCallback(async () => {
+    const s = stateRef.current
+    if (s.isLoadingMore || s.isLoading || !s.hasNext) return
+
+    moreControllerRef.current?.abort()
+    const controller = new AbortController()
+    moreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setLoadMoreError(null)
+    try {
+      const result = await getBlockedUsers({ cursor: s.nextCursor, signal: controller.signal })
+      if (controller.signal.aborted) return
+      setUsers(prev => {
+        const existingIds = new Set(prev.map(u => u.userId))
+        const deduped = result.content.filter(u => !existingIds.has(u.userId))
+        return deduped.length > 0 ? [...prev, ...deduped] : prev
+      })
+      setNextCursor(result.nextCursor)
+      setHasNext(result.hasNext)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      setLoadMoreError(error instanceof Error ? error.message : '추가 로딩에 실패했습니다.')
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }, [])
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect()
+      if (!node) {
+        observerRef.current = null
+        return
+      }
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (!entries[0]?.isIntersecting) return
+          if (stateRef.current.loadMoreError) return
+          fetchMore()
+        },
+        { rootMargin: '200px' }
+      )
+      observerRef.current.observe(node)
+    },
+    [fetchMore]
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  /**
+   * 차단 해제. 낙관적으로 목록에서 즉시 제거 후, API 실패 시 함수형 setState로
+   * 해당 유저를 현재 state 기준으로 다시 삽입. closure 캡처가 아닌 prev 기반이라
+   * 동시 해제 요청 간 롤백이 서로를 덮어쓰지 않는다.
+   */
+  const handleUnblock = async (user: BlockedUser) => {
+    if (unblockingIdsRef.current.has(user.userId)) return
+    if (!window.confirm(`${user.nickname}님의 차단을 해제하시겠습니까?`)) return
+
+    unblockingIdsRef.current.add(user.userId)
+    setUsers(prev => prev.filter(u => u.userId !== user.userId))
+
+    try {
+      await unblockUser(user.userId)
+    } catch {
+      setUsers(prev => (prev.some(u => u.userId === user.userId) ? prev : [...prev, user]))
+    } finally {
+      unblockingIdsRef.current.delete(user.userId)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="차단한 사용자" showBack />
+        <main aria-busy="true" className="flex flex-1 items-center justify-center pb-24">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  if (errorMessage) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppHeader title="차단한 사용자" showBack />
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 pb-24">
+          <span className="material-symbols-outlined text-5xl text-muted-foreground/30">error</span>
+          <p role="alert" className="text-sm text-muted-foreground">
+            {errorMessage}
+          </p>
+        </main>
+        <BottomNav />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="차단한 사용자" showBack />
+
+      <main className="flex-1 overflow-y-auto pb-24">
+        {users.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-20">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              person_off
+            </span>
+            <p className="text-sm text-muted-foreground">차단한 사용자가 없습니다</p>
+          </div>
+        ) : (
+          <section className="px-5 pt-4">
+            <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
+              {users.map((user, idx) => (
+                <div
+                  key={user.userId}
+                  className={`flex items-center justify-between gap-3 px-5 py-4 ${
+                    idx < users.length - 1 ? 'border-b border-border' : ''
+                  }`}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="size-11 shrink-0 overflow-hidden rounded-full bg-primary/10">
+                      {user.profileImageUrl ? (
+                        <img
+                          src={user.profileImageUrl}
+                          alt={user.nickname}
+                          loading="lazy"
+                          className="size-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex size-full items-center justify-center">
+                          <span className="material-symbols-outlined text-[20px] text-primary/40">
+                            person
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="truncate text-[15px] font-semibold text-foreground">
+                        {user.nickname}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(user.blockedAt).toLocaleDateString('ko-KR', {
+                          year: 'numeric',
+                          month: '2-digit',
+                          day: '2-digit',
+                        })}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleUnblock(user)}
+                    className="shrink-0 rounded-full border border-destructive/30 px-4 py-1.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10"
+                  >
+                    차단 해제
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {hasNext && <div ref={sentinelRef} className="h-10" aria-hidden="true" />}
+
+            {isLoadingMore && (
+              <p className="py-4 text-center text-xs text-muted-foreground">더 불러오는 중...</p>
+            )}
+
+            {loadMoreError && !isLoadingMore && (
+              <div className="flex flex-col items-center gap-2 py-4">
+                <p role="alert" className="text-sm text-destructive">
+                  {loadMoreError}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLoadMoreError(null)
+                    fetchMore()
+                  }}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                >
+                  다시 불러오기
+                </button>
+              </div>
+            )}
+          </section>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -236,6 +236,14 @@ export default function SettingsPage() {
           </div>
         </section>
 
+        {/* Block Management */}
+        <section className="px-5 pt-8">
+          <h2 className="mb-3 text-lg font-bold text-primary/80">차단 관리</h2>
+          <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
+            <LinkRow title="차단한 사용자" onClick={() => navigate('/settings/blocked')} noBorder />
+          </div>
+        </section>
+
         {/* Account */}
         <section className="px-5 pt-8">
           <h2 className="mb-3 text-lg font-bold text-primary/80">계정 관리</h2>

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import { getUserProfile, type UserProfile } from '@/api/member'
 import { followUser, unfollowUser } from '@/api/follow'
+import { blockUser } from '@/api/block'
 import { getUserReviews, REVIEW_PAGE_SIZE, type ReviewListItem } from '@/api/review'
 import { formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
@@ -32,6 +33,8 @@ export default function UserProfilePage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isFollowProcessing, setIsFollowProcessing] = useState(false)
   const [followError, setFollowError] = useState<string | null>(null)
+  const [isBlockProcessing, setIsBlockProcessing] = useState(false)
+  const [blockError, setBlockError] = useState<string | null>(null)
   const [reviews, setReviews] = useState<ReviewListItem[]>([])
   const [reviewNextCursor, setReviewNextCursor] = useState<number | null>(null)
   const [hasMoreReviews, setHasMoreReviews] = useState(false)
@@ -166,6 +169,30 @@ export default function UserProfilePage() {
         </main>
       </div>
     )
+  }
+
+  /**
+   * 사용자 차단. confirm 후 API 호출 → 성공 시 이전 페이지로 이동.
+   * 백엔드에서 양방향 팔로우 해제 + 피드 삭제가 함께 처리됨.
+   * 이미 차단된 사용자에게 다시 호출하면 백엔드가 409를 반환하므로 에러 메시지로 안내.
+   */
+  const handleBlock = async () => {
+    if (isBlockProcessing) return
+    if (
+      !window.confirm(
+        `${profile.nickname}님을 차단하시겠습니까?\n차단하면 서로의 팔로우가 해제되고, 피드에서 감상이 숨겨집니다.`
+      )
+    )
+      return
+    setIsBlockProcessing(true)
+    setBlockError(null)
+    try {
+      await blockUser(profile.userId)
+      navigate(-1)
+    } catch (error) {
+      setBlockError(error instanceof Error ? error.message : '차단에 실패했습니다.')
+      setIsBlockProcessing(false)
+    }
   }
 
   /**
@@ -333,6 +360,23 @@ export default function UserProfilePage() {
               className="rounded-lg bg-destructive/10 px-4 py-2 text-center text-sm text-destructive"
             >
               {followError}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={handleBlock}
+            disabled={isBlockProcessing}
+            className="w-full rounded-xl border border-destructive/20 bg-card py-3 text-base font-semibold text-destructive transition-colors hover:bg-destructive/5 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isBlockProcessing ? '처리 중...' : '차단'}
+          </button>
+          {blockError && (
+            <p
+              role="alert"
+              aria-atomic="true"
+              className="rounded-lg bg-destructive/10 px-4 py-2 text-center text-sm text-destructive"
+            >
+              {blockError}
             </p>
           )}
         </section>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
 import PasswordResetPage from '@/pages/PasswordResetPage'
 import EmailVerificationPage from '@/pages/EmailVerificationPage'
 import PasswordChangePage from '@/pages/PasswordChangePage'
+import BlockedUsersPage from '@/pages/BlockedUsersPage'
 import WithdrawPage from '@/pages/WithdrawPage'
 import EditProfilePage from '@/pages/EditProfilePage'
 import UserProfilePage from '@/pages/UserProfilePage'
@@ -191,6 +192,14 @@ export const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <EditProfilePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/settings/blocked',
+    element: (
+      <ProtectedRoute>
+        <BlockedUsersPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
  - block API 클라이언트 신규 생성 (blockUser, unblockUser, getBlockedUsers)
  - BlockedUsersPage 신규: 차단 사용자 목록 + 차단 해제(낙관적 + 함수형 롤백) + 무한 스크롤
  - SettingsPage에 "차단 관리" 섹션 추가 → /settings/blocked 이동
  - UserProfilePage에 차단 버튼 추가 (confirm → 차단 → 에러 피드백)
  - /settings/blocked 라우트 등록
  - 코드 리뷰 반영: AbortController, loadMoreError 재시도, 롤백 race 방지, lazy loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **사용자 차단 기능**: 원치 않는 사용자를 차단하고 필요시 차단을 해제할 수 있습니다.
* **프로필 페이지 차단 버튼**: 다른 사용자의 프로필에서 바로 차단할 수 있습니다.
* **차단 관리 메뉴**: 설정에서 차단한 사용자를 관리할 수 있는 메뉴가 추가되었습니다.
* **차단된 사용자 목록**: 차단된 사용자 목록을 무한 스크롤로 편리하게 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->