### PR TITLE
  feat: 설정 페이지 완성 — 토글 API 연동 + 소셜 계정 표시 (#150)

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import { ApiResponse, normalizeAxiosError } from './_helpers'
+import { ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
 import type { Genre } from './genre'
 
 export type LibraryVisibility = 'PUBLIC' | 'PRIVATE'
@@ -89,6 +89,50 @@ export async function changePassword(currentPassword: string, newPassword: strin
     await apiClient.put('/api/v1/users/me/password', { currentPassword, newPassword })
   } catch (error) {
     throw normalizeAxiosError(error, '비밀번호 변경에 실패했습니다. 잠시 후 다시 시도해주세요.')
+  }
+}
+
+export interface SettingsResponse {
+  likeEnabled: boolean
+  commentEnabled: boolean
+  followEnabled: boolean
+  followingReviewEnabled: boolean
+  libraryVisibility: LibraryVisibility
+}
+
+export interface SettingsUpdateRequest {
+  likeEnabled?: boolean
+  commentEnabled?: boolean
+  followEnabled?: boolean
+  followingReviewEnabled?: boolean
+  libraryVisibility?: LibraryVisibility
+}
+
+export async function getSettings(signal?: AbortSignal): Promise<SettingsResponse> {
+  try {
+    const { data } = await apiClient.get<ApiResponse<SettingsResponse>>(
+      '/api/v1/users/me/settings',
+      { signal }
+    )
+    return parseApiResponse(data, '설정 조회 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '설정을 불러오지 못했습니다.')
+  }
+}
+
+/**
+ * 설정 수정. null/undefined 필드는 백엔드에서 기존값을 유지하므로
+ * 변경된 필드만 전달하면 된다 (partial update).
+ */
+export async function updateSettings(request: SettingsUpdateRequest): Promise<SettingsResponse> {
+  try {
+    const { data } = await apiClient.patch<ApiResponse<SettingsResponse>>(
+      '/api/v1/users/me/settings',
+      request
+    )
+    return parseApiResponse(data, '설정 수정 응답이 올바르지 않습니다.')
+  } catch (error) {
+    throw normalizeAxiosError(error, '설정 변경에 실패했습니다.')
   }
 }
 

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -51,6 +51,7 @@ export default function AuthCallbackPage() {
             email: result.user.email,
             emailVerified: result.user.emailVerified,
             onboardingCompleted: result.user.onboardingCompleted,
+            authProvider: 'GOOGLE',
           },
           result.accessToken
         )

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -61,6 +61,7 @@ export default function LoginPage() {
           bio: result.user.bio,
           emailVerified: result.user.emailVerified,
           onboardingCompleted: result.user.onboardingCompleted,
+          authProvider: 'EMAIL',
         },
         result.accessToken
       )

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -138,14 +138,14 @@ export default function SettingsPage() {
 
   /**
    * 토글 변경 핸들러. 낙관적으로 즉시 UI 반영 후 API 호출.
-   * 실패 시 이전 설정으로 롤백. 개별 필드별 잠금으로 여러 토글을
-   * 빠르게 연속 변경해도 각각 독립적으로 처리됨.
+   * 성공/실패 시 변경한 키만 현재 상태에 머지해서, 동시에 진행 중인
+   * 다른 토글의 낙관적 업데이트를 덮어쓰지 않는다.
    */
   const handleToggle = async (patch: Partial<SettingsResponse>) => {
     if (!settings) return
-    const keys = Object.keys(patch)
+    const keys = Object.keys(patch) as (keyof SettingsResponse)[]
     if (keys.some(k => updatingKeys.has(k))) return
-    const prev = settings
+    const snapshot = { ...settings }
     setSettings({ ...settings, ...patch })
     setUpdatingKeys(prev => {
       const next = new Set(prev)
@@ -154,9 +154,19 @@ export default function SettingsPage() {
     })
     try {
       const result = await updateSettings(patch)
-      setSettings(result)
+      setSettings(curr => {
+        if (!curr) return result
+        const next = { ...curr }
+        for (const k of keys) next[k] = result[k] as never
+        return next
+      })
     } catch {
-      setSettings(prev)
+      setSettings(curr => {
+        if (!curr) return snapshot
+        const next = { ...curr }
+        for (const k of keys) next[k] = snapshot[k] as never
+        return next
+      })
     } finally {
       setUpdatingKeys(prev => {
         const next = new Set(prev)

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
 import { logout, resendEmailCode } from '@/api/auth'
+import { getSettings, updateSettings, type SettingsResponse } from '@/api/member'
 import { useAuthStore } from '@/store/authStore'
 import type { EmailVerifyLocationState } from '@/pages/EmailVerificationPage'
 
@@ -10,10 +11,12 @@ function Toggle({
   checked,
   onChange,
   ariaLabel,
+  disabled,
 }: {
   checked: boolean
   onChange: () => void
   ariaLabel: string
+  disabled?: boolean
 }) {
   return (
     <button
@@ -22,9 +25,10 @@ function Toggle({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={onChange}
+      disabled={disabled}
       className={`relative h-8 w-14 rounded-full transition-colors ${
         checked ? 'bg-primary' : 'bg-primary/10'
-      }`}
+      } ${disabled ? 'opacity-50' : ''}`}
     >
       <span
         className={`absolute top-1 left-1 h-6 w-6 rounded-full bg-background shadow-sm transition-transform ${
@@ -86,6 +90,16 @@ function LinkRow({ title, description, onClick, noBorder = false }: LinkRowProps
   )
 }
 
+/**
+ * 설정 페이지.
+ *
+ * 마운트 시 `GET /api/v1/users/me/settings`로 토글 초기값을 로드하고,
+ * 토글 변경 시 `PATCH /api/v1/users/me/settings`로 낙관적 업데이트.
+ * 실패 시 이전 값으로 롤백.
+ *
+ * `authProvider`는 로그인 시점에 authStore에 저장되며,
+ * Google 사용자는 비밀번호 변경을 숨기고 "Google 연동 중"을 표시.
+ */
 export default function SettingsPage() {
   const navigate = useNavigate()
   const clearAuth = useAuthStore(state => state.clearAuth)
@@ -94,15 +108,70 @@ export default function SettingsPage() {
   const [isSendingVerification, setIsSendingVerification] = useState(false)
   const [verificationError, setVerificationError] = useState<string | null>(null)
 
+  const [settings, setSettings] = useState<SettingsResponse | null>(null)
+  const [isSettingsLoading, setIsSettingsLoading] = useState(true)
+  const [settingsError, setSettingsError] = useState(false)
+  const [updatingKeys, setUpdatingKeys] = useState<Set<string>>(new Set())
+
+  const isGoogleUser = user?.authProvider === 'GOOGLE'
+
+  const loadSettings = async (signal?: AbortSignal) => {
+    setIsSettingsLoading(true)
+    setSettingsError(false)
+    try {
+      const result = await getSettings(signal)
+      if (signal?.aborted) return
+      setSettings(result)
+    } catch {
+      if (signal?.aborted) return
+      setSettingsError(true)
+    } finally {
+      if (!signal?.aborted) setIsSettingsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const controller = new AbortController()
+    loadSettings(controller.signal)
+    return () => controller.abort()
+  }, [])
+
+  /**
+   * 토글 변경 핸들러. 낙관적으로 즉시 UI 반영 후 API 호출.
+   * 실패 시 이전 설정으로 롤백. 개별 필드별 잠금으로 여러 토글을
+   * 빠르게 연속 변경해도 각각 독립적으로 처리됨.
+   */
+  const handleToggle = async (patch: Partial<SettingsResponse>) => {
+    if (!settings) return
+    const keys = Object.keys(patch)
+    if (keys.some(k => updatingKeys.has(k))) return
+    const prev = settings
+    setSettings({ ...settings, ...patch })
+    setUpdatingKeys(prev => {
+      const next = new Set(prev)
+      keys.forEach(k => next.add(k))
+      return next
+    })
+    try {
+      const result = await updateSettings(patch)
+      setSettings(result)
+    } catch {
+      setSettings(prev)
+    } finally {
+      setUpdatingKeys(prev => {
+        const next = new Set(prev)
+        keys.forEach(k => next.delete(k))
+        return next
+      })
+    }
+  }
+
   const handleLogout = async () => {
     if (isLoggingOut) return
     setIsLoggingOut(true)
     try {
       await logout()
     } catch (error) {
-      // TODO: [코드 리뷰 LOW] 프로덕션에서 console.error 잔류 이슈
-      // 공용 토스트/알림 시스템 도입 후 console.error 대신 사용자 피드백으로 교체하거나,
-      // 로그아웃은 실패해도 UX상 무조건 성공으로 처리하므로 로깅 자체를 제거할 것
       console.error('로그아웃 API 호출 실패:', error)
     } finally {
       clearAuth()
@@ -126,12 +195,6 @@ export default function SettingsPage() {
       setIsSendingVerification(false)
     }
   }
-
-  const [likeAlert, setLikeAlert] = useState(true)
-  const [commentAlert, setCommentAlert] = useState(true)
-  const [newFollowerAlert, setNewFollowerAlert] = useState(true)
-  const [followingReviewAlert, setFollowingReviewAlert] = useState(false)
-  const [libraryPublic, setLibraryPublic] = useState(true)
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -173,47 +236,74 @@ export default function SettingsPage() {
         <section className="px-5 pt-6">
           <h2 className="mb-3 text-lg font-bold text-primary/80">알림 설정</h2>
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
-            <SettingRow
-              title="좋아요"
-              right={
-                <Toggle
-                  checked={likeAlert}
-                  onChange={() => setLikeAlert(prev => !prev)}
-                  ariaLabel="좋아요 알림"
+            {isSettingsLoading && !settingsError ? (
+              <div className="px-5 py-8 text-center text-sm text-muted-foreground">
+                설정을 불러오는 중...
+              </div>
+            ) : settings ? (
+              <>
+                <SettingRow
+                  title="좋아요"
+                  right={
+                    <Toggle
+                      checked={settings.likeEnabled}
+                      onChange={() => handleToggle({ likeEnabled: !settings.likeEnabled })}
+                      ariaLabel="좋아요 알림"
+                      disabled={updatingKeys.has('likeEnabled')}
+                    />
+                  }
                 />
-              }
-            />
-            <SettingRow
-              title="댓글"
-              right={
-                <Toggle
-                  checked={commentAlert}
-                  onChange={() => setCommentAlert(prev => !prev)}
-                  ariaLabel="댓글 알림"
+                <SettingRow
+                  title="댓글"
+                  right={
+                    <Toggle
+                      checked={settings.commentEnabled}
+                      onChange={() => handleToggle({ commentEnabled: !settings.commentEnabled })}
+                      ariaLabel="댓글 알림"
+                      disabled={updatingKeys.has('commentEnabled')}
+                    />
+                  }
                 />
-              }
-            />
-            <SettingRow
-              title="새 팔로워"
-              right={
-                <Toggle
-                  checked={newFollowerAlert}
-                  onChange={() => setNewFollowerAlert(prev => !prev)}
-                  ariaLabel="새 팔로워 알림"
+                <SettingRow
+                  title="새 팔로워"
+                  right={
+                    <Toggle
+                      checked={settings.followEnabled}
+                      onChange={() => handleToggle({ followEnabled: !settings.followEnabled })}
+                      ariaLabel="새 팔로워 알림"
+                      disabled={updatingKeys.has('followEnabled')}
+                    />
+                  }
                 />
-              }
-            />
-            <SettingRow
-              title="팔로잉 새 감상"
-              noBorder
-              right={
-                <Toggle
-                  checked={followingReviewAlert}
-                  onChange={() => setFollowingReviewAlert(prev => !prev)}
-                  ariaLabel="팔로잉 새 감상 알림"
+                <SettingRow
+                  title="팔로잉 새 감상"
+                  noBorder
+                  right={
+                    <Toggle
+                      checked={settings.followingReviewEnabled}
+                      onChange={() =>
+                        handleToggle({
+                          followingReviewEnabled: !settings.followingReviewEnabled,
+                        })
+                      }
+                      ariaLabel="팔로잉 새 감상 알림"
+                      disabled={updatingKeys.has('followingReviewEnabled')}
+                    />
+                  }
                 />
-              }
-            />
+              </>
+            ) : (
+              <div className="flex flex-col items-center gap-3 px-5 py-8">
+                <p className="text-sm text-muted-foreground">설정을 불러오지 못했습니다</p>
+                <button
+                  type="button"
+                  onClick={() => loadSettings()}
+                  className="rounded-lg bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+                >
+                  다시 시도
+                </button>
+              </div>
+            )}
           </div>
         </section>
 
@@ -226,11 +316,21 @@ export default function SettingsPage() {
               description="다른 사용자가 내 서재를 방문할 수 있습니다."
               noBorder
               right={
-                <Toggle
-                  checked={libraryPublic}
-                  onChange={() => setLibraryPublic(prev => !prev)}
-                  ariaLabel="서재 공개"
-                />
+                settings ? (
+                  <Toggle
+                    checked={settings.libraryVisibility === 'PUBLIC'}
+                    onChange={() =>
+                      handleToggle({
+                        libraryVisibility:
+                          settings.libraryVisibility === 'PUBLIC' ? 'PRIVATE' : 'PUBLIC',
+                      })
+                    }
+                    ariaLabel="서재 공개"
+                    disabled={updatingKeys.has('libraryVisibility') || isSettingsLoading}
+                  />
+                ) : (
+                  <Toggle checked={false} onChange={() => {}} ariaLabel="서재 공개" disabled />
+                )
               }
             />
           </div>
@@ -256,8 +356,14 @@ export default function SettingsPage() {
         <section className="px-5 pt-8">
           <h2 className="mb-3 text-lg font-bold text-primary/80">계정 관리</h2>
           <div className="overflow-hidden rounded-[28px] bg-card shadow-sm">
-            <LinkRow title="비밀번호 변경" onClick={() => navigate('/settings/password')} />
-            <SettingRow title="연동 소셜 계정" description="Google 연동 중" noBorder />
+            {!isGoogleUser && (
+              <LinkRow title="비밀번호 변경" onClick={() => navigate('/settings/password')} />
+            )}
+            <SettingRow
+              title="연동 소셜 계정"
+              description={isGoogleUser ? 'Google 연동 중' : '이메일 계정'}
+              noBorder
+            />
           </div>
         </section>
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -131,6 +131,7 @@ export default function SignupPage() {
           email: result.user.email,
           bio: result.user.bio,
           emailVerified: result.user.emailVerified,
+          authProvider: 'EMAIL',
         },
         result.accessToken
       )

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -9,6 +9,7 @@ interface User {
   bio?: string | null
   emailVerified?: boolean
   onboardingCompleted?: boolean
+  authProvider?: 'EMAIL' | 'GOOGLE'
 }
 
 interface AuthState {


### PR DESCRIPTION
  - getSettings/updateSettings API 함수 추가 (GET/PATCH /api/v1/users/me/settings)
  - 알림 토글 4개 + 서재 공개 토글: 백엔드 연동 (낙관적 업데이트 + 실패 롤백)
  - 개별 필드 잠금(updatingKeys Set)으로 빠른 연속 토글 독립 처리
  - authStore에 authProvider 필드 추가 (로그인/가입 시점에 EMAIL/GOOGLE 판별)
  - 연동 소셜 계정: authProvider에 따라 동적 표시
  - 비밀번호 변경: Google 사용자는 숨김
  - 설정 로드 실패 시 "다시 시도" 버튼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 설정이 서버와 실시간으로 동기화됩니다
  * 인증 방식(이메일/구글)에 따라 설정 화면이 자동으로 조정됩니다
  * 설정 변경 시 즉시 적용되며, 오류 발생 시 자동으로 이전 상태로 복구됩니다
  * 구글 로그인 사용자는 비밀번호 변경 옵션이 숨겨집니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->