### PR TITLE
feat: 감상 임시저장 기능 구현 (#234)

### DIFF
--- a/src/pages/DraftsListPage.tsx
+++ b/src/pages/DraftsListPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import AppHeader from '@/components/layout/AppHeader'
+import BottomNav from '@/components/layout/BottomNav'
+import { deleteReview, getMyReviews, REVIEW_PAGE_SIZE, type ReviewListItem } from '@/api/review'
+import { formatRelativeTime } from '@/lib/utils'
+
+/**
+ * 임시저장(DRAFT) 감상 보관함.
+ *
+ * `getMyReviews({ status: 'DRAFT' })`로 본인 임시저장 감상만 커서 기반으로 조회한다.
+ * 각 항목은 작성 페이지의 수정 모드(`/review/:reviewId/edit`)로 진입해 이어쓰거나 발행할 수 있고,
+ * 보관함에서 바로 삭제할 수도 있다. 임시저장은 본인만 볼 수 있으므로 스포일러 블러 처리는 하지 않는다.
+ */
+export default function DraftsListPage() {
+  const navigate = useNavigate()
+  const [drafts, setDrafts] = useState<ReviewListItem[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+
+  const loadMoreControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setIsLoading(true)
+    setErrorMessage(null)
+    ;(async () => {
+      try {
+        const response = await getMyReviews({
+          cursor: null,
+          status: 'DRAFT',
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        setDrafts(response)
+        setNextCursor(response.length > 0 ? response[response.length - 1].reviewId : null)
+        setHasMore(response.length === REVIEW_PAGE_SIZE)
+      } catch (error) {
+        if (axios.isCancel(error) || controller.signal.aborted) return
+        setErrorMessage(
+          error instanceof Error ? error.message : '임시저장 목록을 불러오지 못했습니다.'
+        )
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    })()
+
+    return () => {
+      controller.abort()
+      loadMoreControllerRef.current?.abort()
+    }
+  }, [])
+
+  const handleLoadMore = async () => {
+    if (isLoadingMore || !hasMore) return
+
+    loadMoreControllerRef.current?.abort()
+    const controller = new AbortController()
+    loadMoreControllerRef.current = controller
+
+    setIsLoadingMore(true)
+    setErrorMessage(null)
+    try {
+      const response = await getMyReviews({
+        cursor: nextCursor,
+        status: 'DRAFT',
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      if (response.length === 0) {
+        setHasMore(false)
+        return
+      }
+      setDrafts(prev => [...prev, ...response])
+      setNextCursor(response[response.length - 1].reviewId)
+      setHasMore(response.length === REVIEW_PAGE_SIZE)
+    } catch (error) {
+      if (axios.isCancel(error) || controller.signal.aborted) return
+      setErrorMessage(
+        error instanceof Error ? error.message : '임시저장 목록을 더 불러오지 못했습니다.'
+      )
+    } finally {
+      if (!controller.signal.aborted) setIsLoadingMore(false)
+    }
+  }
+
+  const handleDelete = async (reviewId: number) => {
+    if (deletingId != null) return
+    if (!window.confirm('이 임시저장을 삭제할까요?')) return
+
+    setDeletingId(reviewId)
+    setErrorMessage(null)
+    try {
+      await deleteReview(reviewId)
+      setDrafts(prev => prev.filter(d => d.reviewId !== reviewId))
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '임시저장을 삭제하지 못했습니다.')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader title="임시저장" showBack />
+
+      <main className="flex-1 overflow-y-auto px-6 pb-24 pt-6">
+        {isLoading ? (
+          <p role="status" className="py-12 text-center text-sm text-muted-foreground">
+            불러오는 중...
+          </p>
+        ) : drafts.length === 0 && !errorMessage ? (
+          <div className="flex flex-col items-center gap-3 rounded-[24px] bg-card py-16 shadow-sm">
+            <span className="material-symbols-outlined text-5xl text-muted-foreground/30">
+              draft
+            </span>
+            <p className="text-sm text-muted-foreground">임시저장한 감상이 없습니다</p>
+            <p className="text-xs text-muted-foreground/60">
+              감상 작성 중 임시저장하면 여기에 보관돼요
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {drafts.map(draft => (
+              <div key={draft.reviewId} className="flex gap-4 rounded-[24px] bg-card p-4 shadow-sm">
+                <button
+                  type="button"
+                  onClick={() => navigate(`/review/${draft.reviewId}/edit`)}
+                  className="flex min-w-0 flex-1 gap-4 text-left transition-opacity hover:opacity-80"
+                  aria-label={`${draft.book.title} 임시저장 이어쓰기`}
+                >
+                  <div className="flex h-[96px] w-[76px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-primary/5">
+                    {draft.book.coverImageUrl ? (
+                      <img
+                        src={draft.book.coverImageUrl}
+                        alt={`${draft.book.title} 표지`}
+                        loading="lazy"
+                        className="size-full object-cover"
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined text-3xl text-muted-foreground/30">
+                        menu_book
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="min-w-0 flex-1 pt-1">
+                    <h3 className="line-clamp-1 text-xl font-bold text-foreground">
+                      {draft.book.title}
+                    </h3>
+                    <p className="mt-1 text-sm font-medium text-primary/40">
+                      {formatRelativeTime(draft.createdAt)}
+                    </p>
+                    <p className="mt-3 line-clamp-2 text-base leading-6 text-foreground/65">
+                      {draft.content || '작성 중인 감상...'}
+                    </p>
+                  </div>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => handleDelete(draft.reviewId)}
+                  disabled={deletingId === draft.reviewId}
+                  aria-label="임시저장 삭제"
+                  className="flex size-9 shrink-0 items-center justify-center self-start rounded-full text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                >
+                  <span className="material-symbols-outlined text-[20px]">
+                    {deletingId === draft.reviewId ? 'progress_activity' : 'delete'}
+                  </span>
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {errorMessage && (
+          <p
+            role="alert"
+            className="mt-4 rounded-xl bg-destructive/10 px-4 py-3 text-center text-sm text-destructive"
+          >
+            {errorMessage}
+          </p>
+        )}
+
+        {hasMore && !isLoading && (
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            disabled={isLoadingMore}
+            className="mt-5 w-full rounded-xl bg-primary/10 py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoadingMore ? '불러오는 중...' : '더 보기'}
+          </button>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -460,6 +460,23 @@ export default function MyProfilePage() {
           </div>
         </section>
 
+        {/* Drafts Entry */}
+        <section className="px-6 pt-10">
+          <button
+            type="button"
+            onClick={() => navigate('/drafts')}
+            className="flex w-full items-center gap-3 rounded-[20px] bg-card px-5 py-4 shadow-sm transition-colors hover:bg-primary/5"
+          >
+            <span className="material-symbols-outlined text-2xl text-primary">draft</span>
+            <span className="flex-1 text-left text-base font-bold text-foreground">
+              임시저장한 감상
+            </span>
+            <span className="material-symbols-outlined text-xl text-muted-foreground/50">
+              chevron_right
+            </span>
+          </button>
+        </section>
+
         {/* Public Review Timeline */}
         <section className="px-6 pb-10 pt-10">
           <h2 className="mb-5 text-[28px] font-bold tracking-tight text-foreground">

--- a/src/pages/WriteReviewPage.tsx
+++ b/src/pages/WriteReviewPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { getBook, type BookDetail } from '@/api/book'
-import { createReview, getReviewDetail, updateReview } from '@/api/review'
+import { createReview, getReviewDetail, updateReview, type ReviewStatus } from '@/api/review'
 import { extractTextFromImage, type OcrTextField } from '@/api/ocr'
 import AppHeader from '@/components/layout/AppHeader'
 import BottomNav from '@/components/layout/BottomNav'
@@ -48,7 +48,9 @@ export default function WriteReviewPage() {
     null
   )
   const [isLoading, setIsLoading] = useState(true)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  // 진행 중인 제출의 상태(임시저장/발행)를 추적해 두 버튼의 로딩 표시를 분리한다.
+  // null이면 제출 중 아님.
+  const [submittingStatus, setSubmittingStatus] = useState<ReviewStatus | null>(null)
   // [CodeRabbit fix] 단일 errorMessage가 "도서 로드 실패"와 "감상 제출 실패"를 함께 다뤄
   // 제출 실패 시 하단의 풀페이지 분기(errorMessage || !book)에 걸려 "도서를 찾을 수 없습니다"
   // 화면으로 점프하면서 사용자가 작성한 글이 사라진 것처럼 보였다.
@@ -199,7 +201,14 @@ export default function WriteReviewPage() {
     setOcrResult(null)
   }
 
-  const handleSubmit = async () => {
+  /**
+   * 감상을 제출한다. `reviewStatus`에 따라 임시저장('DRAFT')과 발행('PUBLISHED')을 겸한다.
+   * - 임시저장: 저장 후 임시저장 목록(`/drafts`)으로 이동
+   * - 발행: 작성이면 상세로, 수정이면 해당 감상 상세로 이동
+   *
+   * 임시저장도 백엔드 검증(@NotBlank content)에 걸리지 않도록 내용 입력은 공통으로 요구한다.
+   */
+  const handleSubmit = async (reviewStatus: ReviewStatus) => {
     const isValidBookId = /^\d+$/.test(bookId ?? '')
     const isValidReviewId = /^\d+$/.test(reviewId ?? '')
     const trimmedContent = reviewText.trim()
@@ -215,7 +224,7 @@ export default function WriteReviewPage() {
       return
     }
 
-    setIsSubmitting(true)
+    setSubmittingStatus(reviewStatus)
     setSubmitErrorMessage(null)
     try {
       const basePayload = {
@@ -224,7 +233,7 @@ export default function WriteReviewPage() {
         // [HIGH-1 fix] 사용자가 토글로 명시적으로 표시한 값을 그대로 전송 (이전엔 false 고정)
         isSpoiler,
         reviewVisibility: 'PUBLIC' as const,
-        reviewStatus: 'PUBLISHED' as const,
+        reviewStatus,
       }
 
       if (isEditMode) {
@@ -232,7 +241,7 @@ export default function WriteReviewPage() {
           ...basePayload,
           quote: trimmedQuote,
         })
-        navigate(`/review/${reviewId}`, { replace: true })
+        navigate(reviewStatus === 'DRAFT' ? '/drafts' : `/review/${reviewId}`, { replace: true })
         return
       }
 
@@ -243,17 +252,21 @@ export default function WriteReviewPage() {
         // 서재 상세에서 진입한 경우에만 서재책과 연결 (그 외엔 미전송)
         ...(libraryBookId != null ? { libraryBookId } : {}),
       })
-      navigate(`/review/${result.reviewId}`, { replace: true })
+      navigate(reviewStatus === 'DRAFT' ? '/drafts' : `/review/${result.reviewId}`, {
+        replace: true,
+      })
     } catch (error) {
       setSubmitErrorMessage(
         error instanceof Error
           ? error.message
-          : isEditMode
-            ? '감상을 수정하지 못했습니다.'
-            : '감상을 작성하지 못했습니다.'
+          : reviewStatus === 'DRAFT'
+            ? '임시저장에 실패했습니다.'
+            : isEditMode
+              ? '감상을 수정하지 못했습니다.'
+              : '감상을 작성하지 못했습니다.'
       )
     } finally {
-      setIsSubmitting(false)
+      setSubmittingStatus(null)
     }
   }
 
@@ -456,20 +469,20 @@ export default function WriteReviewPage() {
           <div className="flex gap-3">
             <button
               type="button"
-              disabled
-              title="준비 중인 기능입니다"
-              aria-label="임시저장 (준비 중)"
-              className="h-14 flex-1 cursor-not-allowed whitespace-nowrap rounded-full border-2 border-primary/40 bg-background text-sm font-bold text-primary/40"
+              onClick={() => handleSubmit('DRAFT')}
+              disabled={submittingStatus !== null}
+              aria-label="임시저장"
+              className="h-14 flex-1 whitespace-nowrap rounded-full border-2 border-primary/40 bg-background text-sm font-bold text-primary transition-colors hover:bg-primary/5 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              임시저장 (준비 중)
+              {submittingStatus === 'DRAFT' ? '저장 중...' : '임시저장'}
             </button>
             <button
               type="button"
-              onClick={handleSubmit}
-              disabled={isSubmitting}
+              onClick={() => handleSubmit('PUBLISHED')}
+              disabled={submittingStatus !== null}
               className="h-14 flex-[1.7] rounded-full bg-primary text-base font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSubmitting
+              {submittingStatus === 'PUBLISHED'
                 ? isEditMode
                   ? '수정 중...'
                   : '게시 중...'

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,6 +7,7 @@ const BookSearchPage = lazy(() => import('@/pages/BookSearchPage'))
 const BookDetailPage = lazy(() => import('@/pages/BookDetailPage'))
 const WriteReviewPage = lazy(() => import('@/pages/WriteReviewPage'))
 const ReviewDetailPage = lazy(() => import('@/pages/ReviewDetailPage'))
+const DraftsListPage = lazy(() => import('@/pages/DraftsListPage'))
 const MyProfilePage = lazy(() => import('@/pages/MyProfilePage'))
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'))
 const NotificationsPage = lazy(() => import('@/pages/NotificationsPage'))
@@ -132,6 +133,14 @@ const appRoutes = [
     element: (
       <ProtectedRoute>
         <WriteReviewPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/drafts',
+    element: (
+      <ProtectedRoute>
+        <DraftsListPage />
       </ProtectedRoute>
     ),
   },


### PR DESCRIPTION
## 개요

이슈 #234 — 감상 임시저장(DRAFT) 기능을 프론트엔드에 구현합니다.

closes #234

## 변경 내용

- **WriteReviewPage.tsx**: `handleSubmit`을 `reviewStatus` 인자 기반으로 리팩터. 임시저장(DRAFT)·발행(PUBLISHED) 버튼 분리, 버튼별 로딩 상태 분리, 저장 후 상태에 맞는 페이지로 이동.
- **DraftsListPage.tsx** (신규): 임시저장 목록 페이지. 커서 페이지네이션, 이어쓰기(`/review/:id/edit`), 삭제 기능 포함.
- **router/index.tsx**: `/drafts` 보호 라우트 추가.
- **MyProfilePage.tsx**: '임시저장한 감상' 진입 버튼 추가.

## 검증 결과

- tsc -b: 오류 0
- eslint: 오류 0
- vite build: 성공
- vitest: 76/76 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 임시저장한 리뷰 목록 조회 및 관리 기능 추가
  * 임시저장 리뷰의 수정 및 삭제 기능 지원
  * 프로필 페이지에서 임시저장 리뷰 접근 경로 추가
  * 리뷰 작성 시 임시저장과 발행 상태별 제출 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->