### PR TITLE
feat: 알림 페이지 진입 시 전체 읽음 처리 API 연동 (#182)

### DIFF
--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -106,8 +106,8 @@ export async function markNotificationAsRead(
 /**
  * 현재 사용자의 모든 미읽음 알림을 일괄 읽음 처리한다.
  *
- * 멱등 — 미읽음 0건이어도 200 반환. 페이지 이탈 시에도 호출이 완료되어야 하므로
- * AbortSignal을 받지 않는다 (fire-and-forget 용도).
+ * 멱등 — 미읽음 0건이어도 200 반환. 호출자가 fire-and-forget(`.catch(() => {})`)으로
+ * 사용할 수 있도록 설계되었으며, 개별 읽음 처리와 달리 AbortSignal을 받지 않는다.
  */
 export async function markAllNotificationsAsRead(): Promise<void> {
   try {

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -104,6 +104,20 @@ export async function markNotificationAsRead(
 }
 
 /**
+ * 현재 사용자의 모든 미읽음 알림을 일괄 읽음 처리한다.
+ *
+ * 멱등 — 미읽음 0건이어도 200 반환. 페이지 이탈 시에도 호출이 완료되어야 하므로
+ * AbortSignal을 받지 않는다 (fire-and-forget 용도).
+ */
+export async function markAllNotificationsAsRead(): Promise<void> {
+  try {
+    await apiClient.patch<ApiResponse<void>>('/api/v1/notifications/read-all')
+  } catch (error) {
+    throw normalizeAxiosError(error, '알림 전체 읽음 처리에 실패했습니다.')
+  }
+}
+
+/**
  * 미읽음 알림 개수를 조회한다.
  *
  * @remarks HomeFeedPage 종 아이콘 뱃지에서 사용 예정 (후속 이슈).

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { cn, formatRelativeTime } from '@/lib/utils'
 import {
   getNotifications,
+  markAllNotificationsAsRead,
   markNotificationAsRead,
   type NotificationItem,
   type NotificationType,
@@ -130,6 +131,9 @@ export default function NotificationsPage() {
         setNotifications(response.content)
         setNextCursor(response.nextCursor)
         setHasNext(response.hasNext)
+        if (response.content.some(n => !n.isRead)) {
+          markAllNotificationsAsRead().catch(() => {})
+        }
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return
         setErrorMessage(error instanceof Error ? error.message : '알림을 불러오지 못했습니다.')


### PR DESCRIPTION
  - notification.ts에 markAllNotificationsAsRead() 함수 추가
  - NotificationsPage 첫 페이지 로드 성공 후 미읽음 존재 시 fire-and-forget 호출
  - 현재 방문 UI는 유지, 백엔드만 읽음 처리하여 다음 방문 시 반영