### PR TITLE
  feat: 온보딩 장르 선택 페이지 — 신규 사용자 관심 장르 설정 (#144)

### DIFF
--- a/src/api/genre.ts
+++ b/src/api/genre.ts
@@ -1,0 +1,63 @@
+import apiClient from './client'
+import { ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
+
+export interface Genre {
+  genreId: number
+  name: string
+}
+
+export interface GenreListResponse {
+  genres: Genre[]
+}
+
+export interface OnboardingRequest {
+  nickname: string
+  genreIds: number[]
+  bio?: string
+  profileImageUrl?: string
+}
+
+export interface OnboardingResponse {
+  userId: number
+  nickname: string
+  profileImageUrl: string | null
+  bio: string | null
+  onboardingCompleted: boolean
+  genres: Genre[]
+}
+
+/**
+ * 전체 장르 목록 조회. 온보딩 장르 선택 UI에서 사용.
+ * 백엔드 `genres` 테이블의 전체 목록을 반환한다.
+ */
+export async function getGenres(signal?: AbortSignal): Promise<Genre[]> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<GenreListResponse>>('/api/v1/genres', {
+      signal,
+    })
+    const result = parseApiResponse(data, '장르 목록 응답이 올바르지 않습니다.')
+    return result.genres
+  } catch (error) {
+    throw normalizeAxiosError(error, '장르 목록을 불러오지 못했습니다.')
+  }
+}
+
+/**
+ * 온보딩 완료. nickname과 genreIds를 백엔드에 전달하여 프로필+장르를 한 번에 설정.
+ * 성공 시 백엔드가 `member.onboardingCompleted = true`로 갱신.
+ */
+export async function completeOnboarding(
+  request: OnboardingRequest,
+  signal?: AbortSignal
+): Promise<OnboardingResponse> {
+  try {
+    const { data } = await apiClient.post<ApiResponse<OnboardingResponse>>(
+      '/api/v1/users/me/onboarding',
+      request,
+      { signal }
+    )
+    return parseApiResponse(data, '온보딩 완료 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '온보딩 완료에 실패했습니다.')
+  }
+}

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -54,7 +54,7 @@ export default function AuthCallbackPage() {
           },
           result.accessToken
         )
-        navigate(result.user.onboardingCompleted ? '/' : '/onboarding', { replace: true })
+        navigate(result.user.onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
       })
       .catch(err => {
         setErrorMessage(err instanceof Error ? err.message : 'Google 로그인에 실패했습니다.')

--- a/src/pages/GenreSelectionPage.tsx
+++ b/src/pages/GenreSelectionPage.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { getGenres, completeOnboarding, type Genre } from '@/api/genre'
+import { useAuthStore } from '@/store/authStore'
+
+/**
+ * 온보딩 장르 선택 페이지 (`/onboarding/genre`).
+ *
+ * `onboardingCompleted === false`인 신규 사용자가 관심 장르를 선택하는 단계.
+ * 선택된 장르는 `POST /api/v1/users/me/onboarding`으로 전달되어
+ * 추천 피드(`RecommendationService.buildTopCategories`)의 콘텐츠 기반 추천 입력이 된다.
+ *
+ * 최소 1개 선택 필수 (백엔드 `@NotEmpty`). 최대 제한 없음.
+ */
+export default function GenreSelectionPage() {
+  const navigate = useNavigate()
+  const user = useAuthStore(state => state.user)
+  const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
+  const completeOnboardingStore = useAuthStore(state => state.completeOnboarding)
+
+  const [genres, setGenres] = useState<Genre[]>([])
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const result = await getGenres(controller.signal)
+        if (controller.signal.aborted) return
+        setGenres(result)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(error instanceof Error ? error.message : '장르 목록을 불러오지 못했습니다.')
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+    return () => controller.abort()
+  }, [])
+
+  const toggleGenre = (genreId: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(genreId)) {
+        next.delete(genreId)
+      } else {
+        next.add(genreId)
+      }
+      return next
+    })
+  }
+
+  const handleSubmit = async () => {
+    if (isSubmitting || selectedIds.size === 0 || !user) return
+    setIsSubmitting(true)
+    setSubmitError(null)
+    try {
+      await completeOnboarding({
+        nickname: user.nickname,
+        genreIds: Array.from(selectedIds),
+      })
+      completeOnboardingStore()
+      navigate('/', { replace: true })
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : '온보딩 완료에 실패했습니다.')
+      setIsSubmitting(false)
+    }
+  }
+
+  if (onboardingCompleted) return <Navigate to="/" replace />
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background">
+        <p role="status" className="text-sm text-muted-foreground">
+          불러오는 중...
+        </p>
+      </div>
+    )
+  }
+
+  if (errorMessage) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-6">
+        <span className="material-symbols-outlined text-5xl text-muted-foreground/30">error</span>
+        <p role="alert" className="text-sm text-muted-foreground">
+          {errorMessage}
+        </p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+        >
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="px-6 pb-2 pt-12">
+        <h1 className="text-3xl font-bold leading-tight">
+          관심 장르를
+          <br />
+          선택해주세요
+        </h1>
+        <p className="mt-3 text-base text-muted-foreground">
+          선택한 장르를 바탕으로 감상을 추천해드려요
+        </p>
+      </header>
+
+      <main className="flex-1 overflow-y-auto px-6 pb-32 pt-6">
+        <div className="flex flex-wrap gap-3">
+          {genres.map(genre => {
+            const isSelected = selectedIds.has(genre.genreId)
+            return (
+              <button
+                key={genre.genreId}
+                type="button"
+                onClick={() => toggleGenre(genre.genreId)}
+                aria-pressed={isSelected}
+                className={`rounded-full px-5 py-3 text-[15px] font-semibold transition-all ${
+                  isSelected
+                    ? 'bg-primary text-primary-foreground shadow-lg shadow-primary/20'
+                    : 'border border-primary/15 bg-card text-foreground hover:bg-primary/5'
+                }`}
+              >
+                {genre.name}
+              </button>
+            )
+          })}
+        </div>
+
+        {genres.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              category
+            </span>
+            <p className="text-sm text-muted-foreground">등록된 장르가 없습니다</p>
+          </div>
+        )}
+      </main>
+
+      <div className="fixed inset-x-0 bottom-0 bg-background px-6 pb-8 pt-4">
+        {submitError && (
+          <p
+            role="alert"
+            className="mb-3 rounded-lg bg-destructive/10 px-4 py-2 text-center text-sm text-destructive"
+          >
+            {submitError}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={selectedIds.size === 0 || isSubmitting}
+          className="h-14 w-full rounded-full bg-primary text-lg font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {isSubmitting
+            ? '처리 중...'
+            : selectedIds.size === 0
+              ? '장르를 선택해주세요'
+              : `선택 완료 (${selectedIds.size}개)`}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -64,7 +64,7 @@ export default function LoginPage() {
         },
         result.accessToken
       )
