### PR TITLE
fix: 배포 차단 블로커 해소 (Vercel SPA fallback·env fail-fast·빌드 설정·ErrorBoundary)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
+# 로컬 개발용 백엔드 API 주소. 각자 `.env` 파일에 복사해 사용한다.
+# 프로덕션(Vercel) 환경변수는 Vercel 프로젝트 대시보드 > Settings > Environment Variables에서 주입한다.
+# 이 fallback 값은 개발 환경 전용이며, 프로덕션 빌드에서 VITE_API_BASE_URL이 없으면 앱이 fail-fast로 throw한다.
 VITE_API_BASE_URL=http://localhost:8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          # 프로덕션 배포 빌드는 Vercel이 대시보드 환경변수(VITE_API_BASE_URL)로 수행한다.
+          # 이 CI 빌드는 컴파일/번들 sanity check 용도라 secret 미설정 시 플레이스홀더로 충분하다.
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL || 'https://ci-placeholder.invalid' }}
+
+      # TODO(후속): 테스트 PR 게이트 추가. 현재 vitest는 Storybook 브라우저 테스트(Playwright)
+      #            의존성 설치가 선행돼야 하므로, `npx playwright install --with-deps chromium`
+      #            step과 함께 `npm run test`를 도입할 것. (테스트 인프라 정비 이슈에서 처리)

--- a/index.html
+++ b/index.html
@@ -2,8 +2,18 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#f8f8f6" />
+    <meta
+      name="description"
+      content="Shelfeed — 책을 읽고 감상을 기록하고 나누는 독서 피드 서비스"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Shelfeed" />
+    <meta property="og:description" content="책을 읽고 감상을 기록하고 나누는 독서 피드 서비스" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap"
       rel="stylesheet"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Shelfeed">
+  <rect width="32" height="32" rx="7" fill="#b58f5e" />
+  <path
+    d="M16 9c-2.2-1.2-4.7-1.6-7-1.2-.6.1-1 .6-1 1.2v11.4c0 .7.6 1.2 1.3 1.1 2-.3 4.1 0 6 .9.4.2.9.2 1.4 0 1.9-.9 4-1.2 6-.9.7.1 1.3-.4 1.3-1.1V9c0-.6-.4-1.1-1-1.2-2.3-.4-4.8 0-7 1.2Z"
+    fill="#ffffff"
+  />
+  <path d="M16 9v13" stroke="#b58f5e" stroke-width="1.2" stroke-linecap="round" />
+</svg>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,7 +2,21 @@ import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
 import { useAuthStore } from '@/store/authStore'
 import type { ApiResponse } from './_helpers'
 
