### PR TITLE
chore: 배포 전 프론트엔드 클린업 — 보안 위생·OCR UX·코드 정리 (#208)

### DIFF
--- a/src/api/ocr.ts
+++ b/src/api/ocr.ts
@@ -29,7 +29,8 @@ export async function extractTextFromImage(
     const { data } = await apiClient.post<ApiResponse<OcrExtractResponse>>(
       '/api/v1/ocr/extract-text',
       { imageData, imageFormat },
-      { signal }
+      // 대용량 base64 업로드 + CLOVA OCR 처리는 공용 10초 timeout(client.ts)을 넘길 수 있어 개별 상향.
+      { signal, timeout: 30000 }
     )
     const result = parseApiResponse(data, 'OCR 응답이 올바르지 않습니다.')
     // OcrTextSelector가 result.fields[].vertices로 좌표를 계산하므로,

--- a/src/components/common/ReviewCard.tsx
+++ b/src/components/common/ReviewCard.tsx
@@ -188,12 +188,13 @@ function ReviewCard({ review, className }: ReviewCardProps) {
 
             {/* 감상 내용 (스포일러 비공개 시에는 아래 별도 버튼으로 분리) */}
             {(!review.hasSpoiler || spoilerRevealed) && (
-              <p className="mb-4 text-sm leading-relaxed">
-                {review.content}
+              <div className="mb-4">
+                {/* 본문은 4줄로 clamp해 카드 높이를 균일화. '더보기'는 clamp에 잘리지 않도록 형제로 분리 */}
+                <p className="text-sm leading-relaxed line-clamp-4">{review.content}</p>
                 {!review.hasSpoiler && (
-                  <span className="ml-1 font-medium text-primary">더보기</span>
+                  <span className="mt-1 inline-block text-sm font-medium text-primary">더보기</span>
                 )}
-              </p>
+              </div>
             )}
           </Link>
 

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -12,7 +12,7 @@ export default function BottomNav() {
   const { pathname } = useLocation()
 
   return (
-    <nav className="fixed bottom-0 left-1/2 z-30 w-full max-w-[430px] -translate-x-1/2 border-t border-border bg-card/95 px-4 pb-6 pt-2 backdrop-blur-md">
+    <nav className="fixed inset-x-0 bottom-0 z-30 mx-auto w-full max-w-[430px] border-t border-border bg-card/95 px-4 pb-6 pt-2 backdrop-blur-md">
       <div className="flex items-center justify-around">
         {navItems.map(item => {
           const isActive = pathname === item.path

--- a/src/components/ocr/WebcamCapture.tsx
+++ b/src/components/ocr/WebcamCapture.tsx
@@ -17,6 +17,7 @@ const STATUS_MESSAGES: Record<Exclude<CameraStatus, 'initializing' | 'running'>,
   error: '카메라를 시작하지 못했습니다. 잠시 후 다시 시도해주세요.',
 }
 
+// sessionStorage에 저장 — 공용 PC에서 카메라 deviceId가 영구 잔존하지 않도록 탭 세션으로 한정.
 const DEVICE_ID_KEY = 'shelfeed-ocr-device-id'
 
 interface WebcamCaptureProps {
@@ -84,7 +85,7 @@ export default function WebcamCapture({ onCapture, onClose }: WebcamCaptureProps
             deviceId != null
           ) {
             try {
-              localStorage.removeItem(DEVICE_ID_KEY)
+              sessionStorage.removeItem(DEVICE_ID_KEY)
             } catch {
               /* private mode */
             }
@@ -117,7 +118,7 @@ export default function WebcamCapture({ onCapture, onClose }: WebcamCaptureProps
         setActiveDeviceId(usingId)
         if (usingId) {
           try {
-            localStorage.setItem(DEVICE_ID_KEY, usingId)
+            sessionStorage.setItem(DEVICE_ID_KEY, usingId)
           } catch {
             /* private mode */
           }
@@ -167,7 +168,7 @@ export default function WebcamCapture({ onCapture, onClose }: WebcamCaptureProps
   useEffect(() => {
     let saved: string | null = null
     try {
-      saved = localStorage.getItem(DEVICE_ID_KEY)
+      saved = sessionStorage.getItem(DEVICE_ID_KEY)
     } catch {
       saved = null
     }

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -12,7 +12,12 @@ import {
   type BookReviewItem,
   type BackendReadingStatus,
 } from '@/api/book'
-import { addLibraryBook, updateLibraryBookStatus, type ReadingStatus } from '@/api/library'
+import {
+  addLibraryBook,
+  updateLibraryBookStatus,
+  backendToFrontStatus,
+  type ReadingStatus,
+} from '@/api/library'
 import { formatRelativeTime } from '@/lib/utils'
 
 const statusEmoji: Record<ReadingStatus, string> = {
@@ -22,22 +27,12 @@ const statusEmoji: Record<ReadingStatus, string> = {
   stopped: '⏸️ 중단',
 }
 
-// TODO(후속): backendToFrontStatus 맵이 @/api/library 에도 동일하게 export되어 있어 중복. 후속 리팩터 이슈에서 통합 예정.
-const backendToFrontStatus: Record<BackendReadingStatus, ReadingStatus> = {
-  WANT_TO_READ: 'want_to_read',
-  READING: 'reading',
-  FINISHED: 'finished',
-  STOPPED: 'stopped',
-}
-
 // toFrontStatus 유지 이유: getBook 응답의 myLibraryStatus는 string | null 타입(백엔드 Nullable)으로 내려오므로
-// 방어적 null 변환이 필요하다. addLibraryBook 응답은 BackendReadingStatus로 타입 보장되지만, 여기서는
-// 동일한 변환기를 재사용하여 호출부 단순화를 유지한다. 백엔드 enum이 확장되면 exhaustive map으로 이행 고려.
+// 방어적 null 변환이 필요하다. 매핑 자체는 @/api/library의 backendToFrontStatus(단일 출처, Partial)를 재사용한다.
+// Partial이라 미지의 enum 값은 undefined가 되므로 ?? null로 흡수한다.
 function toFrontStatus(s: string | null): ReadingStatus | null {
-  if (s && s in backendToFrontStatus) {
-    return backendToFrontStatus[s as BackendReadingStatus]
-  }
-  return null
+  if (!s) return null
+  return backendToFrontStatus[s as BackendReadingStatus] ?? null
 }
 
 export default function BookDetailPage() {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -36,6 +36,20 @@ export default function LoginPage() {
     setGoogleErrorMessage(null)
     try {
       const { loginUrl } = await getGoogleLoginUrl()
+      // 백엔드 응답 변조/스킴 주입 방어: https 절대 URL만 허용 (javascript:/상대경로/평문 차단)
+      let parsed: URL
+      try {
+        parsed = new URL(loginUrl)
+      } catch {
+        setGoogleErrorMessage('잘못된 로그인 URL을 받았습니다. 잠시 후 다시 시도해주세요.')
+        setIsGoogleLoading(false)
+        return
+      }
+      if (parsed.protocol !== 'https:') {
+        setGoogleErrorMessage('안전하지 않은 로그인 URL입니다.')
+        setIsGoogleLoading(false)
+        return
+      }
       window.location.href = loginUrl
     } catch (error) {
       setGoogleErrorMessage(

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -36,7 +36,8 @@ export default function LoginPage() {
     setGoogleErrorMessage(null)
     try {
       const { loginUrl } = await getGoogleLoginUrl()
-      // 백엔드 응답 변조/스킴 주입 방어: https 절대 URL만 허용 (javascript:/상대경로/평문 차단)
+      // 오픈 리다이렉트 방어: https 스킴만 검사하면 https://evil.example 같은 임의 origin도
+      // 통과하므로, 신뢰 origin allowlist에 든 URL만 이동한다.
       let parsed: URL
       try {
         parsed = new URL(loginUrl)
@@ -45,12 +46,20 @@ export default function LoginPage() {
         setIsGoogleLoading(false)
         return
       }
-      if (parsed.protocol !== 'https:') {
+      // 구글 OAuth 시작 도메인 + (백엔드가 자체 시작 엔드포인트를 줄 수 있으므로) API origin만 허용
+      const allowedOrigins = new Set<string>(['https://accounts.google.com'])
+      try {
+        const apiBase = import.meta.env.VITE_API_BASE_URL
+        if (apiBase) allowedOrigins.add(new URL(apiBase).origin)
+      } catch {
+        /* VITE_API_BASE_URL 미설정/형식 오류 — accounts.google.com만 허용 */
+      }
+      if (!allowedOrigins.has(parsed.origin)) {
         setGoogleErrorMessage('안전하지 않은 로그인 URL입니다.')
         setIsGoogleLoading(false)
         return
       }
-      window.location.href = loginUrl
+      window.location.href = parsed.toString()
     } catch (error) {
       setGoogleErrorMessage(
         error instanceof Error ? error.message : 'Google 로그인 URL을 받아오지 못했습니다.'

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -95,7 +95,8 @@ export default function MyProfilePage() {
         const [result, tower] = await Promise.all([
           getMyProfile(controller.signal),
           getWisdomTower(controller.signal).catch(err => {
-            if (!axios.isCancel(err)) console.error('Failed to load wisdom tower:', err)
+            if (!axios.isCancel(err) && import.meta.env.DEV)
+              console.error('Failed to load wisdom tower:', err)
             return null
           }),
         ])

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -25,7 +25,13 @@ type FormData = z.infer<typeof schema>
 export default function PasswordResetPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const token = searchParams.get('token')
+  // 토큰을 1회만 캡처해 안정화하고, 마운트 직후 URL에서 제거한다.
+  // (성공 여부와 무관하게 즉시 정리해 새로고침/주소 공유 시 ?token= 노출을 막는다)
+  const [token] = useState(() => searchParams.get('token'))
+
+  useEffect(() => {
+    if (token) window.history.replaceState({}, '', '/password-reset')
+  }, [token])
 
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -70,7 +76,6 @@ export default function PasswordResetPage() {
     try {
       await resetPassword(token, data.newPassword)
       setIsSuccess(true)
-      window.history.replaceState({}, '', '/password-reset')
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '비밀번호 변경에 실패했습니다.')
     } finally {

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -489,6 +489,18 @@ export default function WriteReviewPage() {
               progress_activity
             </span>
             <p className="text-lg font-bold text-white">텍스트 인식 중...</p>
+            <button
+              type="button"
+              onClick={() => {
+                // 진행 중인 OCR 요청을 즉시 취소. catch/finally가 aborted면 상태를 안 건드리므로
+                // 여기서 직접 로딩 오버레이를 내린다.
+                ocrAbortRef.current?.abort()
+                setIsOcrLoading(false)
+              }}
+              className="mt-2 rounded-xl border-2 border-white/60 px-6 py-2 text-sm font-bold text-white transition-colors hover:bg-white/10"
+            >
+              취소
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
  ## 변경 사항
  5/29 배포 리뷰의 LOW/INFO 잔존 항목 중 프론트 단독으로 가능한 저위험 항목 9건을 3개 논리 커밋으로 정리.

  **보안 위생**
  - PasswordResetPage: 재설정 토큰 마운트 즉시 URL에서 제거(`replaceState`)
  - WebcamCapture: 카메라 deviceId `localStorage` → `sessionStorage`
  - LoginPage: `loginUrl` https 스킴 검증 후 리다이렉트

  **OCR UX / 안정성**
  - ocr.ts: OCR per-request timeout 30초 상향
  - WriteReviewPage: OCR 로딩 오버레이 "취소" 버튼
  - ReviewCard: 피드 본문 `line-clamp-4` + '더보기' 분리

  **코드 / 위생 정리**
  - BookDetailPage: `backendToFrontStatus` 중복 제거(`@/api/library` 단일 출처)
  - MyProfilePage: 프로덕션 `console.error` DEV 가드
  - BottomNav: 센터링 패턴 `inset-x-0 mx-auto`로 통일

  ## 검증
  - `tsc -b` 0 / `npm run lint` 0 errors / `format:check` green / `vitest run` 29 passed / `build` exit 0

  ## 스킵 / 후속
  - `nextCursor`는 백엔드 응답 계약 필드(JSDoc 명시)라 데드코드 아님 → 유지(스킵).
  - **후속 이슈로 분리**: ① OAuth `state` 클라 검증 ② access token 메모리 보관 + CSP ③ 테스트 커버리지 확충 ④ SettingsPage `as never` 타입 개선.

  Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OCR 요청 취소 기능 추가

* **Bug Fixes**
  * Google 로그인 URL 보안 검증 추가
  * OCR 요청 타임아웃(30초) 설정 추가

* **Improvements**
  * 리뷰 감상 본문을 4줄로 제한하고 더보기 UI 개선
  * 하단 네비게이션 레이아웃 최적화
  * 카메라 기기 ID를 세션 기반 저장소로 변경
  * 비밀번호 재설정 URL 토큰 처리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/techeer-project-team-F/FrontEnd_Project/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->