### PR TITLE
  feat: 설정 관심 장르 변경 — GenreSelectionPage 재활용 + 개인화 섹션 (#146)

### DIFF
--- a/src/api/genre.ts
+++ b/src/api/genre.ts
@@ -43,6 +43,24 @@ export async function getGenres(signal?: AbortSignal): Promise<Genre[]> {
 }
 
 /**
+ * 관심 장르 수정. 기존 장르를 전체 교체한다.
+ * 온보딩 이후 설정에서 장르를 변경할 때 사용.
+ */
+export async function updateMyGenres(genreIds: number[], signal?: AbortSignal): Promise<Genre[]> {
+  try {
+    const { data } = await apiClient.put<ApiResponse<{ genres: Genre[] }>>(
+      '/api/v1/users/me/genres',
+      { genreIds },
+      { signal }
+    )
+    const result = parseApiResponse(data, '장르 수정 응답이 올바르지 않습니다.')
+    return result.genres
+  } catch (error) {
+    throw normalizeAxiosError(error, '장르 수정에 실패했습니다.')
+  }
+}
+
+/**
  * 온보딩 완료. nickname과 genreIds를 백엔드에 전달하여 프로필+장르를 한 번에 설정.
  * 성공 시 백엔드가 `member.onboardingCompleted = true`로 갱신.
  */

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,5 +1,6 @@
 import apiClient from './client'
 import { ApiResponse, normalizeAxiosError } from './_helpers'
+import type { Genre } from './genre'
 
 export type LibraryVisibility = 'PUBLIC' | 'PRIVATE'
 
@@ -15,6 +16,7 @@ export interface MyProfile {
   followerCount: number
   followingCount: number
   reviewCount: number
+  genres: Genre[]
 }
 
 export async function getMyProfile(signal?: AbortSignal): Promise<MyProfile> {

--- a/src/pages/GenreSelectionPage.tsx
+++ b/src/pages/GenreSelectionPage.tsx
@@ -79,11 +79,17 @@ export default function GenreSelectionPage() {
           selectedIds.size === initialIdsRef.current.size &&
           [...selectedIds].every(id => initialIdsRef.current.has(id))
         if (unchanged) {
-          navigate(-1)
+          setIsSubmitting(false)
+          navigate('/settings', { replace: true })
           return
         }
-        await updateMyGenres(genreIds)
-        navigate(-1)
+        try {
+          await updateMyGenres(genreIds)
+          navigate('/settings', { replace: true })
+        } finally {
+          setIsSubmitting(false)
+        }
+        return
       } else {
         await completeOnboarding({
           nickname: user.nickname,

--- a/src/pages/GenreSelectionPage.tsx
+++ b/src/pages/GenreSelectionPage.tsx
@@ -1,26 +1,31 @@
-import { useEffect, useState } from 'react'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { Navigate, useLocation, useNavigate } from 'react-router-dom'
 import axios from 'axios'
-import { getGenres, completeOnboarding, type Genre } from '@/api/genre'
+import AppHeader from '@/components/layout/AppHeader'
+import { getGenres, completeOnboarding, updateMyGenres, type Genre } from '@/api/genre'
+import { getMyProfile } from '@/api/member'
 import { useAuthStore } from '@/store/authStore'
 
 /**
- * 온보딩 장르 선택 페이지 (`/onboarding/genre`).
+ * 장르 선택 페이지 — 온보딩(`/onboarding/genre`)과 설정(`/settings/genres`) 두 모드로 재활용.
  *
- * `onboardingCompleted === false`인 신규 사용자가 관심 장르를 선택하는 단계.
- * 선택된 장르는 `POST /api/v1/users/me/onboarding`으로 전달되어
- * 추천 피드(`RecommendationService.buildTopCategories`)의 콘텐츠 기반 추천 입력이 된다.
- *
- * 최소 1개 선택 필수 (백엔드 `@NotEmpty`). 최대 제한 없음.
+ * - **온보딩 모드**: 신규 사용자. `POST /api/v1/users/me/onboarding` 호출 → 홈 이동.
+ *   `onboardingCompleted === true`이면 홈으로 리디렉트.
+ * - **설정 모드**: 기존 사용자. 현재 장르를 미리 선택 상태로 표시.
+ *   `PUT /api/v1/users/me/genres` 호출 → 뒤로가기.
  */
 export default function GenreSelectionPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const user = useAuthStore(state => state.user)
   const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
   const completeOnboardingStore = useAuthStore(state => state.completeOnboarding)
 
+  const isSettingsMode = location.pathname === '/settings/genres'
+
   const [genres, setGenres] = useState<Genre[]>([])
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const initialIdsRef = useRef<Set<number>>(new Set())
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -30,9 +35,17 @@ export default function GenreSelectionPage() {
     const controller = new AbortController()
     ;(async () => {
       try {
-        const result = await getGenres(controller.signal)
+        const [genreList, profile] = await Promise.all([
+          getGenres(controller.signal),
+          isSettingsMode ? getMyProfile(controller.signal) : null,
+        ])
         if (controller.signal.aborted) return
-        setGenres(result)
+        setGenres(genreList)
+        if (profile?.genres) {
+          const ids = new Set(profile.genres.map(g => g.genreId))
+          setSelectedIds(ids)
+          initialIdsRef.current = ids
+        }
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setErrorMessage(error instanceof Error ? error.message : '장르 목록을 불러오지 못했습니다.')
@@ -41,7 +54,7 @@ export default function GenreSelectionPage() {
       }
     })()
     return () => controller.abort()
-  }, [])
+  }, [isSettingsMode])
 
   const toggleGenre = (genreId: number) => {
     setSelectedIds(prev => {
@@ -60,60 +73,83 @@ export default function GenreSelectionPage() {
     setIsSubmitting(true)
     setSubmitError(null)
     try {
-      await completeOnboarding({
-        nickname: user.nickname,
-        genreIds: Array.from(selectedIds),
-      })
-      completeOnboardingStore()
-      navigate('/', { replace: true })
+      const genreIds = Array.from(selectedIds)
+      if (isSettingsMode) {
+        const unchanged =
+          selectedIds.size === initialIdsRef.current.size &&
+          [...selectedIds].every(id => initialIdsRef.current.has(id))
+        if (unchanged) {
+          navigate(-1)
+          return
+        }
+        await updateMyGenres(genreIds)
+        navigate(-1)
+      } else {
+        await completeOnboarding({
+          nickname: user.nickname,
+          genreIds,
+        })
+        completeOnboardingStore()
+        navigate('/', { replace: true })
+      }
     } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : '온보딩 완료에 실패했습니다.')
+      setSubmitError(error instanceof Error ? error.message : '저장에 실패했습니다.')
       setIsSubmitting(false)
     }
   }
 
-  if (onboardingCompleted) return <Navigate to="/" replace />
+  if (!isSettingsMode && onboardingCompleted) return <Navigate to="/" replace />
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-background">
-        <p role="status" className="text-sm text-muted-foreground">
-          불러오는 중...
-        </p>
+      <div className="flex min-h-screen flex-col bg-background">
+        {isSettingsMode && <AppHeader title="관심 장르 변경" showBack />}
+        <main className="flex flex-1 items-center justify-center">
+          <p role="status" className="text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        </main>
       </div>
     )
   }
 
   if (errorMessage) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-6">
-        <span className="material-symbols-outlined text-5xl text-muted-foreground/30">error</span>
-        <p role="alert" className="text-sm text-muted-foreground">
-          {errorMessage}
-        </p>
-        <button
-          type="button"
-          onClick={() => window.location.reload()}
-          className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
-        >
-          다시 시도
-        </button>
+      <div className="flex min-h-screen flex-col bg-background">
+        {isSettingsMode && <AppHeader title="관심 장르 변경" showBack />}
+        <main className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+          <span className="material-symbols-outlined text-5xl text-muted-foreground/30">error</span>
+          <p role="alert" className="text-sm text-muted-foreground">
+            {errorMessage}
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+          >
+            다시 시도
+          </button>
+        </main>
       </div>
     )
   }
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <header className="px-6 pb-2 pt-12">
-        <h1 className="text-3xl font-bold leading-tight">
-          관심 장르를
-          <br />
-          선택해주세요
-        </h1>
-        <p className="mt-3 text-base text-muted-foreground">
-          선택한 장르를 바탕으로 감상을 추천해드려요
-        </p>
-      </header>
+      {isSettingsMode ? (
+        <AppHeader title="관심 장르 변경" showBack />
+      ) : (
+        <header className="px-6 pb-2 pt-12">
+          <h1 className="text-3xl font-bold leading-tight">
+            관심 장르를
+            <br />
+            선택해주세요
+          </h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            선택한 장르를 바탕으로 감상을 추천해드려요
+          </p>
+        </header>
+      )}
 
       <main className="flex-1 overflow-y-auto px-6 pb-32 pt-6">
         <div className="flex flex-wrap gap-3">
