### PR TITLE
refactor: access token 메모리 보관 전환 + 부팅 silent refresh (#224)

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -24,12 +24,19 @@ const clearAuthMock = vi.fn(() => {
   authState.accessToken = null
   authState.isAuthenticated = false
 })
+// setAuth와 달리 user는 건드리지 않고 토큰만 교체(부팅 refresh·401 자동 refresh 공용).
+// isAuthenticated도 true로 보장하므로 mock도 동일하게 미러링.
+const setAccessTokenMock = vi.fn((accessToken: string) => {
+  authState.accessToken = accessToken
+  authState.isAuthenticated = true
+})
 
 vi.mock('@/store/authStore', () => ({
   useAuthStore: {
     getState: () => ({
       ...authState,
       setAuth: setAuthMock,
+      setAccessToken: setAccessTokenMock,
       clearAuth: clearAuthMock,
     }),
   },
@@ -49,6 +56,7 @@ beforeEach(() => {
   authState.accessToken = 'old-access-token'
   authState.isAuthenticated = true
   setAuthMock.mockClear()
+  setAccessTokenMock.mockClear()
   clearAuthMock.mockClear()
 })
 afterEach(() => {
@@ -249,7 +257,7 @@ describe('apiClient response interceptor — 401 분기', () => {
     } as unknown as AxiosError
   }
 
-  it('401 + 일반 path + 미시도 + 로그인 상태 → refresh 1회 호출 + 새 토큰으로 setAuth', async () => {
+  it('401 + 일반 path + 미시도 + 로그인 상태 → refresh 1회 호출 + 새 토큰으로 setAccessToken', async () => {
     const client = await import('./client')
     const handler = await getErrorHandler()
 
@@ -263,14 +271,37 @@ describe('apiClient response interceptor — 401 분기', () => {
 
     const error = makeAxiosError('/api/v1/users/me', 401)
     // 재시도(apiClient(originalRequest))는 실제 axios가 노드 환경에서 네트워크 요청을 시도해
-    // 실패할 수 있으므로 결과는 신경쓰지 않고 setAuth 호출 여부만 검증한다.
+    // 실패할 수 있으므로 결과는 신경쓰지 않고 setAccessToken 호출 여부만 검증한다.
     // axios 1.x의 bound instance는 spy로 가로채기 어려워 retry 자체는 통합테스트로 검증.
     await handler(error).catch(() => undefined)
 
-    expect(setAuthMock).toHaveBeenCalledOnce()
-    expect(setAuthMock.mock.calls[0]?.[1]).toBe('fresh-token')
+    expect(setAccessTokenMock).toHaveBeenCalledOnce()
+    expect(setAccessTokenMock.mock.calls[0]?.[0]).toBe('fresh-token')
     expect(clearAuthMock).not.toHaveBeenCalled()
     expect(locationStub.href).toBe('')
+  })
+
+  it('refresh 성공 + user=null(부팅 충전 전) → setAccessToken 호출, reject 안 함 (접근 C 회귀)', async () => {
+    // 토큰만 복구된 부팅 직후 상태: isAuthenticated=true인데 user는 아직 비어 있음.
+    // 구 코드의 `!stateAfter.user` 가드였다면 토큰 주입을 거부했을 회귀를 잡는다.
+    authState.user = null
+    const client = await import('./client')
+    const handler = await getErrorHandler()
+
+    vi.spyOn(client.refreshClient, 'post').mockResolvedValueOnce({
+      data: {
+        status: 'SUCCESS',
+        code: 200,
+        data: { accessToken: 'fresh-token', accessTokenExpiresIn: 3600 },
+      },
+    } as never)
+
+    const error = makeAxiosError('/api/v1/users/me', 401)
+    await handler(error).catch(() => undefined)
+
+    expect(setAccessTokenMock).toHaveBeenCalledOnce()
+    expect(setAccessTokenMock.mock.calls[0]?.[0]).toBe('fresh-token')
+    expect(clearAuthMock).not.toHaveBeenCalled()
   })
 
   it('401 + 인증 흐름 path → refresh 시도 안 함, 그대로 reject', async () => {
@@ -371,7 +402,7 @@ describe('apiClient response interceptor — 401 분기', () => {
     expect(locationStub.href).toBe('')
   })
 
-  it('refresh 도중 logout 발생 시 setAuth 미호출, 원본 에러 reject (H1 fix)', async () => {
+  it('refresh 도중 logout 발생 시 setAccessToken 미호출, 원본 에러 reject (H1 fix)', async () => {
     const client = await import('./client')
     const handler = await getErrorHandler()
 
@@ -399,10 +430,10 @@ describe('apiClient response interceptor — 401 분기', () => {
 
     resolveInner!('would-be-stale-token')
     await expect(handlerPromise).rejects.toBe(error)
-    expect(setAuthMock).not.toHaveBeenCalled()
+    expect(setAccessTokenMock).not.toHaveBeenCalled()
   })
 
-  it('refresh 도중 다른 계정으로 전환 시 setAuth 미호출 (H1 fix)', async () => {
+  it('refresh 도중 다른 계정으로 전환 시 setAccessToken 미호출 (H1 fix)', async () => {
     const client = await import('./client')
     const handler = await getErrorHandler()
 
@@ -429,7 +460,7 @@ describe('apiClient response interceptor — 401 분기', () => {
 
     resolveInner!('cross-account-token')
     await expect(handlerPromise).rejects.toBe(error)
-    expect(setAuthMock).not.toHaveBeenCalled()
+    expect(setAccessTokenMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -243,15 +243,18 @@ async function handleApiClientResponseError(error: AxiosError) {
     try {
       const newToken = await getRefreshPromise()
       const stateAfter = useAuthStore.getState()
-      // refresh 도중 사용자가 logout했거나 다른 계정으로 전환된 경우 → 새 토큰을
-      // store에 주입하지 않고 원본 에러를 그대로 reject (토큰/사용자 불일치 방지)
-      if (!stateAfter.isAuthenticated || !stateAfter.user) {
+      // refresh 도중 사용자가 logout한 경우 → 새 토큰을 주입하지 않고 원본 에러 reject.
+      // isAuthenticated 단독으로 판정한다(clearAuth가 false로 flip). user=null은 부팅 직후
+      // 충전 전 정상 상태이므로 로그아웃 신호로 쓰지 않는다.
+      if (!stateAfter.isAuthenticated) {
         return Promise.reject(error)
       }
-      if (userBefore && stateAfter.user.id !== userBefore.id) {
+      // refresh 도중 다른 계정으로 전환된 경우 → 재시도 안 함(양쪽 user가 있을 때만 id 비교)
+      if (userBefore && stateAfter.user && stateAfter.user.id !== userBefore.id) {
         return Promise.reject(error)
       }
-      useAuthStore.getState().setAuth(stateAfter.user, newToken)
+      // user는 그대로 두고 토큰만 교체(요청 인터셉터가 최신 토큰을 자동 부착)
+      useAuthStore.getState().setAccessToken(newToken)
       return apiClient(originalRequest)
     } catch (refreshError) {
       // 인증 문제(400/401)일 때만 logout. 일시적 네트워크/timeout/5xx에선 세션 유지
@@ -268,12 +271,13 @@ async function handleApiClientResponseError(error: AxiosError) {
 apiClient.interceptors.response.use(response => response, handleApiClientResponseError)
 
 export default apiClient
-// 단위 테스트 전용 export (프로덕션 코드에서 직접 사용 금지)
+// 부팅 silent refresh(useAuthBootstrap) 및 단위 테스트에서 재사용하는 내부 유틸 export
 export {
   refreshClient,
   performRefresh,
   getRefreshPromise,
   isAuthFlowUrl,
   isMemberNotFound,
+  isAuthFailureRefreshError,
   handleApiClientResponseError,
 }

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -33,7 +33,13 @@ export default function RootLayout() {
     userFetchRef.current = true
     getMyProfile()
       .then(profile => {
-        useAuthStore.getState().setUser({
+        // 요청 중 로그아웃/계정전환이 일어났으면 stale 응답으로 현재 세션을 덮어쓰지 않는다.
+        // isAuthenticated=false면 로그아웃됨, state.user가 이미 있으면 다른 경로(재로그인 등)가
+        // 충전한 것이므로 건드리지 않는다. (토큰 비교는 부팅 중 401→refresh 토큰 교체를 같은
+        // 사용자인데도 stale로 오판하므로 쓰지 않는다.)
+        const state = useAuthStore.getState()
+        if (!state.isAuthenticated || state.user) return
+        state.setUser({
           id: profile.userId,
           nickname: profile.nickname,
           email: profile.email,

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,15 +1,58 @@
-import { Suspense } from 'react'
+import { Suspense, useEffect, useRef } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import PageLoader from '@/components/common/PageLoader'
 import { usePreventPullToRefresh } from '@/hooks/usePreventPullToRefresh'
+import { useAuthBootstrap } from '@/hooks/useAuthBootstrap'
+import { useAuthStore } from '@/store/authStore'
+import { getMyProfile } from '@/api/member'
 
 /**
  * 라우터 최상위 레이아웃. 라우트 전환에도 언마운트되지 않으므로 전역 1회성 사이드이펙트의
- * 마운트 지점으로 쓴다. iOS pull-to-refresh 차단 훅을 여기서 한 번만 건다.
+ * 마운트 지점으로 쓴다.
+ *
+ * 책임:
+ * 1. iOS pull-to-refresh 차단 훅(`usePreventPullToRefresh`).
+ * 2. 부팅 silent refresh(`useAuthBootstrap`) + `isBootstrapped` 게이트 — 토큰 복구 전 라우트
+ *    렌더를 막아, accessToken을 메모리로 옮긴 뒤 새로고침 시 발생하는 인증 판정 race를 차단한다.
+ * 3. user 안전장치 — 부팅 게이트는 토큰만 기다리므로(접근 C) user가 비어 있을 수 있다. 어떤
+ *    진입 경로(홈 직행 등)에서도 user가 채워지도록 `isAuthenticated && !user`면 getMyProfile을
+ *    비차단으로 1회 호출한다.
  */
 export default function RootLayout() {
   usePreventPullToRefresh()
+  useAuthBootstrap()
+
+  const isBootstrapped = useAuthStore(state => state.isBootstrapped)
+  const isAuthenticated = useAuthStore(state => state.isAuthenticated)
+  const hasUser = useAuthStore(state => state.user !== null)
+  const userFetchRef = useRef(false)
+
+  useEffect(() => {
+    if (!isBootstrapped || !isAuthenticated || hasUser || userFetchRef.current) return
+    userFetchRef.current = true
+    getMyProfile()
+      .then(profile => {
+        useAuthStore.getState().setUser({
+          id: profile.userId,
+          nickname: profile.nickname,
+          email: profile.email,
+          profileImageUrl: profile.profileImageUrl ?? undefined,
+          bio: profile.bio,
+          emailVerified: profile.emailVerified,
+          onboardingCompleted: profile.onboardingCompleted,
+        })
+      })
+      .catch(() => {
+        // 충전 실패는 치명적이지 않음 — user 객체를 쓰는 페이지(MyProfile 등)가 자체
+        // getMyProfile로 채우거나, 후속 API의 401→refresh 흐름이 세션을 정리한다.
+      })
+  }, [isBootstrapped, isAuthenticated, hasUser])
+
+  if (!isBootstrapped) {
+    return <PageLoader />
+  }
+
   return (
     <Suspense fallback={<PageLoader />}>
       <Outlet />

--- a/src/hooks/useAuthBootstrap.test.ts
+++ b/src/hooks/useAuthBootstrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runAuthBootstrap } from './useAuthBootstrap'
+
+type Deps = Parameters<typeof runAuthBootstrap>[0]
+
+function makeDeps(overrides: Partial<Deps> = {}): Deps {
+  return {
+    performRefresh: vi.fn().mockResolvedValue('tok'),
+    isAuthFailure: () => false,
+    setAccessToken: vi.fn(),
+    clearAuth: vi.fn(),
+    delay: vi.fn().mockResolvedValue(undefined),
+    maxRetries: 2,
+    retryBaseDelay: 1,
+    ...overrides,
+  }
+}
+
+describe('runAuthBootstrap', () => {
+  it('refresh 성공 → setAccessToken 호출, clearAuth·재시도 없음', async () => {
+    const deps = makeDeps({ performRefresh: vi.fn().mockResolvedValue('fresh') })
+    await runAuthBootstrap(deps)
+    expect(deps.performRefresh).toHaveBeenCalledOnce()
+    expect(deps.setAccessToken).toHaveBeenCalledWith('fresh')
+    expect(deps.clearAuth).not.toHaveBeenCalled()
+    expect(deps.delay).not.toHaveBeenCalled()
+  })
+
+  it('인증 실패(400/401) → 재시도 없이 즉시 clearAuth', async () => {
+    const deps = makeDeps({
+      performRefresh: vi.fn().mockRejectedValue(new Error('401')),
+      isAuthFailure: () => true,
+    })
+    await runAuthBootstrap(deps)
+    expect(deps.performRefresh).toHaveBeenCalledOnce()
+    expect(deps.clearAuth).toHaveBeenCalledOnce()
+    expect(deps.setAccessToken).not.toHaveBeenCalled()
+    expect(deps.delay).not.toHaveBeenCalled()
+  })
+
+  it('일시 장애 후 재시도 성공 → setAccessToken, clearAuth 미호출', async () => {
+    const performRefresh = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce('recovered')
+    const deps = makeDeps({ performRefresh, isAuthFailure: () => false })
+    await runAuthBootstrap(deps)
+    expect(performRefresh).toHaveBeenCalledTimes(2)
+    expect(deps.delay).toHaveBeenCalledOnce()
+    expect(deps.setAccessToken).toHaveBeenCalledWith('recovered')
+    expect(deps.clearAuth).not.toHaveBeenCalled()
+  })
+
+  it('일시 장애가 끝까지 지속 → 모든 재시도 소진 후 clearAuth', async () => {
+    const deps = makeDeps({
+      performRefresh: vi.fn().mockRejectedValue(new Error('timeout')),
+      isAuthFailure: () => false,
+      maxRetries: 2,
+    })
+    await runAuthBootstrap(deps)
+    expect(deps.performRefresh).toHaveBeenCalledTimes(3) // 최초 1 + 재시도 2
+    expect(deps.delay).toHaveBeenCalledTimes(2)
+    expect(deps.clearAuth).toHaveBeenCalledOnce()
+    expect(deps.setAccessToken).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useAuthBootstrap.ts
+++ b/src/hooks/useAuthBootstrap.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { useAuthStore } from '@/store/authStore'
+import { performRefresh, isAuthFailureRefreshError } from '@/api/client'
+
+/** 일시(timeout/5xx/network) 실패 시 부팅 refresh 재시도 횟수(최초 시도 제외). */
+const MAX_RETRIES = 2
+/** 재시도 간 지수 백오프 기준(ms). */
+const RETRY_BASE_DELAY = 800
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+interface BootstrapDeps {
+  performRefresh: () => Promise<string>
+  isAuthFailure: (error: unknown) => boolean
+  setAccessToken: (token: string) => void
+  clearAuth: () => void
+  delay: (ms: number) => Promise<void>
+  maxRetries: number
+  retryBaseDelay: number
+}
+
+/**
+ * 부팅 silent refresh의 순수 로직 — React 훅 바깥에서 단위 테스트가 가능하도록 의존성을
+ * 주입받는 형태로 분리했다.
+ *
+ * 에러를 두 부류로 나눈다:
+ * - 인증 실패(400 쿠키 누락 / 401 만료): 재시도 무의미 → 즉시 clearAuth(비로그인 확정).
+ * - 일시 장애(timeout/5xx/network): 백엔드 콜드스타트(~31초)일 수 있어 지수 백오프로 재시도
+ *   (콜드스타트 인스턴스를 깨우는 효과). 끝까지 실패하면 clearAuth.
+ */
+export async function runAuthBootstrap(deps: BootstrapDeps): Promise<void> {
+  for (let attempt = 0; attempt <= deps.maxRetries; attempt++) {
+    try {
+      const token = await deps.performRefresh()
+      deps.setAccessToken(token)
+      return
+    } catch (error) {
+      if (deps.isAuthFailure(error)) {
+        deps.clearAuth()
+        return
+      }
+      if (attempt < deps.maxRetries) {
+        await deps.delay(deps.retryBaseDelay * 2 ** attempt)
+        continue
+      }
+      deps.clearAuth()
+    }
+  }
+}
+
+/**
+ * 앱 부팅 시 1회 silent refresh로 세션을 복구한다.
+ *
+ * accessToken을 메모리에만 두면 새로고침 시 휘발되므로, httpOnly refresh 쿠키로 토큰을
+ * 재발급해 로그인 상태를 잇는다. 성공 시 토큰만 저장하고(user는 RootLayout 안전장치가
+ * getMyProfile로 비차단 충전) 즉시 게이트를 해제한다 — 부팅 왕복을 refresh 1회로 최소화.
+ *
+ * 성공/실패와 무관하게 마지막에 markBootstrapped로 게이트를 해제한다.
+ *
+ * @remarks StrictMode 이중 마운트와 무관하게 1회만 실행되도록 ref로 가드한다. client.ts의
+ * in-flight refreshPromise 큐잉도 중복 호출을 추가로 방어한다.
+ */
+export function useAuthBootstrap(): void {
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+
+    const { setAccessToken, clearAuth, markBootstrapped } = useAuthStore.getState()
+
+    runAuthBootstrap({
+      performRefresh,
+      isAuthFailure: isAuthFailureRefreshError,
+      setAccessToken,
+      clearAuth,
+      delay,
+      maxRetries: MAX_RETRIES,
+      retryBaseDelay: RETRY_BASE_DELAY,
+    }).finally(() => {
+      markBootstrapped()
+    })
+  }, [])
+}

--- a/src/lib/authProvider.test.ts
+++ b/src/lib/authProvider.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { saveAuthProvider, loadAuthProvider, clearAuthProvider } from './authProvider'
+
+describe('authProvider 영속', () => {
+  let store: Record<string, string>
+
+  beforeEach(() => {
+    store = {}
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('save → load 왕복', () => {
+    saveAuthProvider('GOOGLE')
+    expect(loadAuthProvider()).toBe('GOOGLE')
+    saveAuthProvider('EMAIL')
+    expect(loadAuthProvider()).toBe('EMAIL')
+  })
+
+  it('undefined 저장은 no-op (기존 값 유지)', () => {
+    saveAuthProvider('GOOGLE')
+    saveAuthProvider(undefined)
+    expect(loadAuthProvider()).toBe('GOOGLE')
+  })
+
+  it('알 수 없는 값은 undefined로 무시', () => {
+    store['auth-provider'] = 'KAKAO'
+    expect(loadAuthProvider()).toBeUndefined()
+  })
+
+  it('값 없으면 undefined', () => {
+    expect(loadAuthProvider()).toBeUndefined()
+  })
+
+  it('clear 후 undefined', () => {
+    saveAuthProvider('GOOGLE')
+    clearAuthProvider()
+    expect(loadAuthProvider()).toBeUndefined()
+  })
+
+  it('localStorage 접근 불가(throw)여도 안전', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('blocked')
+      },
+      removeItem: () => {
+        throw new Error('blocked')
+      },
+    })
+    expect(() => saveAuthProvider('GOOGLE')).not.toThrow()
+    expect(loadAuthProvider()).toBeUndefined()
+    expect(() => clearAuthProvider()).not.toThrow()
+  })
+})

--- a/src/lib/authProvider.ts
+++ b/src/lib/authProvider.ts
@@ -1,0 +1,39 @@
+/**
+ * 로그인 방식(EMAIL/GOOGLE) 라벨만 localStorage에 별도 영속한다.
+ *
+ * access token·세션은 메모리 전용(authStore)으로 옮겼지만, authProvider는 토큰도 PII도 아닌
+ * 단순 enum 라벨이라 XSS가 얻을 보안 가치가 없다("전부 메모리" 취지는 토큰·세션 보호이지 이
+ * 라벨이 아니다). 새로고침 후 부팅 복구(getMyProfile) 시 백엔드 `/users/me` 응답에
+ * authProvider가 없어 유실되면 SettingsPage의 Google 유저 분기(비밀번호 변경 숨김)가 깨지므로,
+ * 이 값만 영속해 복원한다.
+ *
+ * @remarks 백엔드 `/users/me` 응답에 authProvider가 추가되면 이 모듈은 제거 가능(후속).
+ */
+const KEY = 'auth-provider'
+
+export type AuthProvider = 'EMAIL' | 'GOOGLE'
+
+export function saveAuthProvider(provider: AuthProvider | undefined): void {
+  try {
+    if (provider) localStorage.setItem(KEY, provider)
+  } catch {
+    // private 모드 등 localStorage 접근 불가 환경에서는 무시
+  }
+}
+
+export function loadAuthProvider(): AuthProvider | undefined {
+  try {
+    const value = localStorage.getItem(KEY)
+    return value === 'EMAIL' || value === 'GOOGLE' ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function clearAuthProvider(): void {
+  try {
+    localStorage.removeItem(KEY)
+  } catch {
+    // private 모드 등 localStorage 접근 불가 환경에서는 무시
+  }
+}

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -105,10 +105,12 @@ export default function MyProfilePage() {
         if (tower) setWisdomTower(tower)
 
         const state = useAuthStore.getState()
-        if (state.user && state.accessToken) {
+        // user가 비어 있어도(부팅 직후 충전 전) accessToken만 있으면 동기화한다.
+        // 메모리 보관 전환 후 user=null 상태로 진입할 수 있어 조건을 accessToken 기준으로 완화.
+        if (state.accessToken) {
           state.setAuth(
             {
-              ...state.user,
+              ...(state.user ?? {}),
               id: result.userId,
               nickname: result.nickname,
               email: result.email,

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from './authStore'
+
+const sampleUser = { id: 1, nickname: '테스터', email: 't@example.com' }
+
+// authStore가 authProvider를 localStorage에 동기화하므로 node 환경에서도 stub으로 검증한다.
+let lsStore: Record<string, string>
+
+beforeEach(() => {
+  lsStore = {}
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => lsStore[k] ?? null,
+    setItem: (k: string, v: string) => {
+      lsStore[k] = v
+    },
+    removeItem: (k: string) => {
+      delete lsStore[k]
+    },
+  })
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    isAuthenticated: false,
+    isBootstrapped: false,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('authStore', () => {
+  it('초기 상태는 비로그인·미부팅', () => {
+    const s = useAuthStore.getState()
+    expect(s.user).toBeNull()
+    expect(s.accessToken).toBeNull()
+    expect(s.isAuthenticated).toBe(false)
+    expect(s.isBootstrapped).toBe(false)
+  })
+
+  it('setAuth: user·token 저장 + isAuthenticated true', () => {
+    useAuthStore.getState().setAuth(sampleUser, 'tok-1')
+    const s = useAuthStore.getState()
+    expect(s.user).toEqual(sampleUser)
+    expect(s.accessToken).toBe('tok-1')
+    expect(s.isAuthenticated).toBe(true)
+  })
+
+  it('setAccessToken: 토큰만 교체, user 불변, isAuthenticated true', () => {
+    useAuthStore.setState({ user: sampleUser, accessToken: 'old', isAuthenticated: true })
+    useAuthStore.getState().setAccessToken('new-tok')
+    const s = useAuthStore.getState()
+    expect(s.accessToken).toBe('new-tok')
+    expect(s.user).toEqual(sampleUser)
+    expect(s.isAuthenticated).toBe(true)
+  })
+
+  it('setAccessToken: user=null(부팅 직후)에도 토큰 저장 + isAuthenticated true', () => {
+    useAuthStore.getState().setAccessToken('boot-tok')
+    const s = useAuthStore.getState()
+    expect(s.accessToken).toBe('boot-tok')
+    expect(s.user).toBeNull()
+    expect(s.isAuthenticated).toBe(true)
+  })
+
+  it('setUser: user만 주입, 토큰 불변', () => {
+    useAuthStore.setState({ accessToken: 'keep-tok', isAuthenticated: true })
+    useAuthStore.getState().setUser(sampleUser)
+    const s = useAuthStore.getState()
+    expect(s.user).toEqual(sampleUser)
+    expect(s.accessToken).toBe('keep-tok')
+  })
+
+  it('clearAuth: user·token·isAuthenticated 전부 초기화', () => {
+    useAuthStore.setState({ user: sampleUser, accessToken: 'tok', isAuthenticated: true })
+    useAuthStore.getState().clearAuth()
+    const s = useAuthStore.getState()
+    expect(s.user).toBeNull()
+    expect(s.accessToken).toBeNull()
+    expect(s.isAuthenticated).toBe(false)
+  })
+
+  it('markBootstrapped: isBootstrapped true (다른 상태 불변)', () => {
+    useAuthStore.getState().markBootstrapped()
+    expect(useAuthStore.getState().isBootstrapped).toBe(true)
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  })
+
+  it('completeOnboarding: user 있으면 onboardingCompleted true', () => {
+    useAuthStore.setState({
+      user: { ...sampleUser, onboardingCompleted: false },
+      isAuthenticated: true,
+    })
+    useAuthStore.getState().completeOnboarding()
+    expect(useAuthStore.getState().user?.onboardingCompleted).toBe(true)
+  })
+
+  it('completeOnboarding: user 없으면 null 유지', () => {
+    useAuthStore.getState().completeOnboarding()
+    expect(useAuthStore.getState().user).toBeNull()
+  })
+
+  it('setAuth: authProvider를 localStorage에 영속', () => {
+    useAuthStore.getState().setAuth({ ...sampleUser, authProvider: 'GOOGLE' }, 'tok')
+    expect(lsStore['auth-provider']).toBe('GOOGLE')
+    expect(useAuthStore.getState().user?.authProvider).toBe('GOOGLE')
+  })
+
+  it('setUser: authProvider 없는 응답도 localStorage에서 보강 (부팅 충전 회귀)', () => {
+    lsStore['auth-provider'] = 'GOOGLE'
+    useAuthStore.getState().setUser(sampleUser)
+    expect(useAuthStore.getState().user?.authProvider).toBe('GOOGLE')
+  })
+
+  it('clearAuth: authProvider도 localStorage에서 삭제', () => {
+    lsStore['auth-provider'] = 'GOOGLE'
+    useAuthStore.setState({
+      user: { ...sampleUser, authProvider: 'GOOGLE' },
+      accessToken: 'tok',
+      isAuthenticated: true,
+    })
+    useAuthStore.getState().clearAuth()
+    expect(lsStore['auth-provider']).toBeUndefined()
+  })
+})

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { saveAuthProvider, loadAuthProvider, clearAuthProvider } from '@/lib/authProvider'
 
 interface User {
   id: number
@@ -16,34 +16,76 @@ interface AuthState {
   user: User | null
   accessToken: string | null
   isAuthenticated: boolean
+  /**
+   * 부팅 silent refresh(`useAuthBootstrap`) 완료 여부.
+   * false인 동안 RootLayout 게이트가 PageLoader를 표시해, 토큰 복구 전 라우트 렌더를 막는다.
+   */
+  isBootstrapped: boolean
   setAuth: (user: User, accessToken: string) => void
+  setAccessToken: (accessToken: string) => void
+  setUser: (user: User) => void
   clearAuth: () => void
+  markBootstrapped: () => void
   completeOnboarding: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    set => ({
-      user: null,
-      accessToken: null,
-      isAuthenticated: false,
-      setAuth: (user, accessToken) => set({ user, accessToken, isAuthenticated: true }),
-      clearAuth: () => {
-        set({ user: null, accessToken: null, isAuthenticated: false })
-        useAuthStore.persist.clearStorage?.()
-      },
-      completeOnboarding: () =>
-        set(state => ({
-          user: state.user ? { ...state.user, onboardingCompleted: true } : null,
-        })),
-    }),
-    {
-      name: 'auth-storage',
-      partialize: state => ({
-        user: state.user,
-        accessToken: state.accessToken,
-        isAuthenticated: state.isAuthenticated,
-      }),
-    }
-  )
-)
+/**
+ * 과거 버전이 localStorage('auth-storage')에 평문 저장한 access token을 1회 제거한다.
+ *
+ * persist를 걷어내고 토큰을 메모리 전용으로 옮겼으므로, 기존 사용자 브라우저에 남아 있는
+ * 평문 토큰 잔존물을 정리해 탈취 표면을 없앤다. private 모드/비브라우저 환경은 무시.
+ */
+try {
+  localStorage.removeItem('auth-storage')
+} catch {
+  // private 모드 등 localStorage 접근 불가 환경에서는 무시
+}
+
+/**
+ * 인증 상태 store (메모리 전용, 비영속).
+ *
+ * accessToken을 localStorage가 아닌 JS 메모리에만 보관해 XSS 토큰 탈취 표면을 제거한다.
+ * 새로고침 시 상태가 휘발되지만, httpOnly refresh 쿠키로 앱 부팅 때 1회 silent refresh하여
+ * 세션을 복구한다(`useAuthBootstrap`). 이 때문에 persist 미들웨어를 의도적으로 쓰지 않는다.
+ *
+ * @remarks user는 부팅 직후 비어 있을 수 있고(토큰만 복구된 상태), RootLayout 안전장치가
+ * `getMyProfile`로 충전한다. 따라서 user=null이 곧 "비로그인"을 의미하지 않으며, 인증 판정은
+ * `isAuthenticated`로 한다.
+ */
+export const useAuthStore = create<AuthState>(set => ({
+  user: null,
+  accessToken: null,
+  isAuthenticated: false,
+  isBootstrapped: false,
+  /**
+   * 로그인/회원가입/구글 콜백 등 user와 토큰을 동시에 확보한 경우.
+   * authProvider는 별도 영속하고, 호출부가 넘기지 않으면 localStorage에서 보강한다.
+   */
+  setAuth: (user, accessToken) => {
+    const authProvider = user.authProvider ?? loadAuthProvider()
+    set({ user: { ...user, authProvider }, accessToken, isAuthenticated: true })
+    saveAuthProvider(authProvider)
+  },
+  /**
+   * user는 그대로 두고 access token만 교체한다(부팅 silent refresh 성공·401 자동 refresh 공용).
+   * 토큰을 받았다는 것은 유효한 refresh 세션이 있다는 뜻이므로 isAuthenticated=true를 보장한다.
+   */
+  setAccessToken: accessToken => set({ accessToken, isAuthenticated: true }),
+  /**
+   * 부팅 후 비차단 getMyProfile로 받아온 user를 주입(토큰 불변).
+   * getMyProfile 응답엔 authProvider가 없으므로 localStorage에서 보강해 유실을 막는다.
+   */
+  setUser: user => {
+    const authProvider = user.authProvider ?? loadAuthProvider()
+    set({ user: { ...user, authProvider } })
+  },
+  clearAuth: () => {
+    set({ user: null, accessToken: null, isAuthenticated: false })
+    clearAuthProvider()
+  },
+  markBootstrapped: () => set({ isBootstrapped: true }),
+  completeOnboarding: () =>
+    set(state => ({
+      user: state.user ? { ...state.user, onboardingCompleted: true } : null,
+    })),
+}))


### PR DESCRIPTION
  ## 개요
  localStorage에 평문 저장되던 access token을 메모리 전용으로 옮겨 XSS 토큰 탈취 표면을 제거하고, 새로고침 시 휘발되는 토큰을 부팅 silent refresh 1회로 복구한다. (보안 부채 4건 중 최우선 항목)

  ## 변경 사항
  - **authStore**: `persist` 제거(user·accessToken·isAuthenticated 메모리 전용), `isBootstrapped` + `setAccessToken`/`setUser`/`markBootstrapped` 추가, 기존 `auth-storage` 키 정리
  - **useAuthBootstrap**(신규): 부팅 silent refresh 1회 — 인증 실패는 즉시 비로그인, 일시 장애는 지수 백오프 재시도(EC2 콜드스타트 대응)
  - **RootLayout**: `isBootstrapped` 게이트(토큰 복구 전 렌더 차단) + user 비차단 충전
  - **client.ts**: 401 자동 refresh 후처리 user 가드 완화(user=null 충전 전 정상 케이스), `setAuth`→`setAccessToken`
  - **MyProfilePage**: 동기화 조건을 accessToken 기준으로 완화
  - **lib/authProvider**(신규): authProvider 라벨만 별도 영속 — persist 제거로 인한 Google 유저 설정 분기 회귀 수정(토큰은 메모리 유지)

  ## 설계 결정
  - "접근 C": persist 완전 제거(localStorage에 토큰·세션 흔적 0). 부팅 게이트는 refresh **1회만** 기다리고 user는 진입 후 비동기 충전 → 새로고침 왕복 최소화.
  - authProvider는 토큰·PII가 아닌 enum 라벨이라 영속해도 보안 무관 → 부팅 복구 회귀만 막고 토큰 보호는 유지.

  ## 테스트
  - `npx tsc -b --force` — 에러 0
  - `npx eslint .` — 에러 0
  - `npx vitest run --config vitest.config.ts` — **73개 통과**(authStore·useAuthBootstrap·authProvider 신규 + client.test 회귀 케이스)
  - `npm run build` — 성공 / `prettier --check` — 통과

  ## 참고
  - 부분 머지 금지 — persist 제거·게이트·부팅 refresh는 원자적(부분 머지 시 새로고침 로그아웃 회귀).
  - CSP/보안 헤더(PR2), 백엔드 `/users/me` authProvider 추가는 후속.

  Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 앱 시작 시 자동 인증 부팅(무중단 silent refresh) 및 로그인 방식(이메일/구글) 기억 기능 추가

* **Improvements**
  * 토큰 갱신/실패 처리 안정성 향상—불필요한 로그아웃/리다이렉트 방지
  * 라우트 최상위에서 부팅 완료 전 로더 표시 및 부팅 후 프로필 자동 동기화 보강
  * 인증 상태 관리와 토큰 교체 흐름 간소화로 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->