### PR TITLE
fix: PWA 당겨서 새로고침 비활성화 (#212)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,13 @@
   * {
     @apply border-border;
   }
+  /* PWA pull-to-refresh 비활성화: 오버스크롤 차단은 스크롤 체인 최상위인 html에
+     적용돼야 당겨서 새로고침이 막힌다(안드로이드 크롬/PWA). contain은 페이지 내부
+     스크롤은 유지하면서 브라우저 새로고침으로의 전파만 차단. (iOS 사파리는 이 속성
+     미지원이라 막히지 않음 — 별도 구조 변경 필요해 이번 범위 제외) */
+  html {
+    overscroll-behavior-y: contain;
+  }
   body {
     @apply text-foreground;
     font-family: 'Newsreader', serif;


### PR DESCRIPTION
  ## 변경 사항
  - `src/index.css`의 `html`에 `overscroll-behavior-y: contain` 추가

  ## 배경
  PWA(홈 화면 추가)로 실행했을 때 화면을 아래로 당기면 새로고침이 동작해 SPA 상태가 초기화됐습니다. 기존 `body`에만 `overscroll-behavior: none`이 있었으나, pull-to-refresh 차단은 스크롤 체인 최상위인 `html`에 적용돼야 효과가 있습니다.

  ## 수정
  - `html`에 `overscroll-behavior-y: contain` — 페이지 내부 스크롤은 유지하면서 브라우저 새로고침으로의 오버스크롤 전파만 차단

  ## 검증
  - `npm run format:check` green / `npm run build` exit 0
  - 실제 동작: 안드로이드 PWA에서 당겨도 새로고침 안 됨, 내부 스크롤 정상

  ## 한계 (이번 범위 제외)
  - iOS 사파리/PWA는 `overscroll-behavior` 미지원이라 막히지 않음. iOS 차단은 `body position:fixed` + 내부 스크롤 컨테이너 구조 변경이 필요해 부작용 검증 후 별도 진행.

  Closes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * PWA 풀투리프레시(당겨서 새로고침) 동작 비활성화로 페이지 스크롤 시 의도하지 않은 새로고침이 발생하지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->