### PR TITLE
feat: 서재 상세에서 감상 작성 시 libraryBookId 전달 (#226)

### DIFF
--- a/src/api/review.ts
+++ b/src/api/review.ts
@@ -4,6 +4,9 @@ import type { BackendReadingStatus } from './book'
 
 export interface CreateReviewRequest {
   bookId: number
+  // 서재에서 감상을 쓸 때만 채워지는 "내 서재 책" 식별자. 백엔드가 소유자 검증 후
+  // 감상을 해당 서재책과 연결한다(optional — 책 상세/검색 등 서재 밖 진입 시 미전송).
+  libraryBookId?: number
   content: string
   rating: number
   quote?: string

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -325,7 +325,13 @@ export default function LibraryBookDetailPage() {
               <p className="text-sm text-muted-foreground">아직 감상이 없어요</p>
               <button
                 type="button"
-                onClick={() => navigate(`/review/write/${detail.book.bookId}`)}
+                onClick={() =>
+                  navigate(`/review/write/${detail.book.bookId}`, {
+                    // 서재 책 컨텍스트에서 감상을 쓰므로 libraryBookId를 함께 전달 →
+                    // 백엔드가 감상을 이 서재책과 연결(소유자 검증 포함).
+                    state: { libraryBookId: detail.libraryBookId },
+                  })
+                }
                 className="w-full rounded-xl bg-primary py-3 text-sm font-bold text-primary-foreground shadow-sm transition-transform active:scale-[0.98]"
               >
                 감상 쓰기

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { getBook, type BookDetail } from '@/api/book'
 import { createReview, getReviewDetail, updateReview } from '@/api/review'
@@ -27,8 +27,11 @@ type ReviewFormBook = Pick<BookDetail, 'bookId' | 'title' | 'author' | 'coverIma
 export default function WriteReviewPage() {
   const { bookId, reviewId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const currentUserId = useAuthStore(state => state.user?.id)
   const isEditMode = reviewId != null
+  // 서재 상세에서 감상 쓰기로 진입한 경우에만 전달되는 서재책 ID (그 외 경로는 undefined)
+  const libraryBookId = (location.state as { libraryBookId?: number } | null)?.libraryBookId
 
   const [book, setBook] = useState<ReviewFormBook | null>(null)
   const [rating, setRating] = useState(5)
@@ -237,6 +240,8 @@ export default function WriteReviewPage() {
         bookId: parseInt(bookId!, 10),
         ...basePayload,
         ...(trimmedQuote ? { quote: trimmedQuote } : {}),
+        // 서재 상세에서 진입한 경우에만 서재책과 연결 (그 외엔 미전송)
+        ...(libraryBookId != null ? { libraryBookId } : {}),
       })
       navigate(`/review/${result.reviewId}`, { replace: true })
     } catch (error) {


### PR DESCRIPTION
## 변경 내용

closes #226

서재 상세 페이지에서 감상 쓰기로 이동할 때 `libraryBookId`를 router state로 전달하고, 감상 작성 페이지에서 이를 읽어 리뷰 생성 payload에 조건부로 포함합니다. 백엔드는 해당 값으로 소유자 검증 후 감상을 서재책과 연결합니다.

- `CreateReviewRequest`에 `libraryBookId?: number` 선택 필드 추가
- `LibraryBookDetailPage`: 감상 쓰기 네비게이션에 `state: { libraryBookId }` 전달
- `WriteReviewPage`: `useLocation`으로 router state에서 `libraryBookId` 읽어 값이 있을 때만 payload에 포함
- `readPages`(독서량)는 제품 결정으로 미포함

## 검증

- `npx tsc -b --noEmit` 통과 (exit 0)
- eslint 변경 파일 0 에러
- lint-staged 훅 커밋 시 정상 통과

## 체크리스트

- [x] 타입 오류 없음
- [x] lint 오류 없음
- [x] 서재 상세 미경유 감상 작성 시 libraryBookId 미포함 확인 (선택 필드)
- [x] 이슈 #226 연결