### PR TITLE
fix: 통합검색 전체탭 최초 검색 stale 표시 수정 (#210)

### DIFF
--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -397,7 +397,12 @@ export default function BookSearchPage() {
 
   // 전체 탭 fetch — books/users 두 섹션 미리보기, 페이징 없음
   useEffect(() => {
-    if (restoredFromCache.current) return
+    // [#210] 도서/유저 탭과 달리 restoredFromCache 가드를 두지 않는다.
+    // 전체 탭은 페이지네이션·스크롤 위치가 없는 5건 미리보기라 캐시를 보존할 이득이 없고,
+    // 오히려 캐시 복원 후 가드에 막히면 stale 미리보기(예: 이전 검색의 도서 4건)가 그대로
+    // 노출되다가 탭을 왕복해야 갱신되는 버그가 있었다. 캐시값은 useState 초기값으로 즉시
+    // 렌더만 제공하고, effect가 항상 fresh fetch로 덮어쓴다. (도서/유저 탭은 무한스크롤
+    // 위치 보존을 위해 기존 가드 유지.)
     if (!trimmedQuery || activeTab !== 'all') {
       if (!trimmedQuery) {
         setAllBooks([])
@@ -451,7 +456,8 @@ export default function BookSearchPage() {
   }, [trimmedQuery, activeTab])
 
   // 반드시 restoredFromCache를 참조하는 모든 effect 뒤에 선언할 것.
-  // React는 useEffect를 선언 순서대로 실행하므로 위 4개 effect가 먼저 skip된 후 플래그 해제.
+  // React는 useEffect를 선언 순서대로 실행하므로 위 effect들(URL→state·도서·유저 탭)이
+  // 먼저 skip된 후 플래그가 해제된다. 전체 탭 effect는 #210 수정으로 이 가드를 쓰지 않는다.
   useEffect(() => {
     restoredFromCache.current = false
   }, [])


### PR DESCRIPTION
  ## 변경 사항
  - `BookSearchPage` 전체 탭 fetch effect에서 `restoredFromCache` 가드 제거 (1줄 + 주석)

  ## 배경
  검색 후 다른 페이지 이동 → 검색 페이지 재진입 시 `searchStore` 캐시가 복원되는데, `restoredFromCache` 가드가 전체 탭의 첫 fetch를 막아 stale 미리보기(이전 검색의 도서 4건)가 노출되고 '도서 검색 결과 전체 보기' 버튼이 안 떴습니다. '도서' 탭 왕복 후에야 갱신되던 버그.

  ## 원인
  - 백엔드 `/api/v1/search?type=all&limit=5`는 일관되게 5건 + hasNext=true 반환(5회 호출 확인) → 프론트 단독 stale 버그
  - `restoredFromCache`는 무한스크롤 탭(도서/유저)의 스크롤·페이지 상태 보존용인데, 전체 탭은 페이지네이션 없는 5건 미리보기라 캐시 보존 이득이 없고 stale만 유발

  ## 수정
  - 전체 탭: 가드 제거 → 항상 fresh fetch (캐시값은 즉시 렌더용 초기값으로만 사용)
  - 도서/유저 탭: 무한스크롤 위치 보존 위해 기존 가드 유지

  ## 검증
  - `tsc -b` 0 / `npm run lint` 0 errors / `format:check` green / `build` exit 0 / `vitest run` 29 passed
  - code-reviewer(Opus) 리뷰 APPROVE — 정확성·회귀(중복요청/비활성탭/flicker/race) 4개 벡터 안전

  Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 검색 미리보기가 이제 캐시 복원 상태에서도 항상 최신 데이터를 불러오도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->