### PR TITLE
  feat: 감상 카드 프로필 클릭 시 유저 프로필 이동 (#170)

### DIFF
--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -224,15 +224,13 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
     </div>
   )
 
-  const navigate = useNavigate()
-
   return (
     <div
       role="link"
       tabIndex={0}
       onClick={() => navigate(`/review/${review.id}`)}
       onKeyDown={e => {
-        if (e.key === 'Enter') navigate(`/review/${review.id}`)
+        if (e.key === 'Enter' && e.currentTarget === e.target) navigate(`/review/${review.id}`)
       }}
       className={cn(cardClassName, 'cursor-pointer')}
     >

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -97,7 +97,11 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
     <div className="p-4">
       {/* User Header */}
       <div className="mb-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <Link
+          to={`/user/${review.author.id}`}
+          onClick={e => e.stopPropagation()}
+          className="flex items-center gap-3"
+        >
           <div className="size-10 overflow-hidden rounded-full border border-primary/10 bg-primary/10">
             {review.author.profileImageUrl && (
               <img
@@ -111,7 +115,7 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
             <p className="text-sm font-bold">{review.author.nickname}</p>
             <p className="text-xs text-muted-foreground">{formatRelativeTime(review.createdAt)}</p>
           </div>
-        </div>
+        </Link>
         {status && (
           <span
             className={cn(
@@ -220,9 +224,19 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
     </div>
   )
 
+  const navigate = useNavigate()
+
   return (
-    <Link to={`/review/${review.id}`} className={cardClassName}>
+    <div
+      role="link"
+      tabIndex={0}
+      onClick={() => navigate(`/review/${review.id}`)}
+      onKeyDown={e => {
+        if (e.key === 'Enter') navigate(`/review/${review.id}`)
+      }}
+      className={cn(cardClassName, 'cursor-pointer')}
+    >
       {inner}
-    </Link>
+    </div>
   )
 }


### PR DESCRIPTION
  - 프로필 영역(아바타+닉네임+시간)을 Link로 감싸 /user/:userId 이동
  - 외부 카드 래퍼를 Link → div onClick(navigate)로 변경 (중첩 <a> 방지)
  - role="link", tabIndex, onKeyDown(Enter)으로 키보드 접근성 보장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 리뷰 카드에서 작성자 이름을 클릭하면 작성자의 프로필 페이지로 이동하도록 개선되었습니다.
  * 리뷰 카드의 다른 영역을 클릭할 때는 리뷰 상세 페이지로 이동합니다.
  * 키보드 접근성이 개선되어 엔터 키를 사용하여 리뷰를 열 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->