### PR TITLE
refactor: 모바일 바코드 스캔 속도 개선 (#214)

### DIFF
--- a/src/components/common/IsbnScannerModal.tsx
+++ b/src/components/common/IsbnScannerModal.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { createBarcodeDecoder } from '@/lib/barcodeDecoder'
+
 const DEVICE_ID_KEY = 'shelfeed-scan-device-id'
-const SCAN_INTERVAL = 200
+const SCAN_INTERVAL = 120
+// ROI를 디코딩 전 이 폭으로 축소한다. EAN-13(95모듈)엔 640px면 충분(≈6.7px/모듈)하고,
+// 디코딩 대상 픽셀 수를 줄여 모바일 인식 속도를 크게 높인다.
+const MAX_ROI_WIDTH = 640
 
 type ScannerStatus =
   | 'initializing'
@@ -156,9 +161,9 @@ export default function IsbnScannerModal({
     const track = streamRef.current?.getVideoTracks()[0]
     if (!track) return
     try {
-      const { BrowserCodeReader } = await import('@zxing/browser')
       const next = !torchOnRef.current
-      await BrowserCodeReader.mediaStreamSetTorch(track, next)
+      // 네이티브 트랙 제약으로 토치 제어 — zxing 의존 없이 동작(미지원 시 catch로 무시)
+      await track.applyConstraints({ advanced: [{ torch: next }] })
       torchOnRef.current = next
       setTorchOn(next)
     } catch {
@@ -185,15 +190,15 @@ export default function IsbnScannerModal({
           video: deviceId
             ? {
                 deviceId: { exact: deviceId },
-                width: { ideal: 1920 },
-                height: { ideal: 1080 },
+                width: { ideal: 1280 },
+                height: { ideal: 720 },
                 // @ts-expect-error focusMode는 TS 타입 미반영, ideal이므로 미지원 시 무시됨
                 focusMode: { ideal: 'continuous' },
               }
             : {
                 facingMode: { ideal: 'environment' },
-                width: { ideal: 1920 },
-                height: { ideal: 1080 },
+                width: { ideal: 1280 },
+                height: { ideal: 720 },
                 focusMode: { ideal: 'continuous' },
               },
         }
@@ -251,24 +256,18 @@ export default function IsbnScannerModal({
           }
         }
 
-        // ZXing lazy import로 메인 번들 영향 최소화
-        const [{ BrowserMultiFormatReader, BrowserCodeReader }, { BarcodeFormat, DecodeHintType }] =
-          await Promise.all([import('@zxing/browser'), import('@zxing/library')])
-        if (isStale()) return
-
-        // 토치 지원 감지
+        // 토치 지원 감지 (네이티브 트랙 capability — zxing 의존 제거)
         try {
-          setTorchAvailable(BrowserCodeReader.mediaStreamIsTorchCompatible(stream))
+          const caps = stream.getVideoTracks()[0]?.getCapabilities?.()
+          setTorchAvailable(!!caps?.torch)
         } catch {
           setTorchAvailable(false)
         }
 
-        // EAN-13만 타겟 (디폴트로 모든 포맷 시도하면 ISBN 바코드 인식이 느리고 자주 실패).
-        // TRY_HARDER: 정확도 우선, 처리 시간 약간 증가 (실시간 스캔에는 충분)
-        const hints = new Map<number, unknown>()
-        hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.EAN_13])
-        hints.set(DecodeHintType.TRY_HARDER, true)
-        const reader = new BrowserMultiFormatReader(hints)
+        // 네이티브 BarcodeDetector(안드로이드 등) 우선, 미지원 시 zxing 폴백.
+        // zxing은 폴백 경로에서만 동적 import되어 네이티브 환경의 번들 비용을 없앤다.
+        const decoder = await createBarcodeDecoder()
+        if (isStale()) return
 
         // 가이드 박스 영역만 크롭할 offscreen canvas
         const canvas = document.createElement('canvas')
@@ -284,45 +283,41 @@ export default function IsbnScannerModal({
         if (isStale()) return
 
         /**
-         * ROI 크롭 수동 디코딩 루프.
+         * ROI 크롭 + 다운스케일 수동 디코딩 루프.
          *
-         * 기존 `decodeFromVideoElement`는 전체 비디오 프레임을 디코딩하여
-         * 바코드 주변 노이즈(텍스트·이미지)가 인식률을 떨어뜨렸다.
-         * 가이드 박스 영역만 canvas에 크롭 후 `decodeFromCanvas`에 전달하여
-         * 디코딩 대상을 좁힌다.
+         * 가이드 박스 영역만 canvas에 크롭하되 MAX_ROI_WIDTH로 축소해 디코딩 대상
+         * 픽셀 수를 줄인다(모바일 인식 속도의 핵심). 전체 프레임을 디코딩하면 주변
+         * 노이즈로 인식률이 떨어지고, 원본 해상도 그대로면 모바일 CPU에서 느리다.
+         * decode는 비동기(네이티브 detect)일 수 있어 await 직후 stale/detected를
+         * 재확인해 모달 닫힘 시 타이머 누수를 막는다.
          */
-        let lastCanvasW = 0
-        let lastCanvasH = 0
-        const scanLoop = () => {
+        const scanLoop = async () => {
           if (isStale() || detectedRef.current) return
           try {
             const { sx, sy, sw, sh } = computeROI(video)
             if (sw > 0 && sh > 0) {
-              if (sw !== lastCanvasW || sh !== lastCanvasH) {
-                canvas.width = sw
-                canvas.height = sh
-                lastCanvasW = sw
-                lastCanvasH = sh
+              const targetW = Math.min(sw, MAX_ROI_WIDTH)
+              const targetH = Math.max(1, Math.round(sh * (targetW / sw)))
+              if (canvas.width !== targetW || canvas.height !== targetH) {
+                canvas.width = targetW
+                canvas.height = targetH
               } else {
-                ctx.clearRect(0, 0, sw, sh)
+                ctx.clearRect(0, 0, targetW, targetH)
               }
-              ctx.drawImage(video, sx, sy, sw, sh, 0, 0, sw, sh)
-              try {
-                const result = reader.decodeFromCanvas(canvas)
-                if (result) {
-                  handleDetected(result.getText())
-                  return
-                }
-              } catch {
-                // NotFoundException / ChecksumException / FormatException — 다음 프레임 재시도
+              ctx.drawImage(video, sx, sy, sw, sh, 0, 0, targetW, targetH)
+              const text = await decoder.decode(canvas)
+              if (isStale() || detectedRef.current) return
+              if (text) {
+                handleDetected(text)
+                return
               }
             }
           } catch {
-            // video not ready 등 — 다음 프레임 재시도
+            // video not ready / decode 내부 예외 — 다음 프레임 재시도
           }
-          scanTimerRef.current = window.setTimeout(scanLoop, SCAN_INTERVAL)
+          scanTimerRef.current = window.setTimeout(() => void scanLoop(), SCAN_INTERVAL)
         }
-        scanTimerRef.current = window.setTimeout(scanLoop, SCAN_INTERVAL)
+        scanTimerRef.current = window.setTimeout(() => void scanLoop(), SCAN_INTERVAL)
 
         setStatus('running')
       } catch (error) {

--- a/src/lib/barcodeDecoder.test.ts
+++ b/src/lib/barcodeDecoder.test.ts
@@ -56,6 +56,21 @@ describe('createBarcodeDecoder', () => {
     expect(decodeFromCanvasMock).toHaveBeenCalledWith(FAKE_CANVAS)
   })
 
+  it('getSupportedFormats가 reject(throw)하면 zxing 폴백을 사용한다', async () => {
+    class FakeDetector {
+      static getSupportedFormats = vi.fn().mockRejectedValue(new Error('boom'))
+      detect = vi.fn()
+    }
+    vi.stubGlobal('window', { BarcodeDetector: FakeDetector })
+    decodeFromCanvasMock.mockReturnValue({ getText: () => '9788956609959' })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBe('9788956609959')
+    expect(decodeFromCanvasMock).toHaveBeenCalledWith(FAKE_CANVAS)
+  })
+
   it('BarcodeDetector 자체가 없으면 zxing 폴백을 사용한다', async () => {
     vi.stubGlobal('window', {}) // BarcodeDetector 부재 (iOS Safari 등)
     decodeFromCanvasMock.mockReturnValue({ getText: () => '9791169213021' })

--- a/src/lib/barcodeDecoder.test.ts
+++ b/src/lib/barcodeDecoder.test.ts
@@ -21,7 +21,9 @@ const FAKE_CANVAS = {} as HTMLCanvasElement
 
 afterEach(() => {
   vi.unstubAllGlobals()
-  vi.clearAllMocks()
+  // resetAllMocks: 호출 기록뿐 아니라 mock 구현까지 초기화한다. clearAllMocks는 기록만
+  // 지워, 한 테스트의 decodeFromCanvasMock 구현(throw/return)이 다음 테스트로 새는 결합을 만든다.
+  vi.resetAllMocks()
 })
 
 describe('createBarcodeDecoder', () => {

--- a/src/lib/barcodeDecoder.test.ts
+++ b/src/lib/barcodeDecoder.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createBarcodeDecoder } from './barcodeDecoder'
+
+// zxing 폴백 경로를 결정적으로 검증하기 위해 모듈을 모킹(실제 브라우저 디코더 로드 방지).
+// vi.hoisted: vi.mock 팩토리가 호이스팅돼도 참조할 수 있게 mock 핸들을 먼저 만든다.
+const { decodeFromCanvasMock } = vi.hoisted(() => ({ decodeFromCanvasMock: vi.fn() }))
+
+vi.mock('@zxing/browser', () => ({
+  BrowserMultiFormatReader: class {
+    decodeFromCanvas = decodeFromCanvasMock
+  },
+}))
+vi.mock('@zxing/library', () => ({
+  BarcodeFormat: { EAN_13: 1 },
+  DecodeHintType: { POSSIBLE_FORMATS: 2, TRY_HARDER: 3 },
+}))
+
+// 디코더는 canvas를 디코더에 그대로 전달만 하므로 실제 캔버스 없이 식별용 스텁이면 충분.
+const FAKE_CANVAS = {} as HTMLCanvasElement
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('createBarcodeDecoder', () => {
+  it('네이티브 BarcodeDetector가 ean_13을 지원하면 네이티브 디코더를 사용한다', async () => {
+    const detect = vi.fn().mockResolvedValue([{ rawValue: '9788956609959', format: 'ean_13' }])
+    class FakeDetector {
+      static getSupportedFormats = vi.fn().mockResolvedValue(['ean_13', 'qr_code'])
+      detect = detect
+    }
+    vi.stubGlobal('window', { BarcodeDetector: FakeDetector })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBe('9788956609959')
+    expect(detect).toHaveBeenCalledWith(FAKE_CANVAS)
+    expect(decodeFromCanvasMock).not.toHaveBeenCalled() // zxing 미사용
+  })
+
+  it('네이티브가 ean_13을 지원하지 않으면 zxing 폴백을 사용한다', async () => {
+    class FakeDetector {
+      static getSupportedFormats = vi.fn().mockResolvedValue(['qr_code'])
+      detect = vi.fn()
+    }
+    vi.stubGlobal('window', { BarcodeDetector: FakeDetector })
+    decodeFromCanvasMock.mockReturnValue({ getText: () => '9788956609959' })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBe('9788956609959')
+    expect(decodeFromCanvasMock).toHaveBeenCalledWith(FAKE_CANVAS)
+  })
+
+  it('BarcodeDetector 자체가 없으면 zxing 폴백을 사용한다', async () => {
+    vi.stubGlobal('window', {}) // BarcodeDetector 부재 (iOS Safari 등)
+    decodeFromCanvasMock.mockReturnValue({ getText: () => '9791169213021' })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBe('9791169213021')
+  })
+
+  it('zxing이 미검출로 throw하면 null을 반환한다(다음 프레임 재시도)', async () => {
+    vi.stubGlobal('window', {})
+    decodeFromCanvasMock.mockImplementation(() => {
+      throw new Error('NotFoundException')
+    })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBeNull()
+  })
+
+  it('네이티브 detect가 빈 배열이면 null을 반환한다', async () => {
+    const detect = vi.fn().mockResolvedValue([])
+    class FakeDetector {
+      static getSupportedFormats = vi.fn().mockResolvedValue(['ean_13'])
+      detect = detect
+    }
+    vi.stubGlobal('window', { BarcodeDetector: FakeDetector })
+
+    const decoder = await createBarcodeDecoder()
+    const result = await decoder.decode(FAKE_CANVAS)
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/lib/barcodeDecoder.ts
+++ b/src/lib/barcodeDecoder.ts
@@ -1,0 +1,63 @@
+/**
+ * ROI 캔버스 1장을 받아 EAN-13(ISBN) 바코드 문자열을 디코딩하는 추상화.
+ *
+ * `decode` 단일 메서드로 통일해 호출부(IsbnScannerModal)가 네이티브/zxing 중
+ * 무엇이 선택됐는지 신경 쓰지 않고 동일하게 쓰도록 한다. 반환 문자열의 체크섬
+ * 검증은 호출부의 `validate`가 담당하므로 여기서는 raw 디코딩 결과만 돌려준다.
+ */
+export interface BarcodeDecoder {
+  decode(canvas: HTMLCanvasElement): Promise<string | null>
+}
+
+/**
+ * 런타임에 사용 가능한 가장 빠른 EAN-13 디코더를 생성한다.
+ *
+ * 네이티브 `BarcodeDetector`(주로 안드로이드 Chrome)는 zxing 순수 JS 디코딩보다
+ * 훨씬 빨라 모바일 스캔 지연의 핵심 원인을 해소한다. 다만 iOS Safari·Firefox 등은
+ * 미지원이거나 지원 포맷이 달라서 두 단계로 확인한다:
+ *  1. `'BarcodeDetector' in window`로 객체 존재 확인
+ *  2. `getSupportedFormats()`(비동기)에 `ean_13`이 실제 포함되는지 확인
+ *     (객체는 있어도 ean_13을 못 다루는 구현이 있어 await 확인이 필요)
+ * 어느 단계든 실패하면 zxing 폴백으로 떨어진다. zxing은 이 폴백 경로에서만 동적
+ * import하므로, 네이티브가 채택되는 환경(안드로이드)에서는 zxing 번들 로딩·실행을
+ * 통째로 건너뛴다.
+ */
+export async function createBarcodeDecoder(): Promise<BarcodeDecoder> {
+  if (typeof window !== 'undefined' && 'BarcodeDetector' in window && window.BarcodeDetector) {
+    try {
+      const formats = await window.BarcodeDetector.getSupportedFormats()
+      if (formats.includes('ean_13')) {
+        const detector = new window.BarcodeDetector({ formats: ['ean_13'] })
+        return {
+          async decode(canvas) {
+            const codes = await detector.detect(canvas)
+            return codes[0]?.rawValue ?? null
+          },
+        }
+      }
+    } catch {
+      // 네이티브 감지/생성 실패 → zxing 폴백
+    }
+  }
+
+  // zxing 폴백 (iOS Safari 등 BarcodeDetector 미지원 환경)
+  const [{ BrowserMultiFormatReader }, { BarcodeFormat, DecodeHintType }] = await Promise.all([
+    import('@zxing/browser'),
+    import('@zxing/library'),
+  ])
+  // EAN-13만 타겟(전 포맷 시도하면 느리고 오인식↑). TRY_HARDER로 비용 약간↑ 대신 정확도↑.
+  const hints = new Map<number, unknown>()
+  hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.EAN_13])
+  hints.set(DecodeHintType.TRY_HARDER, true)
+  const reader = new BrowserMultiFormatReader(hints)
+  return {
+    async decode(canvas) {
+      try {
+        return reader.decodeFromCanvas(canvas)?.getText() ?? null
+      } catch {
+        // NotFoundException / ChecksumException / FormatException — 미검출
+        return null
+      }
+    },
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,3 +7,29 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+// ── Web BarcodeDetector API (lib.dom.d.ts 미포함) ──
+// 모바일 바코드 스캔 가속용. 미지원 브라우저(iOS Safari 등)는 런타임 feature-detect로 폴백.
+interface DetectedBarcode {
+  rawValue: string
+  format: string
+}
+
+declare class BarcodeDetector {
+  constructor(options?: { formats: string[] })
+  static getSupportedFormats(): Promise<string[]>
+  detect(source: CanvasImageSource | Blob | ImageData): Promise<DetectedBarcode[]>
+}
+
+interface Window {
+  BarcodeDetector?: typeof BarcodeDetector
+}
+
+// 네이티브 토치(플래시) 제어 — lib.dom.d.ts 미포함 필드
+interface MediaTrackCapabilities {
+  torch?: boolean
+}
+
+interface MediaTrackConstraintSet {
+  torch?: boolean
+}


### PR DESCRIPTION
  ## 개요
  스마트폰에서 ISBN 바코드 스캔 인식이 느린 문제를 개선합니다. 네이티브 `BarcodeDetector` 도입(안드로이드 가속) + ROI 다운스케일·해상도 튜닝(전 플랫폼)으로 디코딩 비용을 줄이고, iOS 등 미지원 환경은 zxing으로 폴백합니다.

  ## 원인
  데스크탑은 빠른데 모바일만 느린 이유는 "화면 전체 스캔"이 아니라(데스크탑·모바일 모두 가이드 박스 ROI만 디코딩) **디코딩 비용**이었습니다.
  - ROI 캔버스를 원본 해상도 그대로 디코딩 (세로 스트림 폰은 폭 900px+)
  - 카메라 1920×1080 요청, `TRY_HARDER` + zxing 순수 JS가 모바일 CPU에서 무거움
  - 안드로이드 Chrome의 빠른 네이티브 `BarcodeDetector` 미사용

  ## 변경 사항
  - **신규** `src/lib/barcodeDecoder.ts`: 네이티브 우선 + zxing 폴백 디코더 추상화 (zxing은 폴백에서만 동적 import)
  - **수정** `IsbnScannerModal.tsx`: ROI 640px 다운스케일, 1280×720, 120ms, 토치 네이티브 API 전환, `scanLoop` 비동기화 + stale 가드
  - **수정** `src/vite-env.d.ts`: `BarcodeDetector`·트랙 `torch` ambient 타입
  - **신규** `src/lib/barcodeDecoder.test.ts`: 디코더 선택 로직 단위 테스트 6케이스

  ## 검증
  - [x] `tsc -b --force` 0 에러
  - [x] `eslint` 0 경고
  - [x] `vitest` 6/6 통과
  - [x] 코드 리뷰(Opus) APPROVE — 비동기 루프 타이머/세션 누수 없음
  - [ ] 실기기: 안드로이드(네이티브) / iOS(폴백) / 데스크탑(회귀 없음) / 토치·카메라 선택

  ## 참고
  - iOS Safari는 `BarcodeDetector` 미지원 → zxing 폴백 유지(720p+다운스케일로 기존보다 빠름)
  - (후속·선택) 카메라 전환 시 토치 상태 동기화는 기존부터 있던 기기의존 한계 — 이번 범위 외

  Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ISBN 바코드 스캔 성능 개선(스캔 주기 단축) 및 ROI 처리 개선으로 인식 안정성 향상
  * 카메라 토치 제어 및 해상도 처리 개선으로 모바일 호환성 확대
  * 네이티브/폴백 바코드 디코더 전략 도입으로 더 넓은 환경 지원

* **Tests**
  * 바코드 디코딩 경로별 동작을 검증하는 테스트 스위트 추가

* **Chores**
  * 브라우저 타입 선언 보강(BarcodeDetector·토치 관련)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->