### PR TITLE
feat: 홈 피드 스크롤 위치 복원 (#188)

### DIFF
--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -7,8 +7,7 @@ import { getUnreadNotificationCount } from '@/api/notification'
 import BottomNav from '@/components/layout/BottomNav'
 import PopupBanner from '@/components/common/PopupBanner'
 import ReviewCard, { type ReviewCardData } from '@/components/common/ReviewCard'
-
-type TabValue = 'following' | 'recommend'
+import { useFeedStore, setFeedTabCache, type FeedTab } from '@/store/feedStore'
 
 /**
  * 백엔드 `FeedItem` 응답을 `ReviewCardData`로 매핑한다.
@@ -85,7 +84,7 @@ function recommendToCard(item: RecommendItem): ReviewCardData {
  * @returns 헤더(로고/알림) + 탭(팔로잉/추천) + 피드 리스트 + BottomNav를 렌더링하는 React 엘리먼트
  */
 export default function HomeFeedPage() {
-  const [activeTab, setActiveTab] = useState<TabValue>('following')
+  const [activeTab, setActiveTab] = useState<FeedTab>(() => useFeedStore.getState().activeTab)
   /**
    * 종 아이콘 미읽음 알림 카운트.
    *
@@ -108,6 +107,8 @@ export default function HomeFeedPage() {
 
   const observerRef = useRef<IntersectionObserver | null>(null)
   const moreControllerRef = useRef<AbortController | null>(null)
+  const itemsRef = useRef(items)
+  itemsRef.current = items
 
   const stateRef = useRef({
     hasNext,
@@ -130,8 +131,51 @@ export default function HomeFeedPage() {
     loadMoreError,
   }
 
-  // 초기 로딩 + 탭 변경 시 재요청.
+  /**
+   * 탭 전환·마운트 시 피드 데이터를 로딩하거나 캐시에서 복원한다.
+   *
+   * feedStore에 해당 탭 캐시가 있으면 API 호출 없이 복원 후 스크롤 위치까지 재현.
+   * 캐시가 없으면 기존대로 API에서 첫 페이지를 가져온다.
+   * cleanup에서 현재 탭의 피드 데이터 + scrollY를 feedStore에 저장하여
+   * 다음 방문 시 복원할 수 있도록 한다.
+   */
   useEffect(() => {
+    const currentTab = activeTab
+    const cache = useFeedStore.getState()[currentTab]
+
+    const saveCurrentTab = () => {
+      if (itemsRef.current.length === 0) return
+      setFeedTabCache(currentTab, {
+        items: itemsRef.current,
+        nextCursor: stateRef.current.nextCursor,
+        nextCursorId: stateRef.current.nextCursorId,
+        nextCursorLike: stateRef.current.nextCursorLike,
+        hasNext: stateRef.current.hasNext,
+        scrollY: window.scrollY,
+      })
+    }
+
+    if (cache && cache.items.length > 0) {
+      setItems(cache.items)
+      setNextCursor(cache.nextCursor)
+      setNextCursorId(cache.nextCursorId)
+      setNextCursorLike(cache.nextCursorLike)
+      setHasNext(cache.hasNext)
+      setIsLoading(false)
+      setIsLoadingMore(false)
+      setErrorMessage(null)
+      setLoadMoreError(null)
+      const savedY = cache.scrollY
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => window.scrollTo(0, savedY))
+      })
+
+      return () => {
+        moreControllerRef.current?.abort()
+        saveCurrentTab()
+      }
+    }
+
     setIsLoadingMore(false)
     setLoadMoreError(null)
     moreControllerRef.current?.abort()
@@ -146,7 +190,7 @@ export default function HomeFeedPage() {
     setIsLoading(true)
     ;(async () => {
       try {
-        if (activeTab === 'following') {
+        if (currentTab === 'following') {
           const response = await getFollowingFeed({
             cursor: null,
             signal: controller.signal,
@@ -178,6 +222,7 @@ export default function HomeFeedPage() {
     return () => {
       controller.abort()
       moreControllerRef.current?.abort()
+      saveCurrentTab()
     }
   }, [activeTab])
 
@@ -363,7 +408,10 @@ export default function HomeFeedPage() {
             type="button"
             role="tab"
             aria-selected={activeTab === 'following'}
-            onClick={() => setActiveTab('following')}
+            onClick={() => {
+              setActiveTab('following')
+              useFeedStore.setState({ activeTab: 'following' })
+            }}
             className="relative flex flex-col items-center py-3"
           >
             <span
@@ -382,7 +430,10 @@ export default function HomeFeedPage() {
             type="button"
             role="tab"
             aria-selected={activeTab === 'recommend'}
-            onClick={() => setActiveTab('recommend')}
+            onClick={() => {
+              setActiveTab('recommend')
+              useFeedStore.setState({ activeTab: 'recommend' })
+            }}
             className="relative flex flex-col items-center py-3"
           >
             <span

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { logout, resendEmailCode } from '@/api/auth'
 import { getSettings, updateSettings, type SettingsResponse } from '@/api/member'
 import { useAuthStore } from '@/store/authStore'
 import { clearSearchCache } from '@/store/searchStore'
+import { clearFeedCache } from '@/store/feedStore'
 import type { EmailVerifyLocationState } from '@/pages/EmailVerificationPage'
 
 function Toggle({
@@ -187,6 +188,7 @@ export default function SettingsPage() {
     } finally {
       clearAuth()
       clearSearchCache()
+      clearFeedCache()
       navigate('/login', { replace: true })
     }
   }

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from 'react-router-dom'
 import AppHeader from '@/components/layout/AppHeader'
 import { withdrawAccount } from '@/api/member'
 import { useAuthStore } from '@/store/authStore'
+import { clearSearchCache } from '@/store/searchStore'
+import { clearFeedCache } from '@/store/feedStore'
 import {
   Dialog,
   DialogContent,
@@ -71,6 +73,8 @@ export default function WithdrawPage() {
       setPendingData(null)
       setIsConfirmOpen(false)
       clearAuth()
+      clearSearchCache()
+      clearFeedCache()
       navigate('/login', { replace: true })
     } catch (error) {
       setIsConfirmOpen(false)

--- a/src/store/feedStore.ts
+++ b/src/store/feedStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand'
+import type { ReviewCardData } from '@/components/common/ReviewCard'
+
+export type FeedTab = 'following' | 'recommend'
+
+export interface FeedTabCache {
+  items: ReviewCardData[]
+  nextCursor: number | null
+  nextCursorId: number | null
+  nextCursorLike: number | null
+  hasNext: boolean
+  scrollY: number
+}
+
+interface FeedState {
+  activeTab: FeedTab
+  following: FeedTabCache | null
+  recommend: FeedTabCache | null
+}
+
+/**
+ * 홈 피드 데이터를 컴포넌트 unmount 이후에도 메모리에 보존하는 스토어.
+ * persist 미들웨어 없이 in-memory로만 유지 — 새로고침 시 자연스럽게 초기화.
+ * 탭별(팔로잉/추천) 독립 캐시 + 스크롤 위치를 저장한다.
+ */
+export const useFeedStore = create<FeedState>()(() => ({
+  activeTab: 'following',
+  following: null,
+  recommend: null,
+}))
+
+export function setFeedTabCache(tab: FeedTab, cache: FeedTabCache) {
+  if (tab === 'following') {
+    useFeedStore.setState({ following: cache })
+  } else {
+    useFeedStore.setState({ recommend: cache })
+  }
+}
+
+export function clearFeedCache() {
+  useFeedStore.setState({ following: null, recommend: null })
+}


### PR DESCRIPTION
- feedStore (Zustand, in-memory) 신규 생성 — 탭별 피드 데이터 + scrollY 캐싱
- HomeFeedPage: 마운트 시 캐시 존재하면 API 호출 생략하고 데이터 + 스크롤 위치 복원
- 언마운트·탭 전환 시 현재 피드 상태를 feedStore에 자동 저장
- 팔로잉/추천 탭 각각 독립 캐시로 스크롤 위치 개별 유지
- 스크롤 복원에 double requestAnimationFrame 적용 (대량 리스트 렌더 안정성)
- SettingsPage 로그아웃 + WithdrawPage 회원 탈퇴 시 캐시 정리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 홈 피드의 탭별 데이터 캐싱 기능 추가
  * 탭 전환 시 이전 탭의 데이터 및 스크롤 위치 자동 복원

* **Chores**
  * 로그아웃 및 회원탈퇴 시 피드 캐시 초기화 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->