### PR TITLE
fix: 배포 전 품질 개선 묶음 - 접근성·알림 정확성·라우트 코드스플리팅 (#198)

### DIFF
--- a/src/components/common/AddToLibrarySheet.tsx
+++ b/src/components/common/AddToLibrarySheet.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ReadingStatus } from '@/api/library'
+import { useModalA11y } from '@/hooks/useModalA11y'
 
 interface AddToLibrarySheetProps {
   isOpen: boolean
@@ -28,11 +29,14 @@ export default function AddToLibrarySheet({
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const navigate = useNavigate()
+  const initialFocusRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     setSelected(defaultStatus ?? 'want_to_read')
     setSaveError(null)
   }, [defaultStatus, isOpen])
+
+  useModalA11y({ isOpen, onClose, isBlocked: isSaving, initialFocusRef })
 
   if (!isOpen) return null
 
@@ -55,7 +59,12 @@ export default function AddToLibrarySheet({
   }
 
   return (
-    <div className="fixed inset-0 z-50 mx-auto flex max-w-[430px] flex-col justify-end">
+    <div
+      className="fixed inset-0 z-50 mx-auto flex max-w-[430px] flex-col justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-label="독서 상태 선택"
+    >
       {/* Overlay */}
       <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" onClick={handleOverlayClose} />
 
@@ -63,6 +72,7 @@ export default function AddToLibrarySheet({
       <div className="relative flex flex-col items-stretch overflow-hidden rounded-t-xl bg-card shadow-2xl ring-1 ring-black/5">
         {/* Handle */}
         <button
+          ref={initialFocusRef}
           className="flex h-6 w-full items-center justify-center pt-2"
           onClick={handleOverlayClose}
           disabled={isSaving}

--- a/src/components/common/AddToLibrarySheet.tsx
+++ b/src/components/common/AddToLibrarySheet.tsx
@@ -63,7 +63,7 @@ export default function AddToLibrarySheet({
       className="fixed inset-0 z-50 mx-auto flex max-w-[430px] flex-col justify-end"
       role="dialog"
       aria-modal="true"
-      aria-label="독서 상태 선택"
+      aria-labelledby="add-to-library-title"
     >
       {/* Overlay */}
       <div className="absolute inset-0 bg-black/20 backdrop-blur-sm" onClick={handleOverlayClose} />
@@ -82,7 +82,10 @@ export default function AddToLibrarySheet({
         </button>
 
         <div className="flex-1">
-          <h1 className="px-6 pb-4 pt-6 text-center text-xl font-bold leading-tight tracking-tight">
+          <h1
+            id="add-to-library-title"
+            className="px-6 pb-4 pt-6 text-center text-xl font-bold leading-tight tracking-tight"
+          >
             독서 상태 선택
           </h1>
 

--- a/src/components/common/PageLoader.tsx
+++ b/src/components/common/PageLoader.tsx
@@ -1,10 +1,17 @@
 /**
  * lazy 라우트 청크 로딩 중 표시하는 전체 화면 스피너 fallback.
+ *
+ * 스피너는 장식이라 aria-hidden 처리하고, 스크린리더에는 sr-only 텍스트 + live region으로
+ * 로딩 상태를 알린다.
  */
 export default function PageLoader() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="size-12 animate-spin rounded-full border-4 border-primary/20 border-t-primary" />
+    <div role="status" aria-live="polite" className="flex min-h-screen items-center justify-center">
+      <div
+        aria-hidden="true"
+        className="size-12 animate-spin rounded-full border-4 border-primary/20 border-t-primary"
+      />
+      <span className="sr-only">페이지를 불러오는 중...</span>
     </div>
   )
 }

--- a/src/components/common/PageLoader.tsx
+++ b/src/components/common/PageLoader.tsx
@@ -1,0 +1,10 @@
+/**
+ * lazy 라우트 청크 로딩 중 표시하는 전체 화면 스피너 fallback.
+ */
+export default function PageLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="size-12 animate-spin rounded-full border-4 border-primary/20 border-t-primary" />
+    </div>
+  )
+}

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -150,8 +150,12 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
             </div>
           </div>
 
-          {/* 이동 영역: 책 정보 + 공개된 감상 내용 */}
-          <Link to={`/review/${review.id}`} className="block">
+          {/* 이동 영역: 책 정보 + 공개된 감상 내용. 링크 내부 텍스트가 길어 SR 접근명은 aria-label로 간결화 */}
+          <Link
+            to={`/review/${review.id}`}
+            aria-label={`${review.book.title} 감상 상세 보기`}
+            className="block"
+          >
             <div className="mb-4 flex gap-4">
               <div className="h-28 w-20 shrink-0 overflow-hidden rounded-md bg-primary/5 shadow-md">
                 {review.book.coverImageUrl ? (

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -95,168 +95,154 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
     className
   )
 
-  const inner = (
-    <div className="p-4">
-      {/* User Header */}
-      <div className="mb-4 flex items-center justify-between">
-        <Link
-          to={`/user/${review.author.id}`}
-          onClick={e => e.stopPropagation()}
-          className="flex items-center gap-3"
-        >
-          <div className="size-10 overflow-hidden rounded-full border border-primary/10 bg-primary/10">
-            {review.author.profileImageUrl && (
-              <img
-                src={review.author.profileImageUrl}
-                alt={review.author.nickname}
-                className="size-full object-cover"
-              />
-            )}
-          </div>
-          <div>
-            <p className="text-sm font-bold">{review.author.nickname}</p>
-            <p className="text-xs text-muted-foreground">{formatRelativeTime(review.createdAt)}</p>
-          </div>
-        </Link>
-        <div className="flex items-center gap-2">
-          {status && (
-            <span
-              className={cn(
-                'rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider',
-                status.variant === 'solid'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-primary/10 text-primary'
-              )}
-            >
-              {status.text}
-            </span>
-          )}
-          {!isMyReview && (
-            <button
-              type="button"
-              onClick={e => {
-                e.preventDefault()
-                e.stopPropagation()
-                setIsReportOpen(true)
-              }}
-              aria-label="신고"
-              className="flex size-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
-            >
-              <span className="material-symbols-outlined text-[18px]">more_vert</span>
-            </button>
-          )}
-        </div>
-      </div>
-
-      {/* Book Info */}
-      <div className="mb-4 flex gap-4">
-        <div className="h-28 w-20 shrink-0 overflow-hidden rounded-md bg-primary/5 shadow-md">
-          {review.book.coverImageUrl ? (
-            <img
-              src={review.book.coverImageUrl}
-              alt={review.book.title}
-              className="size-full object-cover"
-            />
-          ) : (
-            // 빈 src는 브라우저가 현재 페이지를 재요청하므로 placeholder로 분기
-            <div
-              aria-hidden="true"
-              className="flex size-full items-center justify-center text-xs text-muted-foreground/60"
-            >
-              <span className="material-symbols-outlined text-2xl">menu_book</span>
-            </div>
-          )}
-        </div>
-        <div className="flex flex-col justify-center">
-          <h3 className="text-lg font-bold leading-tight text-primary">{review.book.title}</h3>
-          <p className="mb-2 text-sm">{review.book.author}</p>
-          {review.rating && <StarRating rating={review.rating} size="md" />}
-        </div>
-      </div>
-
-      {/* Review Text */}
-      {review.hasSpoiler && !spoilerRevealed ? (
-        <button
-          onClick={e => {
-            e.preventDefault()
-            setSpoilerRevealed(true)
-          }}
-          className="group relative mb-4 w-full cursor-pointer"
-        >
-          <div className="pointer-events-none select-none opacity-40 blur-md">
-            <p className="text-sm leading-relaxed">{review.content}</p>
-          </div>
-          <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg border border-primary/10 bg-primary/5 transition-colors group-hover:bg-primary/10">
-            <span className="material-symbols-outlined mb-1 text-primary">visibility_off</span>
-            <p className="text-[13px] font-bold text-primary">스포일러 포함 — 탭하여 보기</p>
-          </div>
-        </button>
-      ) : (
-        <div className="mb-4">
-          <p className="text-sm leading-relaxed">
-            {review.content}
-            {!review.hasSpoiler && (
-              <span className="ml-1 cursor-pointer font-medium text-primary">더보기</span>
-            )}
-          </p>
-        </div>
-      )}
-
-      {/* Actions */}
-      <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
-        {!isMyReview ? (
-          <button
-            onClick={e => {
-              e.preventDefault()
-              e.stopPropagation()
-              toggleLike()
-            }}
-            disabled={isLiking}
-            aria-label={liked ? '좋아요 취소' : '좋아요'}
-            className={cn(
-              'flex items-center gap-1.5 transition-colors disabled:opacity-60',
-              liked ? 'text-primary' : 'hover:text-primary'
-            )}
-          >
-            <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
-              favorite
-            </span>
-            <span className="text-xs font-bold">{likeCount}</span>
-          </button>
-        ) : likeCount > 0 ? (
-          <div className="flex items-center gap-1.5 text-muted-foreground">
-            <span className="material-symbols-outlined text-xl">favorite</span>
-            <span className="text-xs font-bold">{likeCount}</span>
-          </div>
-        ) : null}
-        <button
-          onClick={e => {
-            e.preventDefault()
-            e.stopPropagation()
-            navigate(`/review/${review.id}#comments`)
-          }}
-          className="flex items-center gap-1.5 transition-colors hover:text-primary"
-        >
-          <span className="material-symbols-outlined text-xl">chat_bubble</span>
-          <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
-        </button>
-      </div>
-    </div>
-  )
-
   return (
     <>
-      <div
-        role="link"
-        tabIndex={0}
-        onClick={() => navigate(`/review/${review.id}`)}
-        onKeyDown={e => {
-          if (e.key === 'Enter' && e.currentTarget === e.target) navigate(`/review/${review.id}`)
-        }}
-        className={cn(cardClassName, 'cursor-pointer')}
-      >
-        {inner}
-      </div>
+      {/*
+        접근성(M-6): 카드 루트를 인터랙티브(role="link")로 두면 내부 Link/button이 중첩되어
+        nested-interactive 위반이 된다. 루트는 비인터랙티브 컨테이너로 두고, "본문(책 정보 +
+        공개된 감상 내용)"만 단일 <Link>로 감싸 이동 영역으로 삼는다. 작성자 링크·신고·좋아요·
+        댓글·스포일러 공개는 Link 밖 형제로 분리해 중첩을 제거한다.
+      */}
+      <article className={cardClassName}>
+        <div className="p-4">
+          {/* User Header (이동 영역 아님) */}
+          <div className="mb-4 flex items-center justify-between">
+            <Link to={`/user/${review.author.id}`} className="flex items-center gap-3">
+              <div className="size-10 overflow-hidden rounded-full border border-primary/10 bg-primary/10">
+                {review.author.profileImageUrl && (
+                  <img
+                    src={review.author.profileImageUrl}
+                    alt={review.author.nickname}
+                    className="size-full object-cover"
+                  />
+                )}
+              </div>
+              <div>
+                <p className="text-sm font-bold">{review.author.nickname}</p>
+                <p className="text-xs text-muted-foreground">
+                  {formatRelativeTime(review.createdAt)}
+                </p>
+              </div>
+            </Link>
+            <div className="flex items-center gap-2">
+              {status && (
+                <span
+                  className={cn(
+                    'rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider',
+                    status.variant === 'solid'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-primary/10 text-primary'
+                  )}
+                >
+                  {status.text}
+                </span>
+              )}
+              {!isMyReview && (
+                <button
+                  type="button"
+                  onClick={() => setIsReportOpen(true)}
+                  aria-label="신고"
+                  className="flex size-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
+                >
+                  <span className="material-symbols-outlined text-[18px]">more_vert</span>
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* 이동 영역: 책 정보 + 공개된 감상 내용 */}
+          <Link to={`/review/${review.id}`} className="block">
+            <div className="mb-4 flex gap-4">
+              <div className="h-28 w-20 shrink-0 overflow-hidden rounded-md bg-primary/5 shadow-md">
+                {review.book.coverImageUrl ? (
+                  <img
+                    src={review.book.coverImageUrl}
+                    alt={review.book.title}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  // 빈 src는 브라우저가 현재 페이지를 재요청하므로 placeholder로 분기
+                  <div
+                    aria-hidden="true"
+                    className="flex size-full items-center justify-center text-xs text-muted-foreground/60"
+                  >
+                    <span className="material-symbols-outlined text-2xl">menu_book</span>
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col justify-center">
+                <h3 className="text-lg font-bold leading-tight text-primary">
+                  {review.book.title}
+                </h3>
+                <p className="mb-2 text-sm">{review.book.author}</p>
+                {review.rating && <StarRating rating={review.rating} size="md" />}
+              </div>
+            </div>
+
+            {/* 감상 내용 (스포일러 비공개 시에는 아래 별도 버튼으로 분리) */}
+            {(!review.hasSpoiler || spoilerRevealed) && (
+              <p className="mb-4 text-sm leading-relaxed">
+                {review.content}
+                {!review.hasSpoiler && (
+                  <span className="ml-1 font-medium text-primary">더보기</span>
+                )}
+              </p>
+            )}
+          </Link>
+
+          {/* 스포일러 가림막 — 이동이 아니라 '공개' 동작이므로 Link 밖 버튼으로 분리 */}
+          {review.hasSpoiler && !spoilerRevealed && (
+            <button
+              type="button"
+              onClick={() => setSpoilerRevealed(true)}
+              aria-label="스포일러 감상 보기"
+              className="group relative mb-4 w-full cursor-pointer"
+            >
+              <div className="pointer-events-none select-none opacity-40 blur-md">
+                <p className="text-sm leading-relaxed">{review.content}</p>
+              </div>
+              <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg border border-primary/10 bg-primary/5 transition-colors group-hover:bg-primary/10">
+                <span className="material-symbols-outlined mb-1 text-primary">visibility_off</span>
+                <p className="text-[13px] font-bold text-primary">스포일러 포함 — 탭하여 보기</p>
+              </div>
+            </button>
+          )}
+
+          {/* Actions (이동 영역 아님) */}
+          <div className="flex items-center gap-6 border-t border-primary/5 pt-2">
+            {!isMyReview ? (
+              <button
+                type="button"
+                onClick={() => toggleLike()}
+                disabled={isLiking}
+                aria-label={liked ? '좋아요 취소' : '좋아요'}
+                className={cn(
+                  'flex items-center gap-1.5 transition-colors disabled:opacity-60',
+                  liked ? 'text-primary' : 'hover:text-primary'
+                )}
+              >
+                <span className={cn('material-symbols-outlined text-xl', liked && 'fill-icon')}>
+                  favorite
+                </span>
+                <span className="text-xs font-bold">{likeCount}</span>
+              </button>
+            ) : likeCount > 0 ? (
+              <div className="flex items-center gap-1.5 text-muted-foreground">
+                <span className="material-symbols-outlined text-xl">favorite</span>
+                <span className="text-xs font-bold">{likeCount}</span>
+              </div>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => navigate(`/review/${review.id}#comments`)}
+              className="flex items-center gap-1.5 transition-colors hover:text-primary"
+            >
+              <span className="material-symbols-outlined text-xl">chat_bubble</span>
+              <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
+            </button>
+          </div>
+        </div>
+      </article>
       <ReportDialog
         open={isReportOpen}
         onOpenChange={setIsReportOpen}

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { likeReview, unlikeReview } from '@/api/review'
 import { cn, formatRelativeTime } from '@/lib/utils'
 import { useAuthStore } from '@/store/authStore'
@@ -42,7 +42,6 @@ const statusLabel: Record<string, { text: string; variant: 'solid' | 'outline' }
 }
 
 export default function ReviewCard({ review, className }: ReviewCardProps) {
-  const navigate = useNavigate()
   const currentUserId = useAuthStore(state => state.user?.id)
   const isMyReview = currentUserId != null && review.author.id === currentUserId
 
@@ -236,14 +235,16 @@ export default function ReviewCard({ review, className }: ReviewCardProps) {
                 <span className="text-xs font-bold">{likeCount}</span>
               </div>
             ) : null}
-            <button
-              type="button"
-              onClick={() => navigate(`/review/${review.id}#comments`)}
+            <Link
+              to={`/review/${review.id}#comments`}
+              aria-label="댓글 보기"
               className="flex items-center gap-1.5 transition-colors hover:text-primary"
             >
-              <span className="material-symbols-outlined text-xl">chat_bubble</span>
+              <span className="material-symbols-outlined text-xl" aria-hidden="true">
+                chat_bubble
+              </span>
               <span className="text-xs font-bold">{review.commentCount ?? 0}</span>
-            </button>
+            </Link>
           </div>
         </div>
       </article>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -27,10 +27,14 @@ export default function AppHeader({
       <div className="flex w-10 items-center">
         {showBack && (
           <button
+            type="button"
             onClick={() => navigate(-1)}
+            aria-label="이전 페이지로 돌아가기"
             className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
           >
-            <span className="material-symbols-outlined">arrow_back</span>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              arrow_back
+            </span>
           </button>
         )}
       </div>

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,0 +1,40 @@
+import { useEffect, type RefObject } from 'react'
+
+interface UseModalA11yOptions {
+  isOpen: boolean
+  onClose: () => void
+  isBlocked?: boolean
+  initialFocusRef?: RefObject<HTMLElement | null>
+}
+
+/**
+ * 모달/바텀시트 공통 접근성 동작.
+ *
+ * - 열렸을 때 body 스크롤 잠금(배경 스크롤 누출 방지), 닫힐 때 원복
+ * - Escape 키로 onClose 호출 (isBlocked면 무시 — 저장/로딩 중 닫힘 방지)
+ * - 열릴 때 initialFocusRef로 초기 포커스 이동 (키보드/스크린리더 진입점)
+ *
+ * @remarks 전체 포커스 트랩은 범위 외(Radix 기반 ui/dialog가 담당). PopupBanner의
+ *          기존 로직을 추출해 다른 커스텀 시트가 재사용하도록 한다.
+ */
+export function useModalA11y({
+  isOpen,
+  onClose,
+  isBlocked = false,
+  initialFocusRef,
+}: UseModalA11yOptions) {
+  useEffect(() => {
+    if (!isOpen) return
+    initialFocusRef?.current?.focus()
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isBlocked) onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [isOpen, onClose, isBlocked, initialFocusRef])
+}

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,4 +1,4 @@
-import { useEffect, type RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
 
 interface UseModalA11yOptions {
   isOpen: boolean
@@ -23,18 +23,25 @@ export function useModalA11y({
   isBlocked = false,
   initialFocusRef,
 }: UseModalA11yOptions) {
+  // onClose를 ref로 고정해, 호출부가 매 렌더 새 함수를 넘겨도 effect가 teardown/재등록되거나
+  // 초기 포커스를 반복 호출(포커스 탈취)하지 않도록 한다.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
   useEffect(() => {
     if (!isOpen) return
     initialFocusRef?.current?.focus()
     const prevOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isBlocked) onClose()
+      if (e.key === 'Escape' && !isBlocked) onCloseRef.current()
     }
     document.addEventListener('keydown', onKeyDown)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
       document.body.style.overflow = prevOverflow
     }
-  }, [isOpen, onClose, isBlocked, initialFocusRef])
+  }, [isOpen, isBlocked, initialFocusRef])
 }

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import {
   getBook,
@@ -345,40 +345,51 @@ export default function BookReviewsListPage() {
             return (
               <article
                 key={review.reviewId}
-                onClick={() => navigate(`/review/${review.reviewId}`)}
-                className="cursor-pointer rounded-lg border-l-4 border-primary bg-card p-6 shadow-sm transition-colors hover:bg-primary/5"
+                className="rounded-lg border-l-4 border-primary bg-card p-6 shadow-sm transition-colors hover:bg-primary/5"
               >
-                <div className="mb-4 flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="size-10 overflow-hidden rounded-full bg-primary/10">
-                      {review.user.profileImageUrl ? (
-                        <img
-                          src={review.user.profileImageUrl}
-                          alt={review.user.nickname}
-                          className="size-full object-cover"
-                        />
-                      ) : (
-                        <div className="flex size-full items-center justify-center">
-                          <span className="material-symbols-outlined text-primary/40">person</span>
-                        </div>
-                      )}
+                {/*
+                  접근성(M-7): 카드 전체 onClick 대신 "이동 영역(작성자/평점 + 공개된 감상 내용)"만
+                  <Link>로 감싼다. 스포일러 공개·좋아요는 Link 밖 형제 버튼으로 분리해 인터랙티브
+                  중첩과 키보드 접근 불가 문제를 해소한다.
+                */}
+                <Link to={`/review/${review.reviewId}`} className="block">
+                  <div className="mb-4 flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="size-10 overflow-hidden rounded-full bg-primary/10">
+                        {review.user.profileImageUrl ? (
+                          <img
+                            src={review.user.profileImageUrl}
+                            alt={review.user.nickname}
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex size-full items-center justify-center">
+                            <span className="material-symbols-outlined text-primary/40">
+                              person
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <p className="text-sm font-bold">{review.user.nickname}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatRelativeTime(review.createdAt)}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-sm font-bold">{review.user.nickname}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {formatRelativeTime(review.createdAt)}
-                      </p>
-                    </div>
+                    <StarRating rating={review.rating} size="sm" />
                   </div>
-                  <StarRating rating={review.rating} size="sm" />
-                </div>
 
-                {review.isSpoiler && !revealedSpoilers.has(review.reviewId) ? (
+                  {(!review.isSpoiler || revealedSpoilers.has(review.reviewId)) && (
+                    <p className="mb-4 line-clamp-4 leading-relaxed">{review.content}</p>
+                  )}
+                </Link>
+
+                {review.isSpoiler && !revealedSpoilers.has(review.reviewId) && (
                   <button
-                    onClick={e => {
-                      e.stopPropagation()
-                      toggleSpoiler(review.reviewId)
-                    }}
+                    type="button"
+                    onClick={() => toggleSpoiler(review.reviewId)}
+                    aria-label="스포일러 감상 보기"
                     className="group relative w-full cursor-pointer text-left"
                   >
                     <div className="pointer-events-none select-none blur-md">
@@ -393,18 +404,15 @@ export default function BookReviewsListPage() {
                       </p>
                     </div>
                   </button>
-                ) : (
-                  <p className="mb-4 line-clamp-4 leading-relaxed">{review.content}</p>
                 )}
 
                 <div className="mt-4 flex items-center gap-6 text-muted-foreground">
                   {!isMyReview ? (
                     <button
                       type="button"
-                      onClick={e => {
-                        e.stopPropagation()
+                      onClick={() =>
                         handleToggleLike(review.reviewId, review.isLiked, review.likeCount)
-                      }}
+                      }
                       aria-label={review.isLiked ? '좋아요 취소' : '좋아요'}
                       className={cn(
                         'flex items-center gap-1 transition-colors',

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -352,7 +352,11 @@ export default function BookReviewsListPage() {
                   <Link>로 감싼다. 스포일러 공개·좋아요는 Link 밖 형제 버튼으로 분리해 인터랙티브
                   중첩과 키보드 접근 불가 문제를 해소한다.
                 */}
-                <Link to={`/review/${review.reviewId}`} className="block">
+                <Link
+                  to={`/review/${review.reviewId}`}
+                  aria-label={`${review.user.nickname}님의 감상 상세 보기`}
+                  className="block"
+                >
                   <div className="mb-4 flex items-start justify-between">
                     <div className="flex items-center gap-3">
                       <div className="size-10 overflow-hidden rounded-full bg-primary/10">

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -497,9 +497,9 @@ export default function MyProfilePage() {
           ) : (
             <div className="space-y-4">
               {visibleReviews.map(review => (
-                <article
+                <Link
                   key={review.reviewId}
-                  onClick={() => navigate(`/review/${review.reviewId}`)}
+                  to={`/review/${review.reviewId}`}
                   className="flex cursor-pointer gap-4 rounded-[24px] bg-card p-4 shadow-sm transition-colors hover:bg-primary/5"
                 >
                   <div className="flex h-[96px] w-[76px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-primary/5">
@@ -542,7 +542,7 @@ export default function MyProfilePage() {
                       </span>
                     </div>
                   </div>
-                </article>
+                </Link>
               ))}
             </div>
           )}

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -132,7 +132,13 @@ export default function NotificationsPage() {
         setNextCursor(response.nextCursor)
         setHasNext(response.hasNext)
         if (response.content.some(n => !n.isRead)) {
-          markAllNotificationsAsRead().catch(() => {})
+          markAllNotificationsAsRead()
+            .then(() => {
+              if (!controller.signal.aborted) {
+                setNotifications(prev => prev.map(n => ({ ...n, isRead: true })))
+              }
+            })
+            .catch(() => {})
         }
       } catch (error) {
         if (axios.isCancel(error) || controller.signal.aborted) return

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -138,6 +138,7 @@ export default function NotificationsPage() {
                 setNotifications(prev => prev.map(n => ({ ...n, isRead: true })))
               }
             })
+            // read-all 실패는 무시 — 로컬은 미읽음으로 남고, 개별 클릭 시 read PATCH로 자연 복구된다
             .catch(() => {})
         }
       } catch (error) {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -222,9 +222,11 @@ export default function SignupPage() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 표시'}
+                    aria-pressed={showPassword}
                     className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground"
                   >
-                    <span className="material-symbols-outlined">
+                    <span className="material-symbols-outlined" aria-hidden="true">
                       {showPassword ? 'visibility_off' : 'visibility'}
                     </span>
                   </button>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -155,10 +155,14 @@ export default function SignupPage() {
       {/* Header */}
       <div className="flex items-center justify-between p-4 pb-2">
         <button
+          type="button"
           onClick={() => (step === 1 ? navigate(-1) : handleBackToStep1())}
+          aria-label="뒤로 가기"
           className="flex size-12 shrink-0 items-center text-primary"
         >
-          <span className="material-symbols-outlined text-[24px]">arrow_back</span>
+          <span className="material-symbols-outlined text-[24px]" aria-hidden="true">
+            arrow_back
+          </span>
         </button>
         <h2 className="flex-1 pr-12 text-center text-lg font-bold leading-tight tracking-tight">
           {step === 1 ? '회원가입' : 'Shelfeed'}

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import AppHeader from '@/components/layout/AppHeader'
 import { getUserProfile, type UserProfile } from '@/api/member'
@@ -432,9 +432,9 @@ export default function UserProfilePage() {
           ) : (
             <div className="space-y-4">
               {reviews.map(review => (
-                <article
+                <Link
                   key={review.reviewId}
-                  onClick={() => navigate(`/review/${review.reviewId}`)}
+                  to={`/review/${review.reviewId}`}
                   className="flex cursor-pointer gap-4 rounded-[24px] bg-card p-4 shadow-sm transition-colors hover:bg-primary/5"
                 >
                   <div className="flex h-[96px] w-[76px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-primary/5">
@@ -477,7 +477,7 @@ export default function UserProfilePage() {
                       </span>
                     </div>
                   </div>
-                </article>
+                </Link>
               ))}
             </div>
           )}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,32 +1,34 @@
+import { lazy, Suspense } from 'react'
 import { createBrowserRouter, Outlet } from 'react-router-dom'
-import HomeFeedPage from '@/pages/HomeFeedPage'
 import LoginPage from '@/pages/LoginPage'
-import SignupPage from '@/pages/SignupPage'
-import BookSearchPage from '@/pages/BookSearchPage'
-import BookDetailPage from '@/pages/BookDetailPage'
-import WriteReviewPage from '@/pages/WriteReviewPage'
-import ReviewDetailPage from '@/pages/ReviewDetailPage'
-import MyProfilePage from '@/pages/MyProfilePage'
-import SettingsPage from '@/pages/SettingsPage'
-import NotificationsPage from '@/pages/NotificationsPage'
-import MyLibraryPage from '@/pages/MyLibraryPage'
-import BookReviewsListPage from '@/pages/BookReviewsListPage'
-import OnboardingPage from '@/pages/OnboardingPage'
-import AuthCallbackPage from '@/pages/AuthCallbackPage'
-import PasswordResetRequestPage from '@/pages/PasswordResetRequestPage'
-import PasswordResetPage from '@/pages/PasswordResetPage'
-import EmailVerificationPage from '@/pages/EmailVerificationPage'
-import PasswordChangePage from '@/pages/PasswordChangePage'
-import BlockedUsersPage from '@/pages/BlockedUsersPage'
-import WithdrawPage from '@/pages/WithdrawPage'
-import GenreSelectionPage from '@/pages/GenreSelectionPage'
-import EditProfilePage from '@/pages/EditProfilePage'
-import UserProfilePage from '@/pages/UserProfilePage'
-import LibraryBookDetailPage from '@/pages/LibraryBookDetailPage'
-import UserLibraryPage from '@/pages/UserLibraryPage'
-import FollowListPage from '@/pages/FollowListPage'
+const HomeFeedPage = lazy(() => import('@/pages/HomeFeedPage'))
+const SignupPage = lazy(() => import('@/pages/SignupPage'))
+const BookSearchPage = lazy(() => import('@/pages/BookSearchPage'))
+const BookDetailPage = lazy(() => import('@/pages/BookDetailPage'))
+const WriteReviewPage = lazy(() => import('@/pages/WriteReviewPage'))
+const ReviewDetailPage = lazy(() => import('@/pages/ReviewDetailPage'))
+const MyProfilePage = lazy(() => import('@/pages/MyProfilePage'))
+const SettingsPage = lazy(() => import('@/pages/SettingsPage'))
+const NotificationsPage = lazy(() => import('@/pages/NotificationsPage'))
+const MyLibraryPage = lazy(() => import('@/pages/MyLibraryPage'))
+const BookReviewsListPage = lazy(() => import('@/pages/BookReviewsListPage'))
+const OnboardingPage = lazy(() => import('@/pages/OnboardingPage'))
+const AuthCallbackPage = lazy(() => import('@/pages/AuthCallbackPage'))
+const PasswordResetRequestPage = lazy(() => import('@/pages/PasswordResetRequestPage'))
+const PasswordResetPage = lazy(() => import('@/pages/PasswordResetPage'))
+const EmailVerificationPage = lazy(() => import('@/pages/EmailVerificationPage'))
+const PasswordChangePage = lazy(() => import('@/pages/PasswordChangePage'))
+const BlockedUsersPage = lazy(() => import('@/pages/BlockedUsersPage'))
+const WithdrawPage = lazy(() => import('@/pages/WithdrawPage'))
+const GenreSelectionPage = lazy(() => import('@/pages/GenreSelectionPage'))
+const EditProfilePage = lazy(() => import('@/pages/EditProfilePage'))
+const UserProfilePage = lazy(() => import('@/pages/UserProfilePage'))
+const LibraryBookDetailPage = lazy(() => import('@/pages/LibraryBookDetailPage'))
+const UserLibraryPage = lazy(() => import('@/pages/UserLibraryPage'))
+const FollowListPage = lazy(() => import('@/pages/FollowListPage'))
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 import RouteError from '@/components/common/RouteError'
+import PageLoader from '@/components/common/PageLoader'
 
 const appRoutes = [
   {
@@ -241,7 +243,11 @@ const appRoutes = [
 
 export const router = createBrowserRouter([
   {
-    element: <Outlet />,
+    element: (
+      <Suspense fallback={<PageLoader />}>
+        <Outlet />
+      </Suspense>
+    ),
     errorElement: <RouteError />,
     children: appRoutes,
   },


### PR DESCRIPTION
  ## 개요
  배포 직전 코드 리뷰의 남은 MEDIUM 결함 중 프론트만으로 가능한 7건을 묶어 처리합니다. #194·#196에 이은 작업. 단일 브랜치에 트랙별 논리 커밋으로 분리했습니다.

  Closes #198

  ## 변경 사항 (커밋 4개)
  - **접근성(M-6~M-10)**: ReviewCard/BookReviewsListPage 인터랙티브 중첩 제거(본문만 Link + 액션 분리), 프로필·도서 카드 키보드 접근(article→Link), 모달 a11y
  공통 훅 `useModalA11y` + AddToLibrarySheet 적용, AppHeader·SignupPage 아이콘 버튼 aria
  - **알림(M-3)**: read-all 성공 후 로컬 isRead 동기화 (desync·중복 PATCH 해소)
  - **코드스플리팅(M-12)**: React.lazy + Suspense, 메인 번들 **307kB → 60kB**(gzip 23kB)
  - **코드 리뷰 반영**: 본문 Link aria-label 간결화, 알림 주석

  ## 검증
  - `tsc -b && vite build` ✅ (27개 페이지 청크 분리 확인)
  - `eslint .` ✅ 0 errors · 변경 파일 `prettier --check` ✅
  - code-reviewer(Opus) 별도 리뷰 ✅ **APPROVE** (회귀 0건, CRITICAL/HIGH 0)

  ## 동작 변화 참고
  - M-6/M-7: 카드 "전체 클릭→이동"이 "본문(책정보+감상) 클릭→이동"으로 변경(액션 버튼 영역은 이동 안 함 — 의도된 접근성 개선). 마우스 동작 회귀 확인함.

  ## 후속 (별도)
  - M-4(프로필 PUBLIC 페이지네이션, 백엔드 협의), format-sweep(전역 prettier 78파일), og:image, react-query 도입
  - `useModalA11y`의 PopupBanner/OcrInputMethodSheet 확산 적용, 로고 `h1 role=link`→`Link` 통일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - 페이지 전환 시 로딩 스피너 표시로 시각적 피드백 제공
  - 모달과 버튼의 접근성 개선으로 화면 판독기 지원 강화

* **Bug Fixes**
  - 리뷰 카드 상호작용 구조 개선으로 클릭 동작 안정화
  - 알림 일괄 읽음 처리 로직 개선

* **Performance**
  - 페이지 로딩 성능 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->