### PR TITLE
refactor: 바코드 스캔 카메라 선택 전면 제외·후면만 노출 (#216)

### DIFF
--- a/src/components/common/IsbnScannerModal.tsx
+++ b/src/components/common/IsbnScannerModal.tsx
@@ -248,6 +248,21 @@ export default function IsbnScannerModal({
         // 실제 사용 중인 deviceId 추출 → state/localStorage 동기화
         const trackSettings = stream.getVideoTracks()[0]?.getSettings()
         const usingId = trackSettings?.deviceId ?? null
+
+        // 저장된 deviceId가 전면 카메라면(구버전에서 선택돼 localStorage에 남은 경우 등) 후면으로 폴백.
+        // 전면은 드롭다운(후면만 노출)에 없어 사용자가 되돌릴 수 없으므로, 잘못된 저장값을 지우고
+        // facingMode: environment로 재요청한다. deviceId != null 조건이라 재귀는 1회로 끝난다.
+        if (deviceId != null && trackSettings?.facingMode === 'user') {
+          try {
+            localStorage.removeItem(DEVICE_ID_KEY)
+          } catch {
+            // private 모드 등 — 무시
+          }
+          stream.getTracks().forEach(t => t.stop())
+          streamRef.current = null
+          return startStream(null)
+        }
+
         setActiveDeviceId(usingId)
         if (usingId) {
           try {

--- a/src/components/common/IsbnScannerModal.tsx
+++ b/src/components/common/IsbnScannerModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { createBarcodeDecoder } from '@/lib/barcodeDecoder'
+import { buildCameraOptions } from '@/lib/cameraOptions'
 
 const DEVICE_ID_KEY = 'shelfeed-scan-device-id'
 const SCAN_INTERVAL = 120
@@ -418,9 +419,9 @@ export default function IsbnScannerModal({
       ? STATUS_MESSAGES[status]
       : null
 
-  // 빈 deviceId(권한 부여 직후 일부 브라우저)는 select key/value 충돌 방지 위해 제외
-  const selectableDevices = devices.filter(d => d.deviceId)
-  const showDeviceSelect = selectableDevices.length >= 2 && status === 'running'
+  // 바코드 스캔엔 후면 카메라만 의미 → 전면 제외 + 라벨 정리(빈 deviceId 제거 포함).
+  const deviceOptions = buildCameraOptions(devices)
+  const showDeviceSelect = deviceOptions.length >= 2 && status === 'running'
 
   const currentTip = tipIndex >= 0 ? SCAN_TIPS[tipIndex] : null
 
@@ -465,9 +466,9 @@ export default function IsbnScannerModal({
               onChange={handleDeviceChange}
               className="max-w-[40vw] truncate rounded-md bg-white/10 px-2 py-1 text-xs text-white outline-none"
             >
-              {selectableDevices.map((d, idx) => (
-                <option key={d.deviceId} value={d.deviceId} className="text-black">
-                  {d.label || `카메라 ${idx + 1}`}
+              {deviceOptions.map(o => (
+                <option key={o.id} value={o.id} className="text-black">
+                  {o.label}
                 </option>
               ))}
             </select>

--- a/src/lib/cameraOptions.test.ts
+++ b/src/lib/cameraOptions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCameraOptions } from './cameraOptions'
+
+// MediaDeviceInfo 최소 형태 — buildCameraOptions는 deviceId/label만 사용
+function cam(deviceId: string, label: string): MediaDeviceInfo {
+  return {
+    deviceId,
+    label,
+    kind: 'videoinput',
+    groupId: 'g',
+    toJSON: () => ({}),
+  } as MediaDeviceInfo
+}
+
+describe('buildCameraOptions', () => {
+  it('후면 2 + 전면 2 → 후면만, (기본)/(보조)', () => {
+    const opts = buildCameraOptions([
+      cam('back0', 'camera 0, facing back'),
+      cam('front1', 'camera 1, facing front'),
+      cam('back2', 'camera 2, facing back'),
+      cam('front3', 'camera 3, facing front'),
+    ])
+    expect(opts).toEqual([
+      { id: 'back0', label: '후면 카메라 (기본)' },
+      { id: 'back2', label: '후면 카메라 (보조)' },
+    ])
+  })
+
+  it('후면 1 + 전면 1 → 후면 1개(기본)만 (드롭다운은 length<2로 숨겨짐)', () => {
+    const opts = buildCameraOptions([
+      cam('back0', 'camera 0, facing back'),
+      cam('front1', 'camera 1, facing front'),
+    ])
+    expect(opts).toEqual([{ id: 'back0', label: '후면 카메라 (기본)' }])
+  })
+
+  it('후면 3개 → 기본/보조 1/보조 2', () => {
+    const opts = buildCameraOptions([
+      cam('b0', 'camera 0, facing back'),
+      cam('b1', 'camera 1, facing back'),
+      cam('b2', 'camera 2, facing back'),
+    ])
+    expect(opts.map(o => o.label)).toEqual([
+      '후면 카메라 (기본)',
+      '후면 카메라 (보조 1)',
+      '후면 카메라 (보조 2)',
+    ])
+  })
+
+  it('데스크탑(facing 정보 없는 웹캠) → 전부 유지 + 원 label', () => {
+    const opts = buildCameraOptions([cam('w0', 'Integrated Webcam'), cam('w1', 'USB Camera')])
+    expect(opts).toEqual([
+      { id: 'w0', label: 'Integrated Webcam' },
+      { id: 'w1', label: 'USB Camera' },
+    ])
+  })
+
+  it('빈 deviceId는 제외', () => {
+    const opts = buildCameraOptions([
+      cam('', 'camera 0, facing back'),
+      cam('back2', 'camera 2, facing back'),
+    ])
+    expect(opts).toEqual([{ id: 'back2', label: '후면 카메라 (기본)' }])
+  })
+
+  it('전부 전면이면 안전장치로 원본 유지(선택 기능 소실 방지)', () => {
+    const opts = buildCameraOptions([
+      cam('f0', 'camera 0, facing front'),
+      cam('f1', 'camera 1, facing front'),
+    ])
+    expect(opts).toEqual([
+      { id: 'f0', label: 'camera 0, facing front' },
+      { id: 'f1', label: 'camera 1, facing front' },
+    ])
+  })
+})

--- a/src/lib/cameraOptions.ts
+++ b/src/lib/cameraOptions.ts
@@ -1,0 +1,43 @@
+export interface CameraOption {
+  id: string
+  label: string
+}
+
+// 라벨 휴리스틱 — 브라우저마다 표기가 달라 best-effort. 권한 부여 후 label이 채워질 때 동작.
+const FRONT_RE = /front|전면|selfie|셀피/i
+const BACK_RE = /back|rear|후면|environment/i
+
+/**
+ * videoinput 목록을 바코드 스캔 드롭다운용 옵션으로 변환한다.
+ *
+ * 안드로이드 멀티렌즈폰은 후면(광각/초광각/망원)·전면 렌즈를 각각 별개 카메라로 노출해
+ * 드롭다운이 4개까지 떠 혼란스럽다. 바코드 스캔에 전면은 무의미하므로 전면을 제외하고
+ * 후면만 남긴다. 단 전면 판정에 전부 걸려 후보가 비면(데스크탑 웹캠 등 facing 미표기)
+ * 원본을 그대로 써서 카메라 선택 기능 자체가 사라지지 않게 한다(회귀 방지).
+ *
+ * 라벨은 후면으로 인식된 장치에만 순번을 매긴다(첫 후면 `(기본)`, 이후 `(보조)`).
+ * 브라우저가 렌즈 종류(광각/초광각)를 노출하지 않으므로 "기본"은 "첫 후면" 의미일 뿐
+ * 메인 광각임을 단정하지 않는다. 인식 안 된 장치는 원 label을 유지한다.
+ */
+export function buildCameraOptions(devices: MediaDeviceInfo[]): CameraOption[] {
+  // 빈 deviceId(권한 직후 일부 브라우저)는 select key/value 충돌 방지 위해 제외
+  const withId = devices.filter(d => d.deviceId)
+  const nonFront = withId.filter(d => !FRONT_RE.test(d.label))
+  const visible = nonFront.length > 0 ? nonFront : withId
+
+  const backIds = visible.filter(d => BACK_RE.test(d.label)).map(d => d.deviceId)
+  const numberSuffix = backIds.length >= 3 // 후면 3개 이상일 때만 보조에 번호 부여
+
+  return visible.map((d, idx) => {
+    const backPos = backIds.indexOf(d.deviceId)
+    let label: string
+    if (backPos === 0) {
+      label = '후면 카메라 (기본)'
+    } else if (backPos > 0) {
+      label = numberSuffix ? `후면 카메라 (보조 ${backPos})` : '후면 카메라 (보조)'
+    } else {
+      label = d.label || `카메라 ${idx + 1}`
+    }
+    return { id: d.deviceId, label }
+  })
+}


### PR DESCRIPTION
  ## 개요
  ISBN 바코드 스캔 모달의 카메라 선택 드롭다운에서 전면 카메라를 제외하고 후면만 노출합니다. 후면 멀티렌즈는 `후면 카메라 (기본)/(보조)`로 라벨을 정리합니다.

  ## 배경
  안드로이드 멀티렌즈폰은 후면(광각/초광각/망원)·전면 렌즈를 각각 별개 카메라로 노출해 드롭다운에 `camera 0~3, facing back/front`가 4개나 떠 혼란스러웠습니다. 바코드 스캔에 전면은 무의미하고, 라벨도 브라우저 원문(영어)이라 가독성이 낮았습니다.

  ## 변경 사항
  - **신규** `src/lib/cameraOptions.ts`: `buildCameraOptions()` — 전면 제외 + 후면 `(기본)/(보조)` 라벨 + 데스크탑/라벨없음 안전장치(원본 유지)
  - **수정** `IsbnScannerModal.tsx`: 드롭다운 파생을 `buildCameraOptions`로 교체, 후면 1개면 드롭다운 자동 숨김. 스캔/디코딩 로직(#214)은 무변경
  - **신규** `src/lib/cameraOptions.test.ts`: 단위 테스트 6케이스

  ## 검증
  - [x] `tsc -b --force` 0 에러
  - [x] `eslint` 0 경고
  - [x] `vitest` 6/6 통과
  - [ ] 실기기: 안드로이드(전면 숨김·후면 기본/보조) / 데스크탑(드롭다운 회귀 없음)

  ## 참고
  - 브라우저가 렌즈 종류를 노출하지 않아 "광각/초광각" 단정 표기는 불가 → "기본=첫 후면" 의미로만 표기
  - 라벨 기반 전/후면 판정은 브라우저별 표기 차이로 best-effort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ISBN 스캐너의 카메라 선택 기능을 개선했습니다. 다중 카메라 환경에서 더욱 안정적으로 카메라를 인식하고 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->