### PR TITLE
fix: iOS 당겨서 새로고침(pull-to-refresh) 차단 (#220)

### DIFF
--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { Outlet } from 'react-router-dom'
+
+import PageLoader from '@/components/common/PageLoader'
+import { usePreventPullToRefresh } from '@/hooks/usePreventPullToRefresh'
+
+/**
+ * 라우터 최상위 레이아웃. 라우트 전환에도 언마운트되지 않으므로 전역 1회성 사이드이펙트의
+ * 마운트 지점으로 쓴다. iOS pull-to-refresh 차단 훅을 여기서 한 번만 건다.
+ */
+export default function RootLayout() {
+  usePreventPullToRefresh()
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <Outlet />
+    </Suspense>
+  )
+}

--- a/src/hooks/usePreventPullToRefresh.test.ts
+++ b/src/hooks/usePreventPullToRefresh.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBlockPull } from './usePreventPullToRefresh'
+
+describe('shouldBlockPull', () => {
+  it('세로 아래 당김 + 문서 최상단 + 내부 스크롤 없음 → 차단', () => {
+    expect(shouldBlockPull({ deltaX: 2, deltaY: 40, scrollY: 0, innerScrolling: false })).toBe(true)
+  })
+
+  it('위로 당기면(콘텐츠 스크롤) → 통과', () => {
+    expect(shouldBlockPull({ deltaX: 0, deltaY: -40, scrollY: 0, innerScrolling: false })).toBe(
+      false
+    )
+  })
+
+  it('문서가 최상단이 아니면 → 통과', () => {
+    expect(shouldBlockPull({ deltaX: 0, deltaY: 40, scrollY: 120, innerScrolling: false })).toBe(
+      false
+    )
+  })
+
+  it('내부 스크롤 요소가 소비하면 → 통과', () => {
+    expect(shouldBlockPull({ deltaX: 0, deltaY: 40, scrollY: 0, innerScrolling: true })).toBe(false)
+  })
+
+  it('가로 우세 제스처(캐러셀) → 통과', () => {
+    expect(shouldBlockPull({ deltaX: 80, deltaY: 10, scrollY: 0, innerScrolling: false })).toBe(
+      false
+    )
+  })
+})

