### PR TITLE
  fix: Wisdom Tower 책 클릭 시 서재 상세 페이지로 이동 (#156)

### DIFF
--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import BottomNav from '@/components/layout/BottomNav'
 import { getMyProfile, type MyProfile } from '@/api/member'
@@ -386,9 +386,10 @@ export default function MyProfilePage() {
                 const palette = TOWER_PALETTE[index % TOWER_PALETTE.length]
                 const width = TOWER_WIDTHS[index % TOWER_WIDTHS.length]
                 return (
-                  <div
+                  <Link
                     key={book.libraryBookId}
-                    className="relative h-[58px]"
+                    to={`/library/${book.libraryBookId}`}
+                    className="relative block h-[58px] transition-opacity hover:opacity-80"
                     style={{
                       width: `${width}%`,
                       marginTop: index === 0 ? 0 : '-2px',
@@ -400,7 +401,7 @@ export default function MyProfilePage() {
                     >
                       <span className="truncate px-4">{book.title}</span>
                     </div>
-                  </div>
+                  </Link>
                 )
               })}
             </div>


### PR DESCRIPTION
  - 책 블록을 div → Link로 교체, /library/${libraryBookId}로 이동
  - hover 시 opacity 효과 추가 (클릭 가능 시각적 힌트)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로필 페이지의 지혜의 탑 도서를 클릭 가능한 링크로 변경하여 도서관 상세 페이지로 바로 이동할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->