-const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+/**
+ * API 베이스 URL.
+ *
+ * 프로덕션 빌드(import.meta.env.PROD)에서는 VITE_API_BASE_URL이 반드시 주입되어야 한다
+ * (Vercel 프로젝트 대시보드의 Environment Variables). 미설정 시 localhost로 무음 fallback하면
+ * 운영 번들이 사용자 머신의 localhost:8080을 호출해 전 API가 조용히 실패하므로, 프로덕션에서는
+ * fail-fast로 즉시 원인을 드러낸다. localhost 기본값은 개발 환경(DEV) 전용이다.
+ */
+const envBaseURL = import.meta.env.VITE_API_BASE_URL
+if (!envBaseURL && import.meta.env.PROD) {
+  throw new Error(
+    'VITE_API_BASE_URL이 설정되지 않았습니다. 배포 환경(Vercel)의 환경변수를 확인하세요.'
+  )
+}
+const baseURL = envBaseURL || 'http://localhost:8080'
 
 const apiClient = axios.create({
   baseURL,

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+/**
+ * 앱 전역 React 에러 경계.
+ *
+ * 렌더 단계에서 던져진 예외가 트리 전체를 언마운트(화이트스크린)시키는 것을 막고,
+ * 사용자에게 복구 가능한 fallback UI('다시 시도')를 제공한다. `RouterProvider` 바깥
+ * (`main.tsx`)을 감싸 라우팅 자체나 Provider 단계의 예외까지 최후 방어선으로 포착한다.
+ *
+ * @remarks 라우트 element 렌더 예외는 React Router의 `errorElement`(RouteError)가 1차로
+ *          처리하므로, 이 경계는 그 바깥의 예외를 담당한다. 프로덕션 에러 리포팅(Sentry 등)
+ *          연동 시 `componentDidCatch`를 진입점으로 사용한다.
+ */
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (import.meta.env.DEV) {
+      console.error('ErrorBoundary가 예외를 포착했습니다:', error, info)
+    }
+    // TODO(후속): 프로덕션 에러 리포팅 서비스 연동 지점
+  }
+
+  private handleReload = () => {
+    window.location.assign('/')
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+        <span className="material-symbols-outlined text-5xl text-muted-foreground">error</span>
+        <h1 className="text-lg font-bold text-foreground">문제가 발생했습니다</h1>
+        <p className="text-sm text-muted-foreground">
+          예상치 못한 오류로 화면을 표시할 수 없습니다. 잠시 후 다시 시도해주세요.
+        </p>
+        <button
+          type="button"
+          onClick={this.handleReload}
+          className="mt-2 rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground transition-transform active:scale-[0.98]"
+        >
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+}

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -34,7 +34,8 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
   }
 
   private handleReload = () => {
-    window.location.assign('/')
+    // 현재 URL을 그대로 재요청해 딥링크/복구 컨텍스트를 보존한다('다시 시도' 라벨과 일치).
+    window.location.reload()
   }
 
   render() {

--- a/src/components/common/RouteError.tsx
+++ b/src/components/common/RouteError.tsx
@@ -1,0 +1,42 @@
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom'
+
+/**
+ * 라우트 단위 `errorElement`.
+ *
+ * 라우트 element 렌더 중 발생한 예외나 매칭 실패(존재하지 않는 경로 → 404 ErrorResponse)를
+ * React Router가 포착해 이 컴포넌트로 렌더한다. 루트 레이아웃 라우트에 부여하면 모든 하위
+ * 라우트의 에러와 미매칭 경로(catch-all 404)를 한곳에서 처리한다.
+ *
+ * @remarks 전역 ErrorBoundary(main.tsx)와 달리 라우팅 컨텍스트가 살아 있어 `<Link>`로
+ *          앱 내 복구 이동이 가능하다.
+ */
+export default function RouteError() {
+  const error = useRouteError()
+  if (import.meta.env.DEV) {
+    console.error('RouteError가 에러를 포착했습니다:', error)
+  }
+
+  const is404 = isRouteErrorResponse(error) && error.status === 404
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      <span className="material-symbols-outlined text-5xl text-muted-foreground">
+        {is404 ? 'search_off' : 'error'}
+      </span>
+      <h1 className="text-lg font-bold text-foreground">
+        {is404 ? '페이지를 찾을 수 없습니다' : '문제가 발생했습니다'}
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        {is404
+          ? '요청하신 페이지가 존재하지 않거나 이동되었습니다.'
+          : '예상치 못한 오류로 화면을 표시할 수 없습니다.'}
+      </p>
+      <Link
+        to="/"
+        className="mt-2 rounded-xl bg-primary px-6 py-3 text-sm font-bold text-primary-foreground transition-transform active:scale-[0.98]"
+      >
+        홈으로 가기
+      </Link>
+    </div>
+  )
+}

