### PR TITLE
feat: Shelfeed 로고 클릭 시 홈 화면 이동 (#180)

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -15,6 +15,7 @@ export default function AppHeader({
   className,
 }: AppHeaderProps) {
   const navigate = useNavigate()
+  const isHomeLogo = title === 'Shelfeed'
 
   return (
     <header
@@ -34,7 +35,24 @@ export default function AppHeader({
         )}
       </div>
 
-      <h1 className={cn('text-xl font-bold tracking-tight text-primary', !showBack && 'text-2xl')}>
+      <h1
+        {...(isHomeLogo && {
+          role: 'link',
+          tabIndex: 0,
+          onClick: () => navigate('/'),
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              navigate('/')
+            }
+          },
+        })}
+        className={cn(
+          'text-xl font-bold tracking-tight text-primary',
+          !showBack && 'text-2xl',
+          isHomeLogo && 'cursor-pointer transition-opacity hover:opacity-70'
+        )}
+      >
         {title}
       </h1>
 

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -327,7 +327,20 @@ export default function HomeFeedPage() {
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="flex items-center justify-between px-4 py-3">
           <div className="w-10" />
-          <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
+          <h1
+            role="link"
+            tabIndex={0}
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                window.scrollTo({ top: 0, behavior: 'smooth' })
+              }
+            }}
+            className="cursor-pointer text-2xl font-bold tracking-tight text-primary transition-opacity hover:opacity-70"
+          >
+            Shelfeed
+          </h1>
           <Link
             to="/notifications"
             aria-label={unreadCount > 0 ? `알림 (미읽음 ${unreadCount}개)` : '알림'}

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -328,7 +328,7 @@ export default function HomeFeedPage() {
         <div className="flex items-center justify-between px-4 py-3">
           <div className="w-10" />
           <h1
-            role="link"
+            role="button"
             tabIndex={0}
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
             onKeyDown={e => {

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -201,7 +201,20 @@ export default function MyProfilePage() {
           <div className="grid grid-cols-3 items-center px-4 py-3">
             <div />
             <div className="flex justify-center">
-              <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
+              <h1
+                role="link"
+                tabIndex={0}
+                onClick={() => navigate('/')}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    navigate('/')
+                  }
+                }}
+                className="cursor-pointer text-2xl font-bold tracking-tight text-primary transition-opacity hover:opacity-70"
+              >
+                Shelfeed
+              </h1>
             </div>
             <div />
           </div>
@@ -223,7 +236,20 @@ export default function MyProfilePage() {
           <div className="grid grid-cols-3 items-center px-4 py-3">
             <div />
             <div className="flex justify-center">
-              <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
+              <h1
+                role="link"
+                tabIndex={0}
+                onClick={() => navigate('/')}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    navigate('/')
+                  }
+                }}
+                className="cursor-pointer text-2xl font-bold tracking-tight text-primary transition-opacity hover:opacity-70"
+              >
+                Shelfeed
+              </h1>
             </div>
             <div />
           </div>
@@ -264,7 +290,20 @@ export default function MyProfilePage() {
           </div>
 
           <div className="flex justify-center">
-            <h1 className="text-2xl font-bold tracking-tight text-primary">Shelfeed</h1>
+            <h1
+              role="link"
+              tabIndex={0}
+              onClick={() => navigate('/')}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  navigate('/')
+                }
+              }}
+              className="cursor-pointer text-2xl font-bold tracking-tight text-primary transition-opacity hover:opacity-70"
+            >
+              Shelfeed
+            </h1>
           </div>
 
           <div className="flex justify-end">


### PR DESCRIPTION
  - AppHeader 공통 컴포넌트: title이 'Shelfeed'일 때만 클릭 시 '/' 이동
  - HomeFeedPage: 이미 홈이므로 클릭 시 최상단 스무스 스크롤
  - MyProfilePage: 로딩/에러/정상 상태 헤더 3곳 모두 클릭 시 '/' 이동
  - 키보드 접근성(Enter/Space + preventDefault) 및 hover 피드백 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 헤더의 "Shelfeed" 로고를 모든 관련 페이지에서 클릭 가능한 요소로 변경해 홈으로 빠르게 이동할 수 있습니다.
  * 키보드 접근성 개선: Enter/Space로 로고를 활성화할 수 있습니다.
  * 홈에서는 로고 클릭/키보드로 부드러운 상단 스크롤로 이동합니다.
  * 로고에 커서·호버 전환 효과를 추가해 상호작용을 명확히 표시합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->