### PR TITLE
  fix: 테스트 후 발견된 UI/UX 수정 사항 일괄 반영 (#160)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,6 @@
 import apiClient from './client'
 import { ApiResponse, normalizeAxiosError } from './_helpers'
+import { useAuthStore } from '@/store/authStore'
 
 export interface LoginRequest {
   email: string
@@ -189,8 +190,11 @@ export async function resendEmailCode(email: string): Promise<void> {
 }
 
 export async function logout(): Promise<void> {
+  const token = useAuthStore.getState().accessToken
   try {
-    await apiClient.post('/api/v1/auth/logout')
+    await apiClient.post('/api/v1/auth/logout', null, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
   } catch (error) {
     throw normalizeAxiosError(error, '로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.')
   }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,5 @@
 import apiClient from './client'
 import { ApiResponse, normalizeAxiosError } from './_helpers'
-import { useAuthStore } from '@/store/authStore'
 
 export interface LoginRequest {
   email: string
@@ -189,11 +188,10 @@ export async function resendEmailCode(email: string): Promise<void> {
   }
 }
 
-export async function logout(): Promise<void> {
-  const token = useAuthStore.getState().accessToken
+export async function logout(accessToken?: string | null): Promise<void> {
   try {
     await apiClient.post('/api/v1/auth/logout', null, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
     })
   } catch (error) {
     throw normalizeAxiosError(error, '로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.')

--- a/src/components/common/PopupBanner.tsx
+++ b/src/components/common/PopupBanner.tsx
@@ -67,16 +67,12 @@ export default function PopupBanner({
   if (!visible) return null
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={close}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div
         role="dialog"
         aria-modal="true"
         aria-label={imageAlt}
         className="relative w-[85vw] max-w-xs overflow-hidden rounded-2xl bg-card shadow-xl"
-        onClick={e => e.stopPropagation()}
       >
         <button
           ref={closeButtonRef}

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,17 @@
+const CAROUSEL_SEEN_KEY = 'onboarding-carousel-seen'
+
+export function isCarouselSeen(): boolean {
+  try {
+    return !!localStorage.getItem(CAROUSEL_SEEN_KEY)
+  } catch {
+    return false
+  }
+}
+
+export function markCarouselSeen(): void {
+  try {
+    localStorage.setItem(CAROUSEL_SEEN_KEY, 'true')
+  } catch {
+    /* Safari 프라이빗 모드 등 */
+  }
+}

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { googleLogin } from '@/api/auth'
+import { isCarouselSeen } from '@/lib/onboarding'
 
 export default function AuthCallbackPage() {
   const [searchParams] = useSearchParams()
@@ -55,14 +56,7 @@ export default function AuthCallbackPage() {
           },
           result.accessToken
         )
-        const carouselSeen = (() => {
-          try {
-            return !!localStorage.getItem('onboarding-carousel-seen')
-          } catch {
-            return false
-          }
-        })()
-        navigate(result.user.onboardingCompleted && carouselSeen ? '/' : '/onboarding', {
+        navigate(result.user.onboardingCompleted && isCarouselSeen() ? '/' : '/onboarding', {
           replace: true,
         })
       })

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -55,7 +55,16 @@ export default function AuthCallbackPage() {
           },
           result.accessToken
         )
-        navigate(result.user.onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
+        const carouselSeen = (() => {
+          try {
+            return !!localStorage.getItem('onboarding-carousel-seen')
+          } catch {
+            return false
+          }
+        })()
+        navigate(result.user.onboardingCompleted && carouselSeen ? '/' : '/onboarding', {
+          replace: true,
+        })
       })
       .catch(err => {
         setErrorMessage(err instanceof Error ? err.message : 'Google 로그인에 실패했습니다.')

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -586,8 +586,8 @@ export default function BookSearchPage() {
             }
             className="h-full min-w-0 flex-1 border-none bg-transparent px-3 text-base font-normal outline-none placeholder:text-primary/40 focus:ring-0"
           />
-          {/* 바코드 스캐너는 도서 탭에서만 의미 있음 */}
-          {activeTab === 'book' && (
+          {/* 바코드 스캐너: 도서/전체 탭에서 표시. ISBN 감지 시 자동으로 도서 탭 전환 */}
+          {(activeTab === 'book' || activeTab === 'all') && (
             <button
               type="button"
               onClick={() => setIsScannerOpen(true)}

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -101,7 +101,8 @@ export default function EmailVerificationPage() {
           }
         }
         setCode(['', '', '', '', '', ''])
-        navigate('/', { replace: true })
+        const onboardingDone = useAuthStore.getState().user?.onboardingCompleted
+        navigate(onboardingDone === false ? '/onboarding' : '/', { replace: true })
       } else {
         setErrorMessage('인증 코드가 올바르지 않습니다. 다시 확인해주세요.')
       }

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { verifyEmail, resendEmailCode } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
+import { isCarouselSeen } from '@/lib/onboarding'
 
 // 진입 경로별로 EmailVerificationPage가 다른 탈출 UI를 노출하기 위한 식별자.
 // sender(SignupPage/SettingsPage)와 receiver(이 파일)가 동일한 union을 공유해 오타 시 컴파일 단계에서 차단.
@@ -102,7 +103,7 @@ export default function EmailVerificationPage() {
         }
         setCode(['', '', '', '', '', ''])
         const onboardingDone = useAuthStore.getState().user?.onboardingCompleted
-        navigate(onboardingDone === false ? '/onboarding' : '/', { replace: true })
+        navigate(onboardingDone && isCarouselSeen() ? '/' : '/onboarding', { replace: true })
       } else {
         setErrorMessage('인증 코드가 올바르지 않습니다. 다시 확인해주세요.')
       }

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -277,11 +277,12 @@ export default function HomeFeedPage() {
       {/* Header */}
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="flex items-center justify-between px-4 py-3">
+          <div className="w-10" />
           <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
           <Link
             to="/notifications"
             aria-label={unreadCount > 0 ? `알림 (미읽음 ${unreadCount}개)` : '알림'}
-            className="relative rounded-full p-2 transition-colors hover:bg-primary/5"
+            className="relative flex w-10 items-center justify-center rounded-full p-2 transition-colors hover:bg-primary/5"
           >
             <span className="material-symbols-outlined text-primary">notifications</span>
             {unreadCount > 0 && (

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -65,7 +65,16 @@ export default function LoginPage() {
         },
         result.accessToken
       )
-      navigate(result.user.onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
+      const carouselSeen = (() => {
+        try {
+          return !!localStorage.getItem('onboarding-carousel-seen')
+        } catch {
+          return false
+        }
+      })()
+      navigate(result.user.onboardingCompleted && carouselSeen ? '/' : '/onboarding', {
+        replace: true,
+      })
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '로그인에 실패했습니다.')
     } finally {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/store/authStore'
 import { login, getGoogleLoginUrl } from '@/api/auth'
+import { isCarouselSeen } from '@/lib/onboarding'
 
 const loginSchema = z.object({
   email: z.string().email('올바른 이메일을 입력하세요'),
@@ -65,14 +66,7 @@ export default function LoginPage() {
         },
         result.accessToken
       )
-      const carouselSeen = (() => {
-        try {
-          return !!localStorage.getItem('onboarding-carousel-seen')
-        } catch {
-          return false
-        }
-      })()
-      navigate(result.user.onboardingCompleted && carouselSeen ? '/' : '/onboarding', {
+      navigate(result.user.onboardingCompleted && isCarouselSeen() ? '/' : '/onboarding', {
         replace: true,
       })
     } catch (error) {

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -239,13 +239,14 @@ export default function MyLibraryPage() {
       {/* Header */}
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="flex items-center justify-between px-4 py-4">
+          <div className="w-10" />
           <h1 className="text-2xl font-bold">내 서재</h1>
           <button
             type="button"
             onClick={toggleSearch}
             aria-label={isSearchOpen ? '서재 검색 닫기' : '서재 내 검색'}
             aria-expanded={isSearchOpen}
-            className="rounded-full p-2 transition-colors hover:bg-primary/10"
+            className="flex w-10 items-center justify-center rounded-full p-2 transition-colors hover:bg-primary/10"
           >
             <span className="material-symbols-outlined text-primary">
               {isSearchOpen ? 'close' : 'search'}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
+import { isCarouselSeen, markCarouselSeen } from '@/lib/onboarding'
 import { useAuthStore } from '@/store/authStore'
 
 const slides = [
@@ -47,15 +48,7 @@ export default function OnboardingPage() {
   const navigate = useNavigate()
   const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
 
-  const carouselSeen = (() => {
-    try {
-      return !!localStorage.getItem('onboarding-carousel-seen')
-    } catch {
-      return false
-    }
-  })()
-
-  if (carouselSeen) {
+  if (isCarouselSeen()) {
     return <Navigate to={onboardingCompleted ? '/' : '/onboarding/genre'} replace />
   }
 
@@ -65,11 +58,7 @@ export default function OnboardingPage() {
    * 캐시 초기화 시 localStorage가 지워지므로 캐러셀이 다시 노출된다.
    */
   const finishCarousel = () => {
-    try {
-      localStorage.setItem('onboarding-carousel-seen', 'true')
-    } catch {
-      /* Safari 프라이빗 모드 등 */
-    }
+    markCarouselSeen()
     navigate(onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
   }
 

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -47,17 +47,37 @@ export default function OnboardingPage() {
   const navigate = useNavigate()
   const onboardingCompleted = useAuthStore(state => state.user?.onboardingCompleted)
 
-  if (onboardingCompleted) return <Navigate to="/" replace />
+  const carouselSeen = (() => {
+    try {
+      return !!localStorage.getItem('onboarding-carousel-seen')
+    } catch {
+      return false
+    }
+  })()
 
-  const completeOnboarding = () => {
-    navigate('/onboarding/genre', { replace: true })
+  if (carouselSeen) {
+    return <Navigate to={onboardingCompleted ? '/' : '/onboarding/genre'} replace />
+  }
+
+  /**
+   * 캐러셀 완료 후 localStorage에 "봤음" 플래그를 저장하고,
+   * onboardingCompleted(백엔드) 값에 따라 장르 선택 또는 홈으로 분기.
+   * 캐시 초기화 시 localStorage가 지워지므로 캐러셀이 다시 노출된다.
+   */
+  const finishCarousel = () => {
+    try {
+      localStorage.setItem('onboarding-carousel-seen', 'true')
+    } catch {
+      /* Safari 프라이빗 모드 등 */
+    }
+    navigate(onboardingCompleted ? '/' : '/onboarding/genre', { replace: true })
   }
 
   const handleNext = () => {
     if (step < slides.length - 1) {
       setStep(prev => prev + 1)
     } else {
-      completeOnboarding()
+      finishCarousel()
     }
   }
 
@@ -69,7 +89,7 @@ export default function OnboardingPage() {
       {/* Header */}
       <header className="flex items-center justify-between p-6">
         <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
-        <button onClick={completeOnboarding} className="text-sm font-medium text-primary/60">
+        <button onClick={finishCarousel} className="text-sm font-medium text-primary/60">
           건너뛰기
         </button>
       </header>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -180,7 +180,7 @@ export default function SettingsPage() {
     if (isLoggingOut) return
     setIsLoggingOut(true)
     try {
-      await logout()
+      await logout(useAuthStore.getState().accessToken)
     } catch {
       // 로그아웃 API 실패는 비치명적 — finally에서 로컬 세션 정리 보장
     } finally {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -181,8 +181,8 @@ export default function SettingsPage() {
     setIsLoggingOut(true)
     try {
       await logout()
-    } catch (error) {
-      console.error('로그아웃 API 호출 실패:', error)
+    } catch {
+      // 로그아웃 API 실패는 비치명적 — finally에서 로컬 세션 정리 보장
     } finally {
       clearAuth()
       navigate('/login', { replace: true })

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -131,6 +131,7 @@ export default function SignupPage() {
           email: result.user.email,
           bio: result.user.bio,
           emailVerified: result.user.emailVerified,
+          onboardingCompleted: false,
           authProvider: 'EMAIL',
         },
         result.accessToken


### PR DESCRIPTION
  - PopupBanner 오버레이 클릭 시 닫힘 비활성화 (버튼으로만 닫기)
  - 검색 전체 탭에서도 바코드 스캐너 아이콘 표시
  - HomeFeedPage/MyLibraryPage 헤더 타이틀 가운데 정렬 통일
  - 온보딩 캐러셀(localStorage)과 장르 선택(백엔드 플래그) 분리
  - SignupPage에 onboardingCompleted: false 추가
  - EmailVerificationPage/LoginPage/AuthCallbackPage 온보딩 라우팅 분기
  - 로그아웃 API에 액세스 토큰 명시 첨부 및 console.error 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 바코드 스캐너를 더 많은 탭에서 사용할 수 있습니다.

* **버그 수정**
  * 팝업 배너의 닫기 동작을 개선했습니다.
  * 로그아웃 시 인증 헤더를 포함하도록 개선했습니다.
  * 로그아웃 오류 처리를 단순화했습니다.

* **개선 사항**
  * 온보딩 진행 상황을 기반으로 한 로그인 후 네비게이션이 개선되었습니다.
  * 로컬 저장소를 활용한 온보딩 흐름이 최적화되었습니다.

* **UI/UX**
  * 헤더 레이아웃이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->