### PR TITLE
perf: 리스트 아이템 컴포넌트에 React.memo 적용 (#232)

### DIFF
--- a/src/components/common/BookListItem.tsx
+++ b/src/components/common/BookListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import StarRating from './StarRating'
@@ -18,7 +19,7 @@ interface BookListItemProps {
   className?: string
 }
 
-export default function BookListItem({ book, className }: BookListItemProps) {
+function BookListItem({ book, className }: BookListItemProps) {
   return (
     <Link
       to={`/book/${book.isbn}`}
@@ -55,3 +56,6 @@ export default function BookListItem({ book, className }: BookListItemProps) {
     </Link>
   )
 }
+
+// 리스트에서 .map으로 다수 렌더되므로 props(book/className) 미변경 시 리렌더를 스킵한다.
+export default memo(BookListItem)

--- a/src/components/common/UserSearchCard.tsx
+++ b/src/components/common/UserSearchCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { followUser, unfollowUser } from '@/api/follow'
 import type { UserSearchItem } from '@/api/search'
@@ -20,7 +20,7 @@ import { useAuthStore } from '@/store/authStore'
  * `isProcessing`으로 진행 중이면 새 토글 차단(API는 멱등이지만 race 방지).
  * 언마운트 후 setState 방지를 위해 `isMountedRef` 유지.
  */
-export default function UserSearchCard({ user }: { user: UserSearchItem }) {
+function UserSearchCard({ user }: { user: UserSearchItem }) {
   const myUserId = useAuthStore(state => state.user?.id)
   const isMe = myUserId === user.userId
 
@@ -119,3 +119,7 @@ export default function UserSearchCard({ user }: { user: UserSearchItem }) {
     </Link>
   )
 }
+
+// 유저 검색 리스트에서 .map으로 다수 렌더되고 부모(BookSearchPage)가 빈번히 setState하므로
+// props(user) 미변경 시 리렌더를 스킵한다. (팔로우 토글 콜백은 카드 내부라 props 안정적)
+export default memo(UserSearchCard)


### PR DESCRIPTION
## 변경 내용

- `BookListItem`: `React.memo`로 감쌈. 북 리스트에서 `.map` 렌더되는 아이템으로, 부모 setState 시 `book`/`className` props가 바뀌지 않으면 리렌더를 스킵한다.
- `UserSearchCard`: `React.memo`로 감쌈. `BookSearchPage`가 빈번히 setState하는 환경에서 `user` props 미변경 시 불필요한 리렌더를 방지한다. 팔로우 토글 콜백은 카드 내부 상태라 props 안정성에 영향 없음.
- `ReviewCard`는 이미 memo 적용 상태라 변경 없음.

## 검증

- `npx tsc -b --noEmit` exit 0
- eslint 변경 파일 exit 0
- 두 컴포넌트 모두 `export default memo(...)` 확인

closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 책 목록 항목의 렌더링 성능을 최적화했습니다.
  * 사용자 검색 카드의 렌더링 성능을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->