### PR TITLE
  fix: FOLLOWING_REVIEW 알림 타입 누락으로 undefined 참조 에러 수정 (#152)

### DIFF
--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -8,9 +8,16 @@ import { type ApiResponse, normalizeAxiosError, parseApiResponse } from './_help
  * - `COMMENT`: 내 감상에 댓글 (target: reviewId + commentId)
  * - `COMMENT_LIKE`: 내 댓글에 좋아요 (target: reviewId + commentId)
  * - `FOLLOW`: 나를 팔로우 (target: actor.userId)
+ * - `FOLLOWING_REVIEW`: 내가 팔로우하는 사용자가 새 감상 작성 (target: reviewId)
  * - `SYSTEM`: 시스템 메시지 (actor 없음, 이동 없음)
  */
-export type NotificationType = 'REVIEW_LIKE' | 'COMMENT' | 'COMMENT_LIKE' | 'FOLLOW' | 'SYSTEM'
+export type NotificationType =
+  | 'REVIEW_LIKE'
+  | 'COMMENT'
+  | 'COMMENT_LIKE'
+  | 'FOLLOW'
+  | 'FOLLOWING_REVIEW'
+  | 'SYSTEM'
 
 export interface NotificationActor {
   userId: number

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -23,6 +23,7 @@ const typeIcon: Record<NotificationType, { icon: string; bg: string }> = {
   COMMENT: { icon: 'chat_bubble', bg: 'bg-blue-500' },
   COMMENT_LIKE: { icon: 'favorite', bg: 'bg-red-500' },
   FOLLOW: { icon: 'person_add', bg: 'bg-emerald-500' },
+  FOLLOWING_REVIEW: { icon: 'rate_review', bg: 'bg-primary' },
   SYSTEM: { icon: 'campaign', bg: 'bg-muted-foreground' },
 }
 
@@ -44,6 +45,8 @@ function buildNotificationMessage(n: NotificationItem): string {
       return '님이 회원님의 댓글에 좋아요를 눌렀습니다.'
     case 'FOLLOW':
       return '님이 회원님을 팔로우하기 시작했습니다.'
+    case 'FOLLOWING_REVIEW':
+      return '님이 새 감상을 작성했습니다.'
     case 'SYSTEM':
       return '새로운 시스템 알림이 있습니다.'
   }
@@ -65,6 +68,8 @@ function resolveDestination(n: NotificationItem): string | null {
       return n.reviewId != null ? `/review/${n.reviewId}#comments` : null
     case 'FOLLOW':
       return n.actor ? `/user/${n.actor.userId}` : null
+    case 'FOLLOWING_REVIEW':
+      return n.reviewId != null ? `/review/${n.reviewId}` : null
     case 'SYSTEM':
       return null
   }

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -23,7 +23,7 @@ const typeIcon: Record<NotificationType, { icon: string; bg: string }> = {
   COMMENT: { icon: 'chat_bubble', bg: 'bg-blue-500' },
   COMMENT_LIKE: { icon: 'favorite', bg: 'bg-red-500' },
   FOLLOW: { icon: 'person_add', bg: 'bg-emerald-500' },
-  FOLLOWING_REVIEW: { icon: 'rate_review', bg: 'bg-primary' },
+  FOLLOWING_REVIEW: { icon: 'rate_review', bg: 'bg-violet-500' },
   SYSTEM: { icon: 'campaign', bg: 'bg-muted-foreground' },
 }
 
@@ -69,6 +69,7 @@ function resolveDestination(n: NotificationItem): string | null {
     case 'FOLLOW':
       return n.actor ? `/user/${n.actor.userId}` : null
     case 'FOLLOWING_REVIEW':
+      // reviewId는 항상 존재해야 함; null이면 백엔드 이상
       return n.reviewId != null ? `/review/${n.reviewId}` : null
     case 'SYSTEM':
       return null


### PR DESCRIPTION
  - NotificationType 유니온에 'FOLLOWING_REVIEW' 추가
  - typeIcon Record에 rate_review 아이콘 + primary 배경색 추가
  - buildNotificationMessage에 "님이 새 감상을 작성했습니다." 케이스 추가
  - resolveDestination에 /review/${reviewId} 이동 케이스 추가