@@ -166,7 +202,9 @@ export default function GenreSelectionPage() {
             ? '처리 중...'
             : selectedIds.size === 0
               ? '장르를 선택해주세요'
-              : `선택 완료 (${selectedIds.size}개)`}
+              : isSettingsMode
+                ? '저장'
+                : `선택 완료 (${selectedIds.size}개)`}
         </button>
       </div>
     </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -236,6 +236,14 @@ export default function SettingsPage() {
           </div>
         </section>
 
+        {/* Personalization */}
+        <section className="px-5 pt-8">
+          <h2 className="mb-3 text-lg font-bold text-primary/80">개인화</h2>
+          <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
+            <LinkRow title="관심 장르 변경" onClick={() => navigate('/settings/genres')} noBorder />
+          </div>
+        </section>
+
         {/* Block Management */}
         <section className="px-5 pt-8">
           <h2 className="mb-3 text-lg font-bold text-primary/80">차단 관리</h2>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -205,6 +205,14 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: '/settings/genres',
+    element: (
+      <ProtectedRoute>
+        <GenreSelectionPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: '/settings/blocked',
     element: (
       <ProtectedRoute>


### PR DESCRIPTION
  - updateMyGenres() API 추가 (PUT /api/v1/users/me/genres)
  - MyProfile 타입에 genres 필드 추가
  - GenreSelectionPage 온보딩/설정 모드 분기: 경로 기반 구분
  - 설정 모드: AppHeader + 기존 장르 미리 선택 + "저장" CTA + 변경 없으면 API 스킵
  - SettingsPage에 "개인화" 섹션 추가 (관심 장르 변경 → /settings/genres)
  - /settings/genres 라우트 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 설정 > 개인화에서 관심 장르를 변경할 수 있는 화면이 추가되었습니다.
  * 설정 모드에서는 기존 저장 장르가 미리 선택되어 변경분만 저장합니다.
  * 온보딩 모드와 설정 모드에서 동작과 버튼 문구가 각각 표시됩니다.
  * 설정용 경로가 추가되어 보호된 설정 화면에서 장르 선택을 관리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->