### PR TITLE
refactor: 에러 판별을 메시지 문자열에서 errorCode 기반으로 전환 (#228)

### DIFF
--- a/src/api/_helpers.ts
+++ b/src/api/_helpers.ts
@@ -3,6 +3,9 @@ import axios from 'axios'
 export interface ApiResponse<T> {
   status: 'SUCCESS' | 'ERROR'
   code: number
+  // 백엔드 도메인 에러코드(예: 'M001'). 비즈니스 예외 응답에만 포함된다(성공/일반 에러엔 없음).
+  // 메시지 문구가 아닌 이 코드로 에러를 분기하기 위해 사용.
+  errorCode?: string
   message?: string
   data?: T
   errors?: Array<{ field: string; message: string }>

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -506,6 +506,33 @@ describe('isMemberNotFound', () => {
     expect(isMemberNotFound(new Error('test'))).toBe(false)
     expect(isMemberNotFound(null)).toBe(false)
   })
+
+  it('errorCode "M001" → true (메시지 문구와 무관)', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: { errorCode: 'M001', message: '문구가 바뀌어도 무관' } },
+    }
+    expect(isMemberNotFound(error)).toBe(true)
+  })
+
+  it('errorCode "M001" + 메시지 없음 → true (코드 기반 판별)', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: { errorCode: 'M001' } },
+    }
+    expect(isMemberNotFound(error)).toBe(true)
+  })
+
+  it('다른 errorCode("B001") + 회원 아닌 메시지 → false', async () => {
+    const { isMemberNotFound } = await import('./client')
+    const error = {
+      isAxiosError: true,
+      response: { status: 404, data: { errorCode: 'B001', message: '존재하지 않는 도서입니다.' } },
+    }
+    expect(isMemberNotFound(error)).toBe(false)
+  })
 })
 
 describe('MEMBER_NOT_FOUND 인터셉터 — stale 세션 감지', () => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -134,12 +134,13 @@ apiClient.interceptors.request.use(config => {
 })
 
 /**
- * 백엔드 MEMBER_NOT_FOUND 응답 메시지.
+ * 백엔드 MEMBER_NOT_FOUND 식별자.
  *
- * `ErrorCode.MEMBER_NOT_FOUND(404, "M001", "존재하지 않는 회원입니다.")`이지만
- * `GlobalExceptionHandler.handleBusinessException`이 message만 응답 body에 포함하므로
- * 에러 코드("M001")가 아닌 메시지 문자열로 판별한다.
+ * `ErrorCode.MEMBER_NOT_FOUND(404, "M001", "존재하지 않는 회원입니다.")`.
+ * 백엔드가 응답 body에 `errorCode`("M001")를 내려주므로 이 코드로 판별한다.
+ * 단, errorCode가 없던 구버전 응답(배포 이전)과의 하위호환을 위해 메시지 문자열 폴백도 유지한다.
  */
+const MEMBER_NOT_FOUND_CODE = 'M001'
 const MEMBER_NOT_FOUND_MESSAGE = '존재하지 않는 회원입니다.'
 
 /**
@@ -168,15 +169,19 @@ function isAuthFlowUrl(url: string): boolean {
 }
 
 /**
- * 응답이 MEMBER_NOT_FOUND(HTTP 404 + 특정 message)인지 판별.
+ * 응답이 MEMBER_NOT_FOUND인지 판별.
  *
  * DB 초기화·회원 삭제 등으로 JWT의 사용자가 DB에 없을 때 백엔드의 거의 모든
  * 인증 필요 API가 이 응답을 반환한다. 401(토큰 만료)과 달리 토큰 자체는 유효하므로
  * 별도 감지가 필요하다.
+ *
+ * 도메인 errorCode('M001')로 판별하는 것을 우선하고, errorCode가 없는 구버전 응답에 대해서는
+ * 기존 메시지 문자열(HTTP 404 + 특정 message)로 폴백한다.
  */
 function isMemberNotFound(error: unknown): boolean {
   if (!axios.isAxiosError(error)) return false
-  const data = error.response?.data as { message?: string } | undefined
+  const data = error.response?.data as { errorCode?: string; message?: string } | undefined
+  if (data?.errorCode === MEMBER_NOT_FOUND_CODE) return true
   return error.response?.status === 404 && data?.message === MEMBER_NOT_FOUND_MESSAGE
 }
 


### PR DESCRIPTION
## 개요

백엔드 #207 배포로 내려오는 도메인 `errorCode` 필드를 활용해 `isMemberNotFound` 판별 로직을 강화합니다.
메시지 문구 변경에 의존하지 않고 `errorCode: 'M001'`로 우선 판별하며, `errorCode`가 없는 구버전 응답은 기존 메시지 폴백으로 하위호환을 유지합니다.

## 변경 사항

- `src/api/_helpers.ts`: `ApiResponse` 인터페이스에 `errorCode?: string` 필드 추가
- `src/api/client.ts`: `MEMBER_NOT_FOUND_CODE` 상수(`'M001'`) 추가, `isMemberNotFound`를 errorCode 우선 + 메시지 폴백 방식으로 변경
- `src/api/client.test.ts`: errorCode 기반 판별 테스트 3개 추가

## 검증

- `npx tsc -b --noEmit` — 통과 (exit 0)
- ESLint 변경 파일 — 0 에러
- `npx vitest run src/api/client.test.ts` — 33/33 통과

## 체크리스트

- [x] TypeScript 타입 에러 없음
- [x] ESLint 에러 없음
- [x] 기존 테스트 전부 통과
- [x] 신규 테스트 추가 (errorCode 기반 판별 3개)
- [x] 구버전 응답 하위호환 확인

closes #228