--- a/src/hooks/usePreventPullToRefresh.ts
+++ b/src/hooks/usePreventPullToRefresh.ts
@@ -1,0 +1,75 @@
+import { useEffect } from 'react'
+
+import { isIOS } from '@/lib/device'
+
+/**
+ * pull-to-refresh를 차단해야 하는 제스처인지 판정한다(순수 함수, 단위 테스트 대상).
+ *
+ * 차단 조건: 세로 우세 제스처이면서, 문서가 최상단이고, 아래로 당기며, 그 당김을 소비할
+ * 내부 스크롤 요소가 없을 때. 가로 우세(캐러셀)·위로 당김·문서가 최상단이 아닐 때·내부
+ * 스크롤이 진행 중일 때는 통과시켜 기존 스크롤 동작을 보존한다.
+ */
+export function shouldBlockPull(args: {
+  deltaX: number
+  deltaY: number
+  scrollY: number
+  innerScrolling: boolean
+}): boolean {
+  const { deltaX, deltaY, scrollY, innerScrolling } = args
+  // 가로 우세 제스처(overflow-x 캐러셀 등)는 건드리지 않는다.
+  if (Math.abs(deltaY) <= Math.abs(deltaX)) return false
+  return deltaY > 0 && scrollY <= 0 && !innerScrolling
+}
+
+/**
+ * iOS 사파리의 "당겨서 새로고침(pull-to-refresh)"을 차단하는 훅. 앱 루트에서 1회 마운트한다.
+ *
+ * iOS 사파리는 CSS `overscroll-behavior`를 무시하므로(안드로이드는 그걸로 차단됨),
+ * `touchmove`를 non-passive로 가로채 문서 최상단에서의 아래 방향 당김만 `preventDefault`한다.
+ * 내부 스크롤 요소(모달/시트/리스트)가 스크롤 중(`scrollTop>0`)이면 그 제스처를 통과시키고,
+ * 가로 캐러셀 제스처도 통과시켜 정상 스크롤을 깨지 않는다. 안드로이드/데스크탑에서는 no-op.
+ */
+export function usePreventPullToRefresh(): void {
+  useEffect(() => {
+    if (!isIOS()) return
+
+    let startX = 0
+    let startY = 0
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return
+      startX = e.touches[0].clientX
+      startY = e.touches[0].clientY
+    }
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 1) return // 핀치 줌은 그대로 둔다
+      const deltaX = e.touches[0].clientX - startX
+      const deltaY = e.touches[0].clientY - startY
+
+      // e.target에서 위로 올라가며, 아래 당김을 소비할 수 있는(이미 스크롤된) 요소를 찾는다.
+      let innerScrolling = false
+      let node: HTMLElement | null = e.target instanceof HTMLElement ? e.target : null
+      while (node && node !== document.body) {
+        if (node.scrollHeight > node.clientHeight && node.scrollTop > 0) {
+          innerScrolling = true
+          break
+        }
+        node = node.parentElement
+      }
+
+      if (shouldBlockPull({ deltaX, deltaY, scrollY: window.scrollY, innerScrolling })) {
+        e.preventDefault()
+      }
+    }
+
+    // preventDefault가 동작하려면 touchmove는 반드시 non-passive로 등록해야 한다.
+    document.addEventListener('touchstart', onTouchStart, { passive: true })
+    document.addEventListener('touchmove', onTouchMove, { passive: false })
+
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart)
+      document.removeEventListener('touchmove', onTouchMove)
+    }
+  }, [])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -55,8 +55,8 @@
   }
   /* PWA pull-to-refresh 비활성화: 오버스크롤 차단은 스크롤 체인 최상위인 html에
      적용돼야 당겨서 새로고침이 막힌다(안드로이드 크롬/PWA). contain은 페이지 내부
-     스크롤은 유지하면서 브라우저 새로고침으로의 전파만 차단. (iOS 사파리는 이 속성
-     미지원이라 막히지 않음 — 별도 구조 변경 필요해 이번 범위 제외) */
+     스크롤은 유지하면서 브라우저 새로고침으로의 전파만 차단. (iOS 사파리는 이 속성을
+     미지원이라, JS로 touchmove를 가로채는 usePreventPullToRefresh 훅에서 별도 처리한다) */
   html {
     overscroll-behavior-y: contain;
   }

--- a/src/lib/device.test.ts
+++ b/src/lib/device.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { isMobile } from './device'
+import { isIOS, isMobile } from './device'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -42,5 +42,44 @@ describe('isMobile', () => {
   it('navigator 없으면 false', () => {
     vi.stubGlobal('navigator', undefined)
     expect(isMobile()).toBe(false)
+  })
+})
+
+describe('isIOS', () => {
+  it('iPhone UA → true', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/605',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(true)
+  })
+
+  it('iPadOS(Mac UA + 터치) → true', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(true)
+  })
+
+  it('Android → false', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Linux; Android 13; SM-N986N) Chrome/120',
+      maxTouchPoints: 5,
+    })
+    expect(isIOS()).toBe(false)
+  })
+
+  it('터치 없는 데스크탑 → false', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605',
+      maxTouchPoints: 0,
+    })
+    expect(isIOS()).toBe(false)
+  })
+
+  it('navigator 없으면 false', () => {
+    vi.stubGlobal('navigator', undefined)
+    expect(isIOS()).toBe(false)
   })
 })

--- a/src/lib/device.ts
+++ b/src/lib/device.ts
@@ -11,3 +11,16 @@ export function isMobile(): boolean {
     (navigator.maxTouchPoints > 0 && /Macintosh/i.test(navigator.userAgent))
   )
 }
