### PR TITLE
feat: 공유 기능 구현 (도서/감상/프로필) (#236)

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,58 @@
+/**
+ * 공유 유틸 — Web Share API(navigator.share)를 우선 사용하고,
+ * 미지원 환경(주로 데스크톱 브라우저)에서는 링크를 클립보드에 복사하는 폴백으로 동작한다.
+ *
+ * 반환값으로 호출부가 사용자 피드백(공유됨/복사됨/실패)을 분기할 수 있다.
+ */
+export type ShareResult = 'shared' | 'copied' | 'failed'
+
+export interface ShareLinkOptions {
+  /** 공유 다이얼로그 제목 (Web Share API title) */
+  title: string
+  /** 공유 본문 텍스트 (선택) */
+  text?: string
+  /** 앱 내 상대 경로(예: `/review/12`) 또는 절대 URL. 상대 경로면 현재 origin을 붙인다. */
+  path: string
+}
+
+/**
+ * 상대 경로를 현재 origin 기준 절대 URL로 변환한다. 이미 절대 URL이면 그대로 둔다.
+ */
+function toAbsoluteUrl(path: string): string {
+  if (/^https?:\/\//.test(path)) return path
+  return `${window.location.origin}${path.startsWith('/') ? '' : '/'}${path}`
+}
+
+/**
+ * 링크를 공유하거나(가능하면) 클립보드에 복사한다.
+ *
+ * - Web Share API 지원 시: 네이티브 공유 시트를 띄운다. 사용자가 취소(AbortError)하면
+ *   별도 폴백 없이 'shared'로 간주(사용자가 의도적으로 닫은 것이므로 복사로 이어가지 않음).
+ * - 미지원 시: `navigator.clipboard.writeText`로 URL 복사 → 'copied'.
+ * - 둘 다 불가하면 'failed'.
+ */
+export async function shareLink({ title, text, path }: ShareLinkOptions): Promise<ShareResult> {
+  const url = toAbsoluteUrl(path)
+
+  if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+    try {
+      await navigator.share({ title, text, url })
+      return 'shared'
+    } catch (error) {
+      // 사용자가 공유 시트를 취소한 경우는 실패가 아니므로 복사로 이어가지 않는다.
+      if (error instanceof DOMException && error.name === 'AbortError') return 'shared'
+      // 그 외 오류(권한 등)는 클립보드 폴백으로 진행
+    }
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(url)
+      return 'copied'
+    } catch {
+      return 'failed'
+    }
+  }
+
+  return 'failed'
+}

--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -19,6 +19,7 @@ import {
   type ReadingStatus,
 } from '@/api/library'
 import { formatRelativeTime } from '@/lib/utils'
+import { shareLink } from '@/lib/share'
 
 const statusEmoji: Record<ReadingStatus, string> = {
   want_to_read: '📖 읽고 싶은',
@@ -157,6 +158,17 @@ export default function BookDetailPage() {
     setBook(prev => (prev ? { ...prev, myLibraryBookId: result.libraryBookId } : prev))
   }
 
+  const handleShare = async () => {
+    if (!book) return
+    const result = await shareLink({
+      title: book.title,
+      text: `${book.title} - ${book.author}`,
+      path: `/book/${book.bookId}`,
+    })
+    if (result === 'copied') alert('링크가 복사되었습니다.')
+    else if (result === 'failed') alert('공유에 실패했습니다.')
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <AppHeader
@@ -165,9 +177,9 @@ export default function BookDetailPage() {
         rightAction={
           <button
             type="button"
-            disabled
-            aria-label="공유 (준비 중)"
-            className="flex size-10 items-center justify-center rounded-full text-primary/40"
+            onClick={handleShare}
+            aria-label="공유"
+            className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
           >
             <span className="material-symbols-outlined">share</span>
           </button>

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -6,6 +6,7 @@ import { getMyProfile, type MyProfile } from '@/api/member'
 import { getMyReviews, REVIEW_PAGE_SIZE, type ReviewListItem } from '@/api/review'
 import { getWisdomTower, type WisdomTowerResponse } from '@/api/library'
 import { formatRelativeTime } from '@/lib/utils'
+import { shareLink } from '@/lib/share'
 import { useAuthStore } from '@/store/authStore'
 
 const TOWER_PALETTE = [
@@ -197,6 +198,17 @@ export default function MyProfilePage() {
     }
   }
 
+  const handleShare = async () => {
+    if (!profile) return
+    const result = await shareLink({
+      title: `${profile.nickname}님의 Shelfeed 프로필`,
+      text: `${profile.nickname}님의 Shelfeed 프로필을 확인해보세요.`,
+      path: `/user/${profile.userId}`,
+    })
+    if (result === 'copied') alert('링크가 복사되었습니다.')
+    else if (result === 'failed') alert('공유에 실패했습니다.')
+  }
+
   if (isLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-background">
@@ -288,9 +300,9 @@ export default function MyProfilePage() {
           <div className="flex justify-end">
             <button
               type="button"
-              disabled
-              aria-label="공유 (준비 중)"
-              className="flex size-10 items-center justify-center rounded-full text-primary/40"
+              onClick={handleShare}
+              aria-label="공유"
+              className="flex size-10 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10"
             >
               <span className="material-symbols-outlined">share</span>
             </button>

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { cn } from '@/lib/utils'
+import { shareLink } from '@/lib/share'
 import {
   deleteReview,
   getReviewDetail,
@@ -192,6 +193,17 @@ export default function ReviewDetailPage() {
     } finally {
       setIsDeleting(false)
     }
+  }
+
+  const handleShare = async () => {
+    if (!review) return
+    const result = await shareLink({
+      title: `${review.book.title} 감상`,
+      text: `${review.user.nickname}님의 ${review.book.title} 감상`,
+      path: `/review/${review.reviewId}`,
+    })
+    if (result === 'copied') alert('링크가 복사되었습니다.')
+    else if (result === 'failed') alert('공유에 실패했습니다.')
   }
 
   return (
@@ -386,9 +398,9 @@ export default function ReviewDetailPage() {
 
             <button
               type="button"
-              disabled
-              aria-label="공유 (준비 중)"
-              className="text-muted-foreground/40 disabled:cursor-not-allowed"
+              onClick={handleShare}
+              aria-label="공유"
+              className="text-muted-foreground transition-colors hover:text-primary"
             >
               <span className="material-symbols-outlined text-[22px]">share</span>
             </button>


### PR DESCRIPTION
## 개요

closes #236

도서·감상·프로필 페이지의 공유 버튼을 활성화하고, Web Share API 기반 공유 유틸을 구현합니다.

## 변경 사항

- `src/lib/share.ts` (신규): `shareLink()` 유틸
  - Web Share API(`navigator.share`) 우선 사용
  - 미지원 환경에서는 `navigator.clipboard`로 링크 복사 폴백
  - 사용자 취소(`AbortError`) 정상 처리
  - SSR 가드 포함
- `BookDetailPage.tsx`: 헤더 공유 버튼 활성화 → `/book/:id` 링크 공유
- `ReviewDetailPage.tsx`: 감상 공유 버튼 활성화 → `/review/:id` 링크 공유
- `MyProfilePage.tsx`: 헤더 공유 버튼 활성화 → `/user/:userId` 링크 공유

## 검증

- `tsc -b` 오류 0
- `eslint` 오류 0
- `vite build` 성공
- `vitest` 76/76 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added share functionality for books, profiles, and reviews throughout the app.
  * Share buttons now use the system's native sharing capabilities when available, with automatic fallback to copying links to the clipboard.
  * User feedback alerts confirm whether content was successfully shared or copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->