### PR TITLE
fix: 프로필 페이지 감상 수·리뷰 목록 재방문 시 갱신 (#162)

### DIFF
--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import BottomNav from '@/components/layout/BottomNav'
 import { getMyProfile, type MyProfile } from '@/api/member'
@@ -40,6 +40,7 @@ const categoryStats = [
  */
 export default function MyProfilePage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [profile, setProfile] = useState<MyProfile | null>(null)
   const [wisdomTower, setWisdomTower] = useState<WisdomTowerResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -136,7 +137,7 @@ export default function MyProfilePage() {
     })()
 
     return () => controller.abort()
-  }, [])
+  }, [location.key])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -167,7 +168,7 @@ export default function MyProfilePage() {
       controller.abort()
       loadMoreControllerRef.current?.abort()
     }
-  }, [])
+  }, [location.key])
 
   const handleLoadMoreReviews = async () => {
     if (isReviewsLoadingMore || !hasMoreReviews) return


### PR DESCRIPTION
- 프로필 fetch useEffect 의존성에 location.key 추가
- 리뷰 타임라인 fetch useEffect에도 동일 적용
- 페이지 진입 시마다 최신 reviewCount + 리뷰 목록 자동 갱신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로필 페이지 내비게이션 시 프로필 정보 및 리뷰 데이터가 올바르게 새로고침되도록 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->