### PR TITLE
chore: prettier 포맷 안정화 - package-lock ignore + 줄바꿈 LF 통일 (#200)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# 모든 텍스트 파일을 LF로 통일한다.
+# OS(특히 Windows의 CRLF) 차이로 전체 파일이 modified로 뜨거나 prettier format:check가
+# 깜빡이는 문제를 방지한다. prettier 기본값(endOfLine: "lf")과도 일치한다.
+# 바이너리(png/jpg 등)는 text=auto가 자동 감지해 정규화 대상에서 제외한다.
+* text=auto eol=lf

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 dist
 node_modules
 .husky
+
+# 자동 생성 잠금 파일 — npm install 시 재생성되어 prettier 포맷이 깨지므로 format:check 대상에서 제외
+package-lock.json


### PR DESCRIPTION
  ## 개요
  CI `format:check` 안정화를 위한 포맷/줄바꿈 설정 정비입니다. 애플리케이션 로직 변경 없음.

  Closes #200

  ## 변경 사항
  - **`.prettierignore`**: `package-lock.json` ignore 추가 — npm 자동 생성 파일이라 포맷 대상에 두면 `npm install` 후 `format:check`가 다시 깨짐. ignore로
  지속적 green 보장.
  - **`.gitattributes` (신규)**: `* text=auto eol=lf` — OS(Windows CRLF) 차이로 인한 전체 파일 phantom 수정·`format:check` 깜빡임을 영구 차단(prettier 기본값
  LF와 일치).

  ## 핵심
  - `npx prettier --write .` 실행 결과 **저장소 내용은 이미 전부 포맷 완료 상태**(내용 diff 0)였습니다. 로컬에서 "전체 파일 수정"으로 보인 건 CRLF↔LF 줄바꿈
  차이였고 git이 LF로 정규화 → 실질 변경은 위 설정 2개뿐입니다.

  ## 검증
  - `npm run format:check` ✅ GREEN
  - `npm run build` ✅ · `npm run lint` ✅ (0 errors)
  - `git diff HEAD` 내용 diff 0건

  ## 참고
  - 커밋 2개(`.prettierignore` / `.gitattributes`). 머지 시 **Squash** 권장.
  - 이후 신규 클론·CI는 LF 기준으로 동작해 줄바꿈발 format:check 이슈가 재발하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 일관성 유지를 위한 개발 환경 설정 개선
  * 자동 생성 파일이 코드 포맷팅 검사에서 제외되도록 구성

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->