-      navigate(result.user.onboardingCompleted ? '/' : '/onboarding', { replace: true })
+      navigate(result.user.onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '로그인에 실패했습니다.')
     } finally {

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -46,13 +46,11 @@ export default function OnboardingPage() {
   const [step, setStep] = useState(0)
   const navigate = useNavigate()
   const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
-  const completeOnboardingStore = useAuthStore(state => state.completeOnboarding)
 
   if (onboardingCompleted) return <Navigate to="/" replace />
 
   const completeOnboarding = () => {
-    completeOnboardingStore()
-    navigate('/', { replace: true })
+    navigate('/onboarding/genre', { replace: true })
   }
 
   const handleNext = () => {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -19,6 +19,7 @@ import EmailVerificationPage from '@/pages/EmailVerificationPage'
 import PasswordChangePage from '@/pages/PasswordChangePage'
 import BlockedUsersPage from '@/pages/BlockedUsersPage'
 import WithdrawPage from '@/pages/WithdrawPage'
+import GenreSelectionPage from '@/pages/GenreSelectionPage'
 import EditProfilePage from '@/pages/EditProfilePage'
 import UserProfilePage from '@/pages/UserProfilePage'
 import LibraryBookDetailPage from '@/pages/LibraryBookDetailPage'
@@ -66,6 +67,14 @@ export const router = createBrowserRouter([
   {
     path: '/verify-email',
     element: <EmailVerificationPage />,
+  },
+  {
+    path: '/onboarding/genre',
+    element: (
+      <ProtectedRoute>
+        <GenreSelectionPage />
+      </ProtectedRoute>
+    ),
   },
   {
     path: '/search',


### PR DESCRIPTION
  - genre API 클라이언트 신규 (getGenres, completeOnboarding)
  - GenreSelectionPage 신규: 장르 칩 다중 선택 + 최소 1개 유효성 + 온보딩 완료
  - 온보딩 완료 사용자 /onboarding/genre 직접 접근 시 홈으로 리디렉트 가드
  - OnboardingPage 캐러셀 완료 → /onboarding/genre로 이동 (장르 선택 우회 방지)
  - 로그인/Google 콜백에서 onboardingCompleted=false → /onboarding/genre 리디렉션
  - /onboarding/genre 라우트 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 온보딩 과정 중 선호하는 장르를 선택하는 페이지가 추가되었습니다. 사용자는 최소 1개 이상의 장르를 선택한 후 가입을 완료할 수 있습니다.

## 변경 사항
* 로그인 및 소셜 인증 완료 후 장르 선택 페이지로 이동하는 플로우로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->