### PR TITLE
  fix: UI 피드백 3건 반영 — 서재 버튼 위치·장르 저장 너비·검색 표시 수 (#186)

### DIFF
--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -9,7 +9,7 @@ import { searchAll, type BookSearchItem, type UserSearchItem, type SearchType } 
 import { cn } from '@/lib/utils'
 import { useSearchStore, RECENT_KEYWORDS_KEY } from '@/store/searchStore'
 const MAX_RECENT_KEYWORDS = 10
-const ALL_TAB_PREVIEW_COUNT = 3
+const ALL_TAB_PREVIEW_COUNT = 5
 
 // ZXing 의존성을 가진 모달은 사용자가 카메라 버튼을 눌렀을 때만 다운로드
 const IsbnScannerModal = lazy(() => import('@/components/common/IsbnScannerModal'))

--- a/src/pages/GenreSelectionPage.tsx
+++ b/src/pages/GenreSelectionPage.tsx
@@ -189,7 +189,7 @@ export default function GenreSelectionPage() {
         )}
       </main>
 
-      <div className="fixed inset-x-0 bottom-0 bg-background px-6 pb-8 pt-4">
+      <div className="fixed inset-x-0 bottom-0 mx-auto max-w-[430px] bg-background px-6 pb-8 pt-4">
         {submitError && (
           <p
             role="alert"

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -256,6 +256,26 @@ export default function ReviewDetailPage() {
           </div>
         </section>
 
+        {!isMyReview && (
+          <section className="px-5 pb-3">
+            {savedStatus ? (
+              <div className="flex items-center justify-center gap-2 rounded-xl bg-primary/5 py-3 text-sm font-semibold text-primary/70">
+                <span className="material-symbols-outlined text-[20px]">check_circle</span>
+                서재에 저장됨
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setSheetOpen(true)}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-primary/20 bg-card py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/5"
+              >
+                <span className="material-symbols-outlined text-[20px]">library_add</span>내 서재에
+                추가
+              </button>
+            )}
+          </section>
+        )}
+
         {isMyReview && (
           <section className="flex gap-2 px-5 pb-3">
             <button
@@ -373,26 +393,6 @@ export default function ReviewDetailPage() {
             </button>
           </div>
         </section>
-
-        {!isMyReview && (
-          <section className="border-t border-border px-5 py-4">
-            {savedStatus ? (
-              <div className="flex items-center justify-center gap-2 rounded-xl bg-primary/5 py-3 text-sm font-semibold text-primary/70">
-                <span className="material-symbols-outlined text-[20px]">check_circle</span>
-                서재에 저장됨
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => setSheetOpen(true)}
-                className="flex w-full items-center justify-center gap-2 rounded-xl border border-primary/20 bg-card py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/5"
-              >
-                <span className="material-symbols-outlined text-[20px]">library_add</span>내 서재에
-                추가
-              </button>
-            )}
-          </section>
-        )}
 
         <div ref={commentSectionRef}>
           <CommentSection


### PR DESCRIPTION
  - ReviewDetailPage: "내 서재에 추가" 버튼을 책 카드 아래·감상 제목 위로 이동
  - GenreSelectionPage: 하단 고정 버튼에 max-w-[430px] 추가하여 PC 화면 너비 제한
  - BookSearchPage: 통합검색 전체 탭 도서 표시 수 3→5로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 검색 페이지의 전체 탭에서 표시되는 미리보기 항목 수 증가
  * 리뷰 상세 페이지의 서재 관련 UI 요소 위치 조정 및 레이아웃 개선

* **Style**
  * 장르 선택 페이지 고정 컨테이너의 폭 및 배경 스타일 조정
  * 리뷰 상세 페이지 반응 섹션의 간격 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->