--- a/src/components/common/RouteError.tsx
+++ b/src/components/common/RouteError.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom'
 
 /**
@@ -12,9 +13,13 @@ import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom'
  */
 export default function RouteError() {
   const error = useRouteError()
-  if (import.meta.env.DEV) {
-    console.error('RouteError가 에러를 포착했습니다:', error)
-  }
+
+  // 로깅은 렌더 부수효과를 피해 effect에서 처리한다(StrictMode 이중 렌더 시 중복 로깅 방지).
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      console.error('RouteError가 에러를 포착했습니다:', error)
+    }
+  }, [error])
 
   const is404 = isRouteErrorResponse(error) && error.status === 404
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { router } from '@/router'
+import ErrorBoundary from '@/components/common/ErrorBoundary'
 import './index.css'
 
 const queryClient = new QueryClient({
@@ -17,9 +18,11 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Outlet } from 'react-router-dom'
 import HomeFeedPage from '@/pages/HomeFeedPage'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
@@ -26,8 +26,9 @@ import LibraryBookDetailPage from '@/pages/LibraryBookDetailPage'
 import UserLibraryPage from '@/pages/UserLibraryPage'
 import FollowListPage from '@/pages/FollowListPage'
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
+import RouteError from '@/components/common/RouteError'
 
-export const router = createBrowserRouter([
+const appRoutes = [
   {
     path: '/',
     element: (
@@ -235,5 +236,13 @@ export const router = createBrowserRouter([
         <WithdrawPage />
       </ProtectedRoute>
     ),
+  },
+]
+
+export const router = createBrowserRouter([
+  {
+    element: <Outlet />,
+    errorElement: <RouteError />,
+    children: appRoutes,
   },
 ])

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,34 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  base: '/',
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        // 무거운 의존성을 별도 vendor 청크로 분리해 초기 로드/캐시 효율을 높인다.
+        // (vitest/config 타입이 객체 형태 manualChunks를 함수형으로 좁혀 잡으므로 함수형으로 작성한다.)
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (id.includes('@zxing')) return 'scanner-vendor'
+          if (id.includes('@tanstack')) return 'query-vendor'
+          if (id.includes('react-hook-form') || id.includes('@hookform') || id.includes('/zod/'))
+            return 'form-vendor'
+          if (id.includes('@radix-ui') || id.includes('lucide-react')) return 'ui-vendor'
+          if (
+            id.includes('react-router') ||
+            id.includes('react-dom') ||
+            id.includes('/react/') ||
+            id.includes('scheduler')
+          )
+            return 'react-vendor'
+          return undefined
+        },
+      },
+    },
+  },
   test: {
     projects: [
       {


### PR DESCRIPTION
  ## 개요
  배포 직전 코드 리뷰에서 NO-GO 판정의 원인이 된 배포 차단 블로커(설정·인프라 레벨) 5건을 해소해 Vercel 프로덕션 배포가 가능한 상태로 만듭니다.

  Closes #194

  ## 변경 사항
  - **B-1 SPA fallback**: `vercel.json` rewrites(모든 경로 → `/index.html`) — 딥링크 새로고침 404 해소
  - **B-2 API URL**: `client.ts` 프로덕션 fail-fast(localhost는 DEV 전용) + `.env.example` 주석화
  - **B-3 빌드 설정**: `vite.config.ts`에 `base`·`build`·vendor `manualChunks` 추가
  - **B-4 에러 경계**: 전역 `ErrorBoundary` + 라우트 `errorElement`(`RouteError`, 404 catch-all 포함)
  - **B-5 favicon/CI**: `public/favicon.svg` + `index.html`(preconnect·메타) + `ci.yml`(env 주입·테스트 TODO)
  - (보너스) ReactQueryDevtools를 DEV 전용으로 가드해 프로덕션 번들에서 제외

  ## 검증
  - `tsc -b && vite build` ✅ 통과 (2053 모듈, vendor 청크 분리: react/query/scanner/form/ui)
  - `eslint .` ✅ 0 errors
  - 변경 파일 `prettier --check` ✅ 통과

  ## 배포 담당자 체크 (Vercel 대시보드, 코드 외)
  - [ ] 프로젝트 Root Directory = `FrontEnd_Project`
  - [ ] 환경변수 `VITE_API_BASE_URL` = 프로덕션 백엔드 URL (미설정 시 앱 fail-fast)

  ## 참고 / 후속
  - 본 PR은 블로커 B-1~B-5만 다룹니다.
  - MEDIUM 코드 결함(M-1 피드 dedup, M-2 abort 가드, M-5 StarRating clamp, M-11 임시저장 데드버튼 등)은 별도 이슈로 분리 예정.
  - 저장소 전역 prettier 미정리(78개 파일)로 CI `format:check`가 red 상태입니다 → 팀 공지 후 별도 `chore/format-sweep` PR에서 일괄 해소 예정(본 PR 범위 밖).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 애플리케이션 에러 발생 시 사용자 친화적인 에러 화면 제공
  * 404 페이지 미매칭 처리 개선

* **Chores**
  * 메타 데이터 및 SEO 설정 강화
  * 배포 환경 설정 추가
  * 빌드 최적화 및 청크 분리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->