### PR TITLE
  feat: 검색 상태 유지 + 프로필 장르 통계 제거 (#164)

### DIFF
--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -7,9 +7,7 @@ import UserSearchCard from '@/components/common/UserSearchCard'
 import { getBookByIsbn, searchBooks, type BookDetail, type BookSummary } from '@/api/book'
 import { searchAll, type BookSearchItem, type UserSearchItem, type SearchType } from '@/api/search'
 import { cn } from '@/lib/utils'
-import { useSearchStore } from '@/store/searchStore'
-
-const RECENT_KEYWORDS_KEY = 'shelfeed-recent-keywords'
+import { useSearchStore, RECENT_KEYWORDS_KEY } from '@/store/searchStore'
 const MAX_RECENT_KEYWORDS = 10
 const ALL_TAB_PREVIEW_COUNT = 3
 
@@ -101,16 +99,15 @@ export default function BookSearchPage() {
   const [recentKeywords, setRecentKeywords] = useState<string[]>(() => loadRecentKeywords())
 
   const cached = useRef(useSearchStore.getState()).current
+  const urlQuery = searchParams.get('q')
+  const urlTabRaw = searchParams.get('tab')
+  const urlTab = isSearchType(urlTabRaw) ? urlTabRaw : null
+  const hasUrlParams = urlQuery !== null || urlTab !== null
   const hasCache = cached.query.length > 0
-  const restoredFromCache = useRef(hasCache)
+  const restoredFromCache = useRef(hasCache && !hasUrlParams)
 
-  const initialQuery = hasCache ? cached.query : (searchParams.get('q') ?? '')
-  const initialTab = hasCache
-    ? cached.activeTab
-    : (() => {
-        const t = searchParams.get('tab')
-        return isSearchType(t) ? t : 'all'
-      })()
+  const initialQuery = urlQuery ?? (hasCache ? cached.query : '')
+  const initialTab: SearchType = urlTab ?? (hasCache ? cached.activeTab : 'all')
 
   const [searchQuery, setSearchQuery] = useState(initialQuery)
   const [activeTab, setActiveTab] = useState<SearchType>(initialTab)

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -7,6 +7,7 @@ import UserSearchCard from '@/components/common/UserSearchCard'
 import { getBookByIsbn, searchBooks, type BookDetail, type BookSummary } from '@/api/book'
 import { searchAll, type BookSearchItem, type UserSearchItem, type SearchType } from '@/api/search'
 import { cn } from '@/lib/utils'
+import { useSearchStore } from '@/store/searchStore'
 
 const RECENT_KEYWORDS_KEY = 'shelfeed-recent-keywords'
 const MAX_RECENT_KEYWORDS = 10
@@ -98,39 +99,46 @@ export default function BookSearchPage() {
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [recentKeywords, setRecentKeywords] = useState<string[]>(() => loadRecentKeywords())
-  const initialQuery = searchParams.get('q') ?? ''
-  const initialTab = (() => {
-    const t = searchParams.get('tab')
-    return isSearchType(t) ? t : 'all'
-  })()
+
+  const cached = useRef(useSearchStore.getState()).current
+  const hasCache = cached.query.length > 0
+  const restoredFromCache = useRef(hasCache)
+
+  const initialQuery = hasCache ? cached.query : (searchParams.get('q') ?? '')
+  const initialTab = hasCache
+    ? cached.activeTab
+    : (() => {
+        const t = searchParams.get('tab')
+        return isSearchType(t) ? t : 'all'
+      })()
 
   const [searchQuery, setSearchQuery] = useState(initialQuery)
   const [activeTab, setActiveTab] = useState<SearchType>(initialTab)
   const [isScannerOpen, setIsScannerOpen] = useState(false)
 
   // 도서 탭 (searchBooks 응답) — 백엔드가 page 기반 페이지네이션으로 변경됨
-  const [bookResults, setBookResults] = useState<BookSummary[]>([])
-  const [bookNextPage, setBookNextPage] = useState<number | null>(null)
-  const [bookHasNext, setBookHasNext] = useState(false)
+  const [bookResults, setBookResults] = useState<BookSummary[]>(cached.bookResults)
+  const [bookNextPage, setBookNextPage] = useState<number | null>(cached.bookNextPage)
+  const [bookHasNext, setBookHasNext] = useState(cached.bookHasNext)
   const [isBookLoading, setIsBookLoading] = useState(false)
   const [isBookLoadingMore, setIsBookLoadingMore] = useState(false)
   const [bookErrorMessage, setBookErrorMessage] = useState<string | null>(null)
   const [bookLoadMoreError, setBookLoadMoreError] = useState<string | null>(null)
 
   // 유저 탭 (searchAll type=user 응답)
-  const [userResults, setUserResults] = useState<UserSearchItem[]>([])
-  const [userNextCursor, setUserNextCursor] = useState<number | null>(null)
-  const [userHasNext, setUserHasNext] = useState(false)
+  const [userResults, setUserResults] = useState<UserSearchItem[]>(cached.userResults)
+  const [userNextCursor, setUserNextCursor] = useState<number | null>(cached.userNextCursor)
+  const [userHasNext, setUserHasNext] = useState(cached.userHasNext)
   const [isUserLoading, setIsUserLoading] = useState(false)
   const [isUserLoadingMore, setIsUserLoadingMore] = useState(false)
   const [userErrorMessage, setUserErrorMessage] = useState<string | null>(null)
   const [userLoadMoreError, setUserLoadMoreError] = useState<string | null>(null)
 
   // 전체 탭 (searchAll type=all 응답 — 미리보기용, 페이징 없음)
-  const [allBooks, setAllBooks] = useState<BookSearchItem[]>([])
-  const [allUsers, setAllUsers] = useState<UserSearchItem[]>([])
-  const [allBooksHasMore, setAllBooksHasMore] = useState(false)
-  const [allUsersHasMore, setAllUsersHasMore] = useState(false)
+  const [allBooks, setAllBooks] = useState<BookSearchItem[]>(cached.allBooks)
+  const [allUsers, setAllUsers] = useState<UserSearchItem[]>(cached.allUsers)
+  const [allBooksHasMore, setAllBooksHasMore] = useState(cached.allBooksHasMore)
+  const [allUsersHasMore, setAllUsersHasMore] = useState(cached.allUsersHasMore)
   const [isAllLoading, setIsAllLoading] = useState(false)
   const [allErrorMessage, setAllErrorMessage] = useState<string | null>(null)
 
@@ -176,6 +184,41 @@ export default function BookSearchPage() {
     activeTab,
   }
 
+  const searchCacheRef = useRef({
+    query: searchQuery,
+    activeTab,
+    bookResults,
+    bookNextPage,
+    bookHasNext,
+    userResults,
+    userNextCursor,
+    userHasNext,
+    allBooks,
+    allUsers,
+    allBooksHasMore,
+    allUsersHasMore,
+  })
+  searchCacheRef.current = {
+    query: searchQuery,
+    activeTab,
+    bookResults,
+    bookNextPage,
+    bookHasNext,
+    userResults,
+    userNextCursor,
+    userHasNext,
+    allBooks,
+    allUsers,
+    allBooksHasMore,
+    allUsersHasMore,
+  }
+
+  useEffect(() => {
+    return () => {
+      useSearchStore.setState(searchCacheRef.current)
+    }
+  }, [])
+
   // ISBN13이면 자동 도서 탭으로 강제 — 바코드 스캐너 결과/사용자 직접 입력 모두 커버
   useEffect(() => {
     if (isIsbnMode && activeTab !== 'book') {
@@ -192,6 +235,7 @@ export default function BookSearchPage() {
   // deps에 넣으면 무한 루프가 발생. toString()으로 값 기반 비교.
   const searchParamsString = searchParams.toString()
   useEffect(() => {
+    if (restoredFromCache.current) return
     const urlQuery = searchParams.get('q') ?? ''
     const urlTabRaw = searchParams.get('tab')
     const urlTab: SearchType = isSearchType(urlTabRaw) ? urlTabRaw : 'all'
@@ -229,6 +273,7 @@ export default function BookSearchPage() {
 
   // 도서 탭 첫 페이지 fetch (검색어 변경 시 debounce)
   useEffect(() => {
+    if (restoredFromCache.current) return
     setIsBookLoadingMore(false)
     setBookLoadMoreError(null)
     bookMoreControllerRef.current?.abort()
@@ -290,6 +335,7 @@ export default function BookSearchPage() {
 
   // 유저 탭 첫 페이지 fetch
   useEffect(() => {
+    if (restoredFromCache.current) return
     setIsUserLoadingMore(false)
     setUserLoadMoreError(null)
     userMoreControllerRef.current?.abort()
@@ -344,6 +390,7 @@ export default function BookSearchPage() {
 
   // 전체 탭 fetch — books/users 두 섹션 미리보기, 페이징 없음
   useEffect(() => {
+    if (restoredFromCache.current) return
     if (!trimmedQuery || activeTab !== 'all') {
       if (!trimmedQuery) {
         setAllBooks([])
@@ -395,6 +442,12 @@ export default function BookSearchPage() {
       controller.abort()
     }
   }, [trimmedQuery, activeTab])
+
+  // 반드시 restoredFromCache를 참조하는 모든 effect 뒤에 선언할 것.
+  // React는 useEffect를 선언 순서대로 실행하므로 위 4개 effect가 먼저 skip된 후 플래그 해제.
+  useEffect(() => {
+    restoredFromCache.current = false
+  }, [])
 
   /**
    * 도서 탭 다음 페이지 로딩. observer 콜백과 retry 버튼이 공유 호출.

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -21,13 +21,6 @@ const TOWER_PALETTE = [
 
 const TOWER_WIDTHS = [92, 88, 90, 86, 91, 84, 89, 82, 87, 93, 85, 90, 88, 86, 91]
 
-// 카테고리 분포 — 백엔드 API 미구현으로 placeholder 유지
-const categoryStats = [
-  { label: '소설 60%', color: '#B9935A' },
-  { label: '에세이 25%', color: '#D3BE9E' },
-  { label: '인문 15%', color: '#EEE3D2' },
-]
-
 /**
  * 본인 프로필 페이지.
  *
@@ -35,8 +28,6 @@ const categoryStats = [
  * 1. `getMyProfile` — 프로필 정보 + authStore 동기화
  * 2. `getWisdomTower` — 완독 도서 스택(지혜의 탑) + 통계 카드 + 월별 독서량 파생
  * 3. `getMyReviews` — 공개 감상 타임라인
- *
- * 카테고리 분포 통계는 백엔드 API 미구현으로 mock placeholder 유지.
  */
 export default function MyProfilePage() {
   const navigate = useNavigate()
@@ -447,20 +438,6 @@ export default function MyProfilePage() {
                 <p className="text-sm text-muted-foreground">올해 독서 기록이 없습니다</p>
               </div>
             )}
-
-            {/* 카테고리 분포 — 백엔드 API 미구현, placeholder 유지 */}
-            <div className="mt-3 flex flex-wrap items-center justify-center gap-x-8 gap-y-3">
-              {categoryStats.map(item => (
-                <div key={item.label} className="flex items-center gap-2">
-                  <span
-                    className="inline-block h-3 w-3 rounded-full"
-                    style={{ backgroundColor: item.color }}
-                  />
-                  <span className="text-sm font-medium text-primary/65">{item.label}</span>
-                </div>
-              ))}
-              <span className="text-xs text-muted-foreground/50">(준비 중)</span>
-            </div>
           </div>
         </section>
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import BottomNav from '@/components/layout/BottomNav'
 import { logout, resendEmailCode } from '@/api/auth'
 import { getSettings, updateSettings, type SettingsResponse } from '@/api/member'
 import { useAuthStore } from '@/store/authStore'
+import { clearSearchCache } from '@/store/searchStore'
 import type { EmailVerifyLocationState } from '@/pages/EmailVerificationPage'
 
 function Toggle({
@@ -185,6 +186,7 @@ export default function SettingsPage() {
       // 로그아웃 API 실패는 비치명적 — finally에서 로컬 세션 정리 보장
     } finally {
       clearAuth()
+      clearSearchCache()
       navigate('/login', { replace: true })
     }
   }

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -38,6 +38,13 @@ const initialState: SearchState = {
 
 export const useSearchStore = create<SearchState>()(() => ({ ...initialState }))
 
+export const RECENT_KEYWORDS_KEY = 'shelfeed-recent-keywords'
+
 export function clearSearchCache() {
   useSearchStore.setState(initialState)
+  try {
+    localStorage.removeItem(RECENT_KEYWORDS_KEY)
+  } catch {
+    // private 모드 등 localStorage 접근 불가 시 무시
+  }
 }

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+import type { BookSummary } from '@/api/book'
+import type { BookSearchItem, SearchType, UserSearchItem } from '@/api/search'
+
+interface SearchState {
+  query: string
+  activeTab: SearchType
+  bookResults: BookSummary[]
+  bookNextPage: number | null
+  bookHasNext: boolean
+  userResults: UserSearchItem[]
+  userNextCursor: number | null
+  userHasNext: boolean
+  allBooks: BookSearchItem[]
+  allUsers: UserSearchItem[]
+  allBooksHasMore: boolean
+  allUsersHasMore: boolean
+}
+
+/**
+ * 검색 결과를 컴포넌트 unmount 이후에도 메모리에 보존하는 스토어.
+ * persist 미들웨어 없이 in-memory로만 유지 — 새로고침 시 자연스럽게 초기화.
+ */
+const initialState: SearchState = {
+  query: '',
+  activeTab: 'all',
+  bookResults: [],
+  bookNextPage: null,
+  bookHasNext: false,
+  userResults: [],
+  userNextCursor: null,
+  userHasNext: false,
+  allBooks: [],
+  allUsers: [],
+  allBooksHasMore: false,
+  allUsersHasMore: false,
+}
+
+export const useSearchStore = create<SearchState>()(() => ({ ...initialState }))
+
+export function clearSearchCache() {
+  useSearchStore.setState(initialState)
+}


### PR DESCRIPTION
  - Zustand in-memory 스토어로 검색 결과·탭·페이지네이션 탭 이동 간 보존
  - 마운트 시 캐시 복원, unmount 시 저장, 캐시 복원 시 불필요한 재검색 방지
  - 로그아웃 시 clearSearchCache() 호출로 사용자 간 데이터 격리
  - 프로필 장르 분포 mock 데이터(categoryStats) 및 관련 JSX 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검색 UI 상태를 브라우저 내에서 복원하고 저장하는 기능 추가

* **Improvements**
  * 초기 복원 기간 동안 불필요한 추가 요청을 억제해 불필요한 네트워크 호출 감소
  * 복원 후 URL 동기화 및 탭별 조회가 정상적으로 재개되도록 동작 개선
  * 프로필 페이지에서 미사용 UI 제거로 화면 단순화

* **Bug Fixes**
  * 로그아웃 시 검색 관련 캐시가 자동으로 정리되도록 수정

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/165)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/165)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->