### PR TITLE
perf: 이미지 lazy loading 일괄 적용 (#230)

### DIFF
--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -574,6 +574,7 @@ function CommentRow({
               <img
                 src={user.profileImageUrl}
                 alt={user.nickname}
+                loading="lazy"
                 className="size-full object-cover"
               />
             ) : (

--- a/src/components/common/PopupBanner.tsx
+++ b/src/components/common/PopupBanner.tsx
@@ -85,7 +85,7 @@ export default function PopupBanner({
         </button>
 
         <div className="aspect-square w-full">
-          <img src={imageUrl} alt={imageAlt} className="size-full object-cover" />
+          <img loading="lazy" src={imageUrl} alt={imageAlt} className="size-full object-cover" />
         </div>
 
         <div className="flex gap-2 p-4">

--- a/src/components/common/UserSearchCard.tsx
+++ b/src/components/common/UserSearchCard.tsx
@@ -85,6 +85,7 @@ export default function UserSearchCard({ user }: { user: UserSearchItem }) {
           <img
             src={user.profileImageUrl}
             alt={`${user.nickname} 프로필 이미지`}
+            loading="lazy"
             className="size-full object-cover"
           />
         ) : (

--- a/src/components/ocr/OcrTextSelector.tsx
+++ b/src/components/ocr/OcrTextSelector.tsx
@@ -95,6 +95,7 @@ export default function OcrTextSelector({
             src={imageSrc}
             alt="OCR 대상 이미지"
             onLoad={handleImageLoad}
+            loading="lazy"
             className="max-h-[70vh] max-w-full rounded-lg"
           />
 

--- a/src/components/ocr/WebcamCapture.tsx
+++ b/src/components/ocr/WebcamCapture.tsx
@@ -278,7 +278,12 @@ export default function WebcamCapture({ onCapture, onClose }: WebcamCaptureProps
         <>
           {/* Captured Image Preview */}
           <div className="relative flex flex-1 items-center justify-center overflow-hidden">
-            <img src={capturedImage} alt="촬영된 사진" className="size-full object-contain" />
+            <img
+              loading="lazy"
+              src={capturedImage}
+              alt="촬영된 사진"
+              className="size-full object-contain"
+            />
           </div>
 
           {/* Confirm / Retake */}

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -179,7 +179,12 @@ export default function BookDetailPage() {
         <div className="flex justify-center px-6 py-8">
           <div className="relative aspect-[2/3] w-2/3 overflow-hidden rounded-lg border border-primary/5 shadow-2xl">
             {book.coverImageUrl ? (
-              <img src={book.coverImageUrl} alt={book.title} className="size-full object-cover" />
+              <img
+                loading="lazy"
+                src={book.coverImageUrl}
+                alt={book.title}
+                className="size-full object-cover"
+              />
             ) : (
               <div className="flex size-full items-center justify-center bg-primary/5">
                 <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
@@ -286,6 +291,7 @@ export default function BookDetailPage() {
                             <img
                               src={review.user.profileImageUrl}
                               alt={review.user.nickname}
+                              loading="lazy"
                               className="size-full object-cover"
                             />
                           ) : (

--- a/src/pages/BookReviewsListPage.tsx
+++ b/src/pages/BookReviewsListPage.tsx
@@ -289,6 +289,7 @@ export default function BookReviewsListPage() {
               <img
                 src={book.coverImageUrl}
                 alt={book.title}
+                loading="lazy"
                 className="h-14 w-10 rounded-md object-cover shadow-sm"
               />
             ) : (
@@ -364,6 +365,7 @@ export default function BookReviewsListPage() {
                           <img
                             src={review.user.profileImageUrl}
                             alt={review.user.nickname}
+                            loading="lazy"
                             className="size-full object-cover"
                           />
                         ) : (

--- a/src/pages/BookSearchPage.tsx
+++ b/src/pages/BookSearchPage.tsx
@@ -794,6 +794,7 @@ export default function BookSearchPage() {
                         <img
                           src={book.coverImageUrl}
                           alt={book.title}
+                          loading="lazy"
                           className="size-full object-cover"
                         />
                       ) : (
@@ -1020,6 +1021,7 @@ function AllTabContent({
                     <img
                       src={book.coverImageUrl}
                       alt={book.title}
+                      loading="lazy"
                       className="size-full object-cover"
                     />
                   ) : (

--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -97,6 +97,7 @@ export default function EditProfilePage() {
                 <img
                   src={user.profileImageUrl}
                   alt={`${user.nickname} 프로필 이미지`}
+                  loading="lazy"
                   className="h-full w-full object-cover"
                 />
               ) : (

--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -350,6 +350,7 @@ export default function FollowListPage() {
                           <img
                             src={item.profileImageUrl}
                             alt={`${item.nickname} 프로필 이미지`}
+                            loading="lazy"
                             className="size-full object-cover"
                           />
                         ) : (

--- a/src/pages/LibraryBookDetailPage.tsx
+++ b/src/pages/LibraryBookDetailPage.tsx
@@ -231,6 +231,7 @@ export default function LibraryBookDetailPage() {
               <img
                 src={detail.book.coverImageUrl}
                 alt={`${detail.book.title} 표지`}
+                loading="lazy"
                 className="size-full object-cover"
               />
             ) : (

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -389,6 +389,7 @@ export default function MyLibraryPage() {
                         <img
                           src={item.book.coverImageUrl}
                           alt={item.book.title}
+                          loading="lazy"
                           className="size-full object-cover"
                         />
                       ) : (

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -306,6 +306,7 @@ export default function MyProfilePage() {
               <img
                 src={profile.profileImageUrl}
                 alt={`${profile.nickname} 프로필 이미지`}
+                loading="lazy"
                 className="h-32 w-32 rounded-full object-cover"
               />
             ) : (
@@ -486,6 +487,7 @@ export default function MyProfilePage() {
                       <img
                         src={review.book.coverImageUrl}
                         alt={`${review.book.title} 표지`}
+                        loading="lazy"
                         className="size-full object-cover"
                       />
                     ) : (

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -483,6 +483,7 @@ function NotificationRow({
             <img
               src={notification.actor.profileImageUrl}
               alt={actorName}
+              loading="lazy"
               className="size-full object-cover"
             />
           ) : (

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -92,6 +92,7 @@ export default function OnboardingPage() {
               <img
                 src={current.imageUrl}
                 alt={current.imageAlt}
+                loading="lazy"
                 className="absolute inset-0 size-full object-cover opacity-80 mix-blend-multiply"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -223,6 +223,7 @@ export default function ReviewDetailPage() {
                   <img
                     src={coverImageUrl}
                     alt={review.book.title}
+                    loading="lazy"
                     className="size-full object-cover"
                   />
                 ) : (

--- a/src/pages/UserLibraryPage.tsx
+++ b/src/pages/UserLibraryPage.tsx
@@ -325,6 +325,7 @@ export default function UserLibraryPage() {
                             <img
                               src={item.book.coverImageUrl}
                               alt={item.book.title}
+                              loading="lazy"
                               className="size-full object-cover"
                             />
                           ) : (

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -312,6 +312,7 @@ export default function UserProfilePage() {
               <img
                 src={profile.profileImageUrl}
                 alt={`${profile.nickname} 프로필 이미지`}
+                loading="lazy"
                 className="h-32 w-32 rounded-full object-cover"
               />
             ) : (
@@ -451,6 +452,7 @@ export default function UserProfilePage() {
                       <img
                         src={review.book.coverImageUrl}
                         alt={`${review.book.title} 표지`}
+                        loading="lazy"
                         className="size-full object-cover"
                       />
                     ) : (

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -310,6 +310,7 @@ export default function WriteReviewPage() {
                   <img
                     src={book.coverImageUrl}
                     alt={book.title}
+                    loading="lazy"
                     className="size-full object-cover"
                   />
                 ) : (


### PR DESCRIPTION
## 개요

무한스크롤 리스트의 뷰포트 밖 이미지(표지·아바타)에 `loading="lazy"` 속성을 일괄 추가하여 초기 네트워크 비용을 절감합니다.

closes #230

## 변경 내용

- `loading` 속성이 없던 `<img>` 24개에 `loading="lazy"` 추가
- 전체 28개 `<img>` 태그 모두 lazy 적용 완료 (기존 4개 + 신규 24개)
- 로직·레이아웃 무변경, 속성 추가만

**적용 파일 (19개)**

| 분류 | 파일 |
|------|------|
| pages | ReviewDetailPage, UserLibraryPage, UserProfilePage, WriteReviewPage, BookSearchPage, MyLibraryPage, BookReviewsListPage, NotificationsPage, FollowListPage, BookDetailPage, LibraryBookDetailPage, MyProfilePage, OnboardingPage, EditProfilePage |
| components | CommentSection, WebcamCapture, OcrTextSelector, UserSearchCard, PopupBanner |

## 검증

- [x] `<img>` 28개 전부 `loading="lazy"` 확인 (누락 0 · 중복 0)
- [x] `npx tsc -b --noEmit` exit 0
- [x] ESLint 변경 파일 exit 0
- [x] husky / lint-staged 훅 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 앱 전반의 이미지 로딩을 최적화했습니다. 프로필 이미지, 도서 표지, 아바타 등이 필요한 시점에만 로드되어 초기 로딩 속도가 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->