+
+/**
+ * iOS(iPhone/iPad/iPod) 단말 여부를 판정한다(best-effort).
+ *
+ * iPadOS는 데스크탑 Safari처럼 Macintosh UA로 위장하므로 maxTouchPoints까지 본다.
+ * 안드로이드는 CSS `overscroll-behavior`로 pull-to-refresh가 이미 차단되므로 의도적으로
+ * 제외한다. `usePreventPullToRefresh`에서 iOS에만 JS 가드를 거는 데 쓴다.
+ */
+export function isIOS(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const ua = navigator.userAgent
+  return /iPhone|iPad|iPod/i.test(ua) || (navigator.maxTouchPoints > 0 && /Macintosh/i.test(ua))
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense } from 'react'
-import { createBrowserRouter, Outlet } from 'react-router-dom'
+import { lazy } from 'react'
+import { createBrowserRouter } from 'react-router-dom'
 import LoginPage from '@/pages/LoginPage'
 const HomeFeedPage = lazy(() => import('@/pages/HomeFeedPage'))
 const SignupPage = lazy(() => import('@/pages/SignupPage'))
@@ -28,7 +28,7 @@ const UserLibraryPage = lazy(() => import('@/pages/UserLibraryPage'))
 const FollowListPage = lazy(() => import('@/pages/FollowListPage'))
 import ProtectedRoute from '@/components/layout/ProtectedRoute'
 import RouteError from '@/components/common/RouteError'
-import PageLoader from '@/components/common/PageLoader'
+import RootLayout from '@/components/layout/RootLayout'
 
 const appRoutes = [
   {
@@ -245,11 +245,7 @@ const appRoutes = [
 
 export const router = createBrowserRouter([
   {
-    element: (
-      <Suspense fallback={<PageLoader />}>
-        <Outlet />
-      </Suspense>
-    ),
+    element: <RootLayout />,
     errorElement: <RouteError />,
     children: appRoutes,
   },


### PR DESCRIPTION
  ## 개요
  iOS 사파리에서 화면 최상단을 아래로 당기면 발생하던 페이지 새로고침(pull-to-refresh)을 차단합니다. 안드로이드는 기존 CSS(`overscroll-behavior`)로 이미 막혀 있었으나, iOS 사파리는 해당 속성을 미지원해 새로고침이 그대로 발생했습니다.

  ## 변경 사항
  - `usePreventPullToRefresh` 훅 추가: iOS에서만 `touchmove`를 non-passive로 가로채 **문서 최상단 + 세로 아래 당김 + 내부 스크롤 없음**일 때만 `preventDefault`
  - 가로 캐러셀·내부 스크롤(모달/시트/리스트)은 통과시켜 기존 스크롤 동작 보존
  - 전역 1회 마운트를 위해 라우터 루트를 `RootLayout` 컴포넌트로 추출
  - `isIOS()` 판정 헬퍼를 `device.ts`에 추가(안드로이드/데스크탑은 no-op)
  - `index.css`의 `overscroll-behavior`는 안드로이드용으로 유지(주석만 갱신)
  - `isIOS` / `shouldBlockPull` 단위 테스트 추가

  ## 테스트
  - `npx tsc -b --force` — 에러 0
  - `npx eslint` — 에러 0 / 경고 0
  - `npx vitest run` — 15/15 통과

  ## 실기기 확인 필요
  - iPhone 사파리: 최상단 당김 → 새로고침 차단 / 피드·모달·캐러셀 스크롤 정상
  - 안드로이드: 회귀 없음

  Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  - iOS 기기에서 페이지 최상단 스크롤 시 당김 새로고침 동작 차단
  - 개선된 라우터 레이아웃으로 페이지 로딩 경험 향상

* **테스트**
  - iOS 장치 감지 로직 테스트 추가
  - 당김 새로고침 방지 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->