### PR TITLE
fix: MEDIUM 코드 결함 1차 패치 - 피드 dedup·abort 가드·StarRating·임시저장 (#196)

### DIFF
--- a/src/components/common/StarRating.tsx
+++ b/src/components/common/StarRating.tsx
@@ -13,9 +13,12 @@ const sizeMap = {
 }
 
 export default function StarRating({ rating, size = 'md', className }: StarRatingProps) {
-  const fullStars = Math.floor(rating)
-  const hasHalf = rating - fullStars >= 0.5
-  const emptyStars = 5 - fullStars - (hasHalf ? 1 : 0)
+  // 백엔드 집계 오류 등으로 [0,5]를 벗어난 값(또는 NaN/Infinity)이 와도 Array.from에 음수 length가
+  // 들어가 RangeError(화이트스크린)가 나지 않도록 진입부에서 clamp한다.
+  const safeRating = Math.min(5, Math.max(0, Number.isFinite(rating) ? rating : 0))
+  const fullStars = Math.floor(safeRating)
+  const hasHalf = safeRating - fullStars >= 0.5
+  const emptyStars = Math.max(0, 5 - fullStars - (hasHalf ? 1 : 0))
 
   return (
     <div className={cn('flex gap-0.5', className)}>

--- a/src/pages/HomeFeedPage.tsx
+++ b/src/pages/HomeFeedPage.tsx
@@ -294,9 +294,17 @@ export default function HomeFeedPage() {
         })
         if (controller.signal.aborted) return
         if (stateRef.current.activeTab !== tab) return
-        setItems(prev => [...prev, ...response.content.map(toReviewCardData)])
-        setNextCursor(response.nextCursor)
-        setHasNext(response.hasNext)
+        // 중복 제거: 페이지 경계에서 동일 리뷰가 재등장하면 key 충돌·카드 중복이 생기므로
+        // 기존 id Set으로 필터링해 append한다(BookReviewsListPage/BookSearchPage 패턴과 통일).
+        const mapped = response.content.map(toReviewCardData)
+        setItems(prev => {
+          const existingIds = new Set(prev.map(item => item.id))
+          const deduped = mapped.filter(item => !existingIds.has(item.id))
+          return deduped.length > 0 ? [...prev, ...deduped] : prev
+        })
+        const hasNewItems = response.content.length > 0
+        if (hasNewItems) setNextCursor(response.nextCursor)
+        setHasNext(hasNewItems && response.hasNext)
       } else {
         const response = await getRecommendFeed({
           cursorLike: s.nextCursorLike,
@@ -305,10 +313,18 @@ export default function HomeFeedPage() {
         })
         if (controller.signal.aborted) return
         if (stateRef.current.activeTab !== tab) return
-        setItems(prev => [...prev, ...response.content.map(recommendToCard)])
-        setNextCursorId(response.nextCursorId)
-        setNextCursorLike(response.nextCursorLike)
-        setHasNext(response.hasNext)
+        const mapped = response.content.map(recommendToCard)
+        setItems(prev => {
+          const existingIds = new Set(prev.map(item => item.id))
+          const deduped = mapped.filter(item => !existingIds.has(item.id))
+          return deduped.length > 0 ? [...prev, ...deduped] : prev
+        })
+        const hasNewItems = response.content.length > 0
+        if (hasNewItems) {
+          setNextCursorId(response.nextCursorId)
+          setNextCursorLike(response.nextCursorLike)
+        }
+        setHasNext(hasNewItems && response.hasNext)
       }
     } catch (error) {
       if (axios.isCancel(error) || controller.signal.aborted) return

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -68,14 +68,14 @@ export default function ReviewDetailPage() {
     ;(async () => {
       try {
         const result = await getReviewDetail(reviewId, controller.signal)
+        // 응답이 abort 직전에 이미 resolve된 경우 axios가 throw하지 않으므로, reviewId를 빠르게
+        // 전환할 때 stale 데이터로 화면을 덮어쓰지 않도록 setter 직전에 가드한다(다른 fetch effect와 패턴 통일).
+        if (controller.signal.aborted) return
         setReview(result)
         setLiked(result.isLiked)
         setLikeCount(result.likeCount)
       } catch (error) {
-        // [MED-1 fix] try 블록 내 controller.signal.aborted 가드는 사실상 도달 불가
-        // (요청이 abort되면 axios가 throw로 빠짐) + _helpers.ts의 normalizeAxiosError가
-        // 이미 cancel을 rethrow하므로 catch에서 axios.isCancel만 보면 책임이 끝난다.
-        // 다른 도메인(book/library 등)과 패턴 통일 + CLAUDE.md "방어 코드 최소화"에 맞춰 단일화.
+        // 요청 취소(reviewId 전환/언마운트)는 정상 흐름이므로 무시. normalizeAxiosError가 cancel을 rethrow.
         if (axios.isCancel(error)) return
         setErrorMessage(error instanceof Error ? error.message : '감상을 불러오지 못했습니다.')
       } finally {

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -447,9 +447,9 @@ export default function WriteReviewPage() {
               disabled
               title="준비 중인 기능입니다"
               aria-label="임시저장 (준비 중)"
-              className="h-14 flex-1 cursor-not-allowed rounded-full border-2 border-primary/40 bg-background text-base font-bold text-primary/40"
+              className="h-14 flex-1 cursor-not-allowed whitespace-nowrap rounded-full border-2 border-primary/40 bg-background text-sm font-bold text-primary/40"
             >
-              임시저장
+              임시저장 (준비 중)
             </button>
             <button
               type="button"

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -444,8 +444,10 @@ export default function WriteReviewPage() {
           <div className="flex gap-3">
             <button
               type="button"
-              disabled={isSubmitting}
-              className="h-14 flex-1 rounded-full border-2 border-primary bg-background text-base font-bold text-primary transition-colors hover:bg-primary/5"
+              disabled
+              title="준비 중인 기능입니다"
+              aria-label="임시저장 (준비 중)"
+              className="h-14 flex-1 cursor-not-allowed rounded-full border-2 border-primary/40 bg-background text-base font-bold text-primary/40"
             >
               임시저장
             </button>


### PR DESCRIPTION
  ## 개요
  배포 직전 코드 리뷰에서 식별된 MEDIUM 우선순위 코드 결함 4건(안정성·정확성·핵심 UX)을 해소합니다. 프론트 배포는 백엔드(EC2) 완료 후 진행 예정이며, 그 대기
  기간의 1차 코드 패치입니다.

  Closes #196

  ## 변경 사항
  - **M-1 · HomeFeedPage**: 팔로잉/추천 `fetchMore`에 id Set dedup 추가 → 페이지 경계 중복 카드·key 충돌 방지 (cursor 기반 BookReviewsListPage 패턴과 통일)
  - **M-2 · ReviewDetailPage**: 응답 resolve 후 setter 직전 `controller.signal.aborted` 가드 추가 → reviewId 빠른 전환 시 stale 덮어쓰기 방지
  - **M-5 · StarRating**: rating `[0,5]` clamp + `emptyStars` 방어 → 비정상 값의 `Array.from` RangeError(화이트스크린) 방지
  - **M-11 · WriteReviewPage**: 미배선 '임시저장' 버튼을 비활성화 + `임시저장 (준비 중)` 표기 (DRAFT 정식 구현은 별도 feature)

  ## 검증
  - `eslint .` ✅ 0 errors
  - 변경 파일 `prettier --check` ✅ 통과
  - `tsc -b && vite build` ✅ 통과

  ## 리뷰 대응 (CodeRabbit)
  - 피드 dedup의 `hasNext` 게이팅을 "deduped 길이"로 바꾸라는 Critical 코멘트는 **미채택**. HomeFeed는 cursor 기반 페이지네이션이라 커서를 서버 페이지 기준으로
  전진시켜야 하며, deduped 게이팅은 경계 전중복 페이지에서 조기 종료(콘텐츠 누락)를 유발함. dedup은 표시 전용으로 유지(정상 exclusive 커서에선 무한 루프
  없음). page 기반인 BookSearchPage와는 의도적으로 다른 패턴.
  - 임시저장 버튼 mobile 가시성 nitpick은 반영(`임시저장 (준비 중)` 텍스트).

  ## 참고 / 후속
  - 접근성 묶음(M-6~M-10), 라우트 코드스플리팅(M-12), 전역 prettier 정리(78파일)는 별도 이슈로 분리.
  - 배포 연동은 백엔드 EC2 배포 완료 후 진행(참고: `docs/backend-integration-checklist.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 별점 평가에서 유효하지 않은 값(NaN, Infinity 등)을 안전하게 처리하여 오류 방지
  * 피드 로드 시 중복 항목이 누적되는 문제 해결
  * 페이지 이동 중 상태 업데이트 오류 방지 처리 추가
  * 임시저장 버튼을 준비 단계로 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->