### PR TITLE
feat: 타인 감상 상세에서 내 서재에 추가 버튼 (#184)

### DIFF
--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import apiClient from './client'
 import { ApiResponse, normalizeAxiosError, parseApiResponse } from './_helpers'
 import type { BackendReadingStatus } from './book'
@@ -242,7 +243,7 @@ export async function getWisdomTower(signal?: AbortSignal): Promise<WisdomTowerR
 export async function addLibraryBook(
   bookId: number,
   status: ReadingStatus
-): Promise<LibraryBookAddResponse> {
+): Promise<LibraryBookAddResponse | { alreadyExists: true }> {
   try {
     const { data } = await apiClient.post<ApiResponse<LibraryBookAddResponse>>('/api/v1/library', {
       bookId,
@@ -253,6 +254,9 @@ export async function addLibraryBook(
     }
     return data.data
   } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 409) {
+      return { alreadyExists: true }
+    }
     throw normalizeAxiosError(
       error,
       '서재에 도서를 추가하지 못했습니다. 잠시 후 다시 시도해주세요.'

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -154,6 +154,10 @@ export default function BookDetailPage() {
     // 신규 추가 → POST. 응답의 libraryBookId를 로컬 book 상태에 반영해 다음 수정이 PATCH로 가도록 한다.
     const result = await addLibraryBook(book.bookId, status)
     if (!isMountedRef.current) return
+    if ('alreadyExists' in result) {
+      setSavedStatus(status)
+      return
+    }
     setSavedStatus(toFrontStatus(result.status) ?? status)
     setBook(prev => (prev ? { ...prev, myLibraryBookId: result.libraryBookId } : prev))
   }

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -9,8 +9,9 @@ import {
   unlikeReview,
   type ReviewDetail,
 } from '@/api/review'
-import { backendToFrontStatus, type ReadingStatus } from '@/api/library'
+import { addLibraryBook, backendToFrontStatus, type ReadingStatus } from '@/api/library'
 import AppHeader from '@/components/layout/AppHeader'
+import AddToLibrarySheet from '@/components/common/AddToLibrarySheet'
 import BottomNav from '@/components/layout/BottomNav'
 import {
   Dialog,
@@ -49,6 +50,8 @@ export default function ReviewDetailPage() {
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null)
   const [isReportOpen, setIsReportOpen] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [savedStatus, setSavedStatus] = useState<ReadingStatus | null>(null)
 
   useEffect(() => {
     if (!Number.isFinite(reviewId)) {
@@ -169,6 +172,11 @@ export default function ReviewDetailPage() {
     } finally {
       setIsLiking(false)
     }
+  }
+
+  const handleSaveToLibrary = async (status: ReadingStatus) => {
+    await addLibraryBook(review.book.bookId, status)
+    setSavedStatus(status)
   }
 
   const handleDeleteReview = async () => {
@@ -364,6 +372,26 @@ export default function ReviewDetailPage() {
           </div>
         </section>
 
+        {!isMyReview && (
+          <section className="border-t border-border px-5 py-4">
+            {savedStatus ? (
+              <div className="flex items-center justify-center gap-2 rounded-xl bg-primary/5 py-3 text-sm font-semibold text-primary/70">
+                <span className="material-symbols-outlined text-[20px]">check_circle</span>
+                서재에 저장됨
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setSheetOpen(true)}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-primary/20 bg-card py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/5"
+              >
+                <span className="material-symbols-outlined text-[20px]">library_add</span>내 서재에
+                추가
+              </button>
+            )}
+          </section>
+        )}
+
         <div ref={commentSectionRef}>
           <CommentSection
             reviewId={review.reviewId}
@@ -429,6 +457,15 @@ export default function ReviewDetailPage() {
         targetType="REVIEW"
         targetId={review.reviewId}
       />
+
+      {!isMyReview && review && (
+        <AddToLibrarySheet
+          isOpen={sheetOpen}
+          onClose={() => setSheetOpen(false)}
+          onSave={handleSaveToLibrary}
+          bookId={String(review.book.bookId)}
+        />
+      )}
 
       <BottomNav />
     </div>

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -63,6 +63,8 @@ export default function ReviewDetailPage() {
     const controller = new AbortController()
     setIsLoading(true)
     setErrorMessage(null)
+    setSheetOpen(false)
+    setSavedStatus(null)
     ;(async () => {
       try {
         const result = await getReviewDetail(reviewId, controller.signal)


### PR DESCRIPTION
  - ReviewDetailPage에 타인 감상일 때 "내 서재에 추가" 버튼 표시
  - 기존 AddToLibrarySheet 바텀 시트 재사용 (독서 상태 선택)
  - 저장 성공 시 "서재에 저장됨" 표시로 전환
  - addLibraryBook 409 Conflict를 센티넬 반환으로 처리 (dead code 방지)
  - BookDetailPage에도 센티넬 분기 추가하여 타입 안전성 확보

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 감상 상세 페이지에서 책을 내 서재에 추가할 수 있는 기능 추가

* **Bug Fixes**
  * 이미 서재에 존재하는 책을 추가할 때 오류 대신 적절하게 